### PR TITLE
feat(backend): encrypted vault Prisma models + migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ DATABASE_USER=postgres
 DATABASE_PASSWORD=Admin@123
 DATABASE_NAME=myorganizer
 
-DATABASE_URL=postgresql://$DATABASE_USER:$DATABASE_PASSWORD@localhost:5453/$DATABASE_NAME
+DATABASE_URL=postgresql://postgres:Admin%40123@localhost:5453/myorganizer
 
 # PgAdmin 
 PGADMIN_DEFAULT_EMAIL=admin@myorganizer.com

--- a/apps/backend/src/prisma/migrations/20251229000000_add_encrypted_vault/migration.sql
+++ b/apps/backend/src/prisma/migrations/20251229000000_add_encrypted_vault/migration.sql
@@ -1,0 +1,45 @@
+-- CreateTable
+CREATE TABLE "EncryptedVault" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "kdf_name" TEXT NOT NULL,
+    "kdf_salt" TEXT NOT NULL,
+    "kdf_params" JSONB NOT NULL,
+    "wrapped_mk_passphrase" JSONB NOT NULL,
+    "wrapped_mk_recovery" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EncryptedVault_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EncryptedVaultBlob" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "blob" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EncryptedVaultBlob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EncryptedVault_userId_key" ON "EncryptedVault"("userId");
+
+-- CreateIndex
+CREATE INDEX "EncryptedVault_userId_idx" ON "EncryptedVault"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EncryptedVaultBlob_userId_type_key" ON "EncryptedVaultBlob"("userId", "type");
+
+-- CreateIndex
+CREATE INDEX "EncryptedVaultBlob_userId_idx" ON "EncryptedVaultBlob"("userId");
+
+-- AddForeignKey
+ALTER TABLE "EncryptedVault" ADD CONSTRAINT "EncryptedVault_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EncryptedVaultBlob" ADD CONSTRAINT "EncryptedVaultBlob_userId_fkey" FOREIGN KEY ("userId") REFERENCES "EncryptedVault"("userId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/src/prisma/schema/user.prisma
+++ b/apps/backend/src/prisma/schema/user.prisma
@@ -7,5 +7,7 @@ model User {
     email_verification_timestamp    DateTime? 
     blacklisted_tokens              String[]
 
+    encrypted_vault                  EncryptedVault?
+
     @@index([email])
 }

--- a/apps/backend/src/prisma/schema/vault.prisma
+++ b/apps/backend/src/prisma/schema/vault.prisma
@@ -1,0 +1,35 @@
+model EncryptedVault {
+    id                      String              @id @default(cuid())
+    userId                  String              @unique
+
+    version                 Int
+    kdf_name                String
+    kdf_salt                String
+    kdf_params              Json
+
+    wrapped_mk_passphrase   Json
+    wrapped_mk_recovery     Json
+
+    createdAt               DateTime            @default(now())
+    updatedAt               DateTime            @updatedAt
+
+    user                    User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+    blobs                   EncryptedVaultBlob[]
+
+    @@index([userId])
+}
+
+model EncryptedVaultBlob {
+    id          String          @id @default(cuid())
+    userId      String
+    type        String
+    blob        Json
+
+    createdAt   DateTime        @default(now())
+    updatedAt   DateTime        @updatedAt
+
+    vault       EncryptedVault  @relation(fields: [userId], references: [userId], onDelete: Cascade)
+
+    @@unique([userId, type])
+    @@index([userId])
+}


### PR DESCRIPTION
Implements the database layer for the Phase 2 encrypted vault sync epic.

- Adds `EncryptedVault` and `EncryptedVaultBlob` Prisma models (ciphertext-only JSON fields)
- Enforces constraints:
  - one vault per user (`EncryptedVault.userId` unique)
  - one blob per `(userId, type)`
- Adds migration with cascading deletes (`User → EncryptedVault → EncryptedVaultBlob`)

Closes #21
Part of #20