### PR TITLE
feat(backend): vault blind-storage controller (meta/blobs/export/import)

### DIFF
--- a/apps/backend/src/controllers/VaultController.ts
+++ b/apps/backend/src/controllers/VaultController.ts
@@ -1,0 +1,175 @@
+import { Request as ExRequest } from 'express';
+import {
+  Body,
+  Controller,
+  Get,
+  Header,
+  Middlewares,
+  Path,
+  Post,
+  Put,
+  Request,
+  Route,
+  Security,
+  Tags,
+} from 'tsoa';
+import vaultService, {
+  EncryptedBlobV1,
+  VaultBlobType,
+  VaultExportV1,
+  VaultMetaV1,
+} from '../services/VaultService';
+import { UserInterface } from '../types';
+import passport from '../utils/passport';
+
+type ErrorResponse = { message: string; details?: unknown };
+
+type GetVaultMetaResponse =
+  | { meta: VaultMetaV1; updatedAt: string; etag: string }
+  | ErrorResponse;
+
+type PutVaultMetaResponse =
+  | { ok: true; etag: string; updatedAt: string }
+  | ErrorResponse;
+
+type GetVaultBlobResponse =
+  | {
+      type: VaultBlobType;
+      blob: EncryptedBlobV1;
+      updatedAt: string;
+      etag: string;
+    }
+  | ErrorResponse;
+
+type PutVaultBlobResponse =
+  | { ok: true; etag: string; updatedAt: string }
+  | ErrorResponse;
+
+type ExportVaultResponse = VaultExportV1 | ErrorResponse;
+
+type ImportVaultResponse = { ok: true } | ErrorResponse;
+
+@Tags('Vault')
+@Route('/vault')
+@Security('jwt')
+@Middlewares([passport.authenticate('jwt', { session: false })])
+export class VaultController extends Controller {
+  private getUserId(req: ExRequest): string {
+    const user = req.user as UserInterface;
+    return user?.id;
+  }
+
+  @Get()
+  public async getVaultMeta(
+    @Request() req: ExRequest
+  ): Promise<GetVaultMetaResponse> {
+    const userId = this.getUserId(req);
+    if (!userId) {
+      this.setStatus(401);
+      return { message: 'Unauthorized' };
+    }
+
+    const result = await vaultService.getVaultMeta(userId);
+    this.setStatus(result.status);
+    return result.body as GetVaultMetaResponse;
+  }
+
+  @Put()
+  public async putVaultMeta(
+    @Request() req: ExRequest,
+    @Body() requestBody: { meta: VaultMetaV1 },
+    @Header('if-match') ifMatch?: string
+  ): Promise<PutVaultMetaResponse> {
+    const userId = this.getUserId(req);
+    if (!userId) {
+      this.setStatus(401);
+      return { message: 'Unauthorized' };
+    }
+
+    const result = await vaultService.putVaultMeta(
+      userId,
+      requestBody?.meta,
+      ifMatch
+    );
+    this.setStatus(result.status);
+    return result.body as PutVaultMetaResponse;
+  }
+
+  @Get('/blob/{type}')
+  public async getVaultBlob(
+    @Request() req: ExRequest,
+    @Path() type: VaultBlobType
+  ): Promise<GetVaultBlobResponse> {
+    const userId = this.getUserId(req);
+    if (!userId) {
+      this.setStatus(401);
+      return { message: 'Unauthorized' };
+    }
+
+    const result = await vaultService.getBlob(userId, type);
+    this.setStatus(result.status);
+    return result.body as GetVaultBlobResponse;
+  }
+
+  @Put('/blob/{type}')
+  public async putVaultBlob(
+    @Request() req: ExRequest,
+    @Path() type: VaultBlobType,
+    @Body() requestBody: { type: VaultBlobType; blob: EncryptedBlobV1 },
+    @Header('if-match') ifMatch?: string
+  ): Promise<PutVaultBlobResponse> {
+    const userId = this.getUserId(req);
+    if (!userId) {
+      this.setStatus(401);
+      return { message: 'Unauthorized' };
+    }
+
+    if (requestBody?.type && requestBody.type !== type) {
+      this.setStatus(422);
+      return { message: 'Body type must match path type' };
+    }
+
+    const result = await vaultService.putBlob(
+      userId,
+      type,
+      requestBody?.blob,
+      ifMatch
+    );
+    this.setStatus(result.status);
+    return result.body as PutVaultBlobResponse;
+  }
+
+  @Post('/export')
+  public async exportVault(
+    @Request() req: ExRequest
+  ): Promise<ExportVaultResponse> {
+    const userId = this.getUserId(req);
+    if (!userId) {
+      this.setStatus(401);
+      return { message: 'Unauthorized' };
+    }
+
+    const result = await vaultService.exportVault(userId);
+    this.setStatus(result.status);
+    return result.body as ExportVaultResponse;
+  }
+
+  @Post('/import')
+  public async importVault(
+    @Request() req: ExRequest,
+    @Body() requestBody: VaultExportV1
+  ): Promise<ImportVaultResponse> {
+    const userId = this.getUserId(req);
+    if (!userId) {
+      this.setStatus(401);
+      return { message: 'Unauthorized' };
+    }
+
+    const result = await vaultService.importVault(userId, requestBody);
+    this.setStatus(result.status);
+    return result.body as ImportVaultResponse;
+  }
+}
+
+const vaultController = new VaultController();
+export default vaultController;

--- a/apps/backend/src/routes/routes.ts
+++ b/apps/backend/src/routes/routes.ts
@@ -4,6 +4,8 @@
 import type { TsoaRoute } from '@tsoa/runtime';
 import { fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { VaultController } from './../controllers/VaultController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../controllers/UserController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { TodoController } from './../controllers/TodoController';
@@ -28,6 +30,192 @@ const expressAuthenticationRecasted = expressAuthentication as (
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 const models: TsoaRoute.Models = {
+  'Record_string.unknown_': {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'nestedObjectLiteral',
+      nestedProperties: {},
+      additionalProperties: { dataType: 'any' },
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  VaultMetaV1: {
+    dataType: 'refObject',
+    properties: {
+      version: { dataType: 'double', required: true },
+      kdf_name: { dataType: 'string', required: true },
+      kdf_salt: { dataType: 'string', required: true },
+      kdf_params: { ref: 'Record_string.unknown_', required: true },
+      wrapped_mk_passphrase: { dataType: 'any', required: true },
+      wrapped_mk_recovery: { dataType: 'any', required: true },
+    },
+    additionalProperties: { dataType: 'any' },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  ErrorResponse: {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'nestedObjectLiteral',
+      nestedProperties: {
+        details: { dataType: 'any' },
+        message: { dataType: 'string', required: true },
+      },
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  GetVaultMetaResponse: {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'union',
+      subSchemas: [
+        {
+          dataType: 'nestedObjectLiteral',
+          nestedProperties: {
+            etag: { dataType: 'string', required: true },
+            updatedAt: { dataType: 'string', required: true },
+            meta: { ref: 'VaultMetaV1', required: true },
+          },
+        },
+        { ref: 'ErrorResponse' },
+      ],
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  PutVaultMetaResponse: {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'union',
+      subSchemas: [
+        {
+          dataType: 'nestedObjectLiteral',
+          nestedProperties: {
+            updatedAt: { dataType: 'string', required: true },
+            etag: { dataType: 'string', required: true },
+            ok: { dataType: 'enum', enums: [true], required: true },
+          },
+        },
+        { ref: 'ErrorResponse' },
+      ],
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  VaultBlobType: {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'union',
+      subSchemas: [
+        { dataType: 'enum', enums: ['addresses'] },
+        { dataType: 'enum', enums: ['mobileNumbers'] },
+      ],
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  EncryptedBlobV1: {
+    dataType: 'refObject',
+    properties: {
+      version: { dataType: 'double', required: true },
+      iv: { dataType: 'string', required: true },
+      ciphertext: { dataType: 'string', required: true },
+    },
+    additionalProperties: { dataType: 'any' },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  GetVaultBlobResponse: {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'union',
+      subSchemas: [
+        {
+          dataType: 'nestedObjectLiteral',
+          nestedProperties: {
+            etag: { dataType: 'string', required: true },
+            updatedAt: { dataType: 'string', required: true },
+            blob: { ref: 'EncryptedBlobV1', required: true },
+            type: { ref: 'VaultBlobType', required: true },
+          },
+        },
+        { ref: 'ErrorResponse' },
+      ],
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  PutVaultBlobResponse: {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'union',
+      subSchemas: [
+        {
+          dataType: 'nestedObjectLiteral',
+          nestedProperties: {
+            updatedAt: { dataType: 'string', required: true },
+            etag: { dataType: 'string', required: true },
+            ok: { dataType: 'enum', enums: [true], required: true },
+          },
+        },
+        { ref: 'ErrorResponse' },
+      ],
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  'Partial_Record_VaultBlobType.EncryptedBlobV1__': {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'nestedObjectLiteral',
+      nestedProperties: {
+        addresses: { ref: 'EncryptedBlobV1' },
+        mobileNumbers: { ref: 'EncryptedBlobV1' },
+      },
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  VaultExportV1: {
+    dataType: 'refObject',
+    properties: {
+      exportVersion: { dataType: 'enum', enums: [1], required: true },
+      exportedAt: { dataType: 'string', required: true },
+      meta: { ref: 'VaultMetaV1', required: true },
+      blobs: {
+        ref: 'Partial_Record_VaultBlobType.EncryptedBlobV1__',
+        required: true,
+      },
+    },
+    additionalProperties: false,
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  ExportVaultResponse: {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'union',
+      subSchemas: [{ ref: 'VaultExportV1' }, { ref: 'ErrorResponse' }],
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  ImportVaultResponse: {
+    dataType: 'refAlias',
+    type: {
+      dataType: 'union',
+      subSchemas: [
+        {
+          dataType: 'nestedObjectLiteral',
+          nestedProperties: {
+            ok: { dataType: 'enum', enums: [true], required: true },
+          },
+        },
+        { ref: 'ErrorResponse' },
+      ],
+      validators: {},
+    },
+  },
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
   User: {
     dataType: 'refObject',
     properties: {
@@ -131,6 +319,289 @@ export function RegisterRoutes(app: Router) {
   //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa
   // ###########################################################################################################
 
+  app.get(
+    '/vault',
+    authenticateMiddleware([{ jwt: [] }]),
+    ...fetchMiddlewares<RequestHandler>(VaultController),
+    ...fetchMiddlewares<RequestHandler>(VaultController.prototype.getVaultMeta),
+
+    async function VaultController_getVaultMeta(
+      request: ExRequest,
+      response: ExResponse,
+      next: any
+    ) {
+      const args: Record<string, TsoaRoute.ParameterSchema> = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+      };
+
+      // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = templateService.getValidatedArgs({
+          args,
+          request,
+          response,
+        });
+
+        const controller = new VaultController();
+
+        await templateService.apiHandler({
+          methodName: 'getVaultMeta',
+          controller,
+          response,
+          next,
+          validatedArgs,
+          successStatus: undefined,
+        });
+      } catch (err) {
+        return next(err);
+      }
+    }
+  );
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  app.put(
+    '/vault',
+    authenticateMiddleware([{ jwt: [] }]),
+    ...fetchMiddlewares<RequestHandler>(VaultController),
+    ...fetchMiddlewares<RequestHandler>(VaultController.prototype.putVaultMeta),
+
+    async function VaultController_putVaultMeta(
+      request: ExRequest,
+      response: ExResponse,
+      next: any
+    ) {
+      const args: Record<string, TsoaRoute.ParameterSchema> = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        requestBody: {
+          in: 'body',
+          name: 'requestBody',
+          required: true,
+          dataType: 'nestedObjectLiteral',
+          nestedProperties: { meta: { ref: 'VaultMetaV1', required: true } },
+        },
+        ifMatch: { in: 'header', name: 'if-match', dataType: 'string' },
+      };
+
+      // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = templateService.getValidatedArgs({
+          args,
+          request,
+          response,
+        });
+
+        const controller = new VaultController();
+
+        await templateService.apiHandler({
+          methodName: 'putVaultMeta',
+          controller,
+          response,
+          next,
+          validatedArgs,
+          successStatus: undefined,
+        });
+      } catch (err) {
+        return next(err);
+      }
+    }
+  );
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  app.get(
+    '/vault/blob/:type',
+    authenticateMiddleware([{ jwt: [] }]),
+    ...fetchMiddlewares<RequestHandler>(VaultController),
+    ...fetchMiddlewares<RequestHandler>(VaultController.prototype.getVaultBlob),
+
+    async function VaultController_getVaultBlob(
+      request: ExRequest,
+      response: ExResponse,
+      next: any
+    ) {
+      const args: Record<string, TsoaRoute.ParameterSchema> = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        type: {
+          in: 'path',
+          name: 'type',
+          required: true,
+          ref: 'VaultBlobType',
+        },
+      };
+
+      // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = templateService.getValidatedArgs({
+          args,
+          request,
+          response,
+        });
+
+        const controller = new VaultController();
+
+        await templateService.apiHandler({
+          methodName: 'getVaultBlob',
+          controller,
+          response,
+          next,
+          validatedArgs,
+          successStatus: undefined,
+        });
+      } catch (err) {
+        return next(err);
+      }
+    }
+  );
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  app.put(
+    '/vault/blob/:type',
+    authenticateMiddleware([{ jwt: [] }]),
+    ...fetchMiddlewares<RequestHandler>(VaultController),
+    ...fetchMiddlewares<RequestHandler>(VaultController.prototype.putVaultBlob),
+
+    async function VaultController_putVaultBlob(
+      request: ExRequest,
+      response: ExResponse,
+      next: any
+    ) {
+      const args: Record<string, TsoaRoute.ParameterSchema> = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        type: {
+          in: 'path',
+          name: 'type',
+          required: true,
+          ref: 'VaultBlobType',
+        },
+        requestBody: {
+          in: 'body',
+          name: 'requestBody',
+          required: true,
+          dataType: 'nestedObjectLiteral',
+          nestedProperties: {
+            blob: { ref: 'EncryptedBlobV1', required: true },
+            type: { ref: 'VaultBlobType', required: true },
+          },
+        },
+        ifMatch: { in: 'header', name: 'if-match', dataType: 'string' },
+      };
+
+      // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = templateService.getValidatedArgs({
+          args,
+          request,
+          response,
+        });
+
+        const controller = new VaultController();
+
+        await templateService.apiHandler({
+          methodName: 'putVaultBlob',
+          controller,
+          response,
+          next,
+          validatedArgs,
+          successStatus: undefined,
+        });
+      } catch (err) {
+        return next(err);
+      }
+    }
+  );
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  app.post(
+    '/vault/export',
+    authenticateMiddleware([{ jwt: [] }]),
+    ...fetchMiddlewares<RequestHandler>(VaultController),
+    ...fetchMiddlewares<RequestHandler>(VaultController.prototype.exportVault),
+
+    async function VaultController_exportVault(
+      request: ExRequest,
+      response: ExResponse,
+      next: any
+    ) {
+      const args: Record<string, TsoaRoute.ParameterSchema> = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+      };
+
+      // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = templateService.getValidatedArgs({
+          args,
+          request,
+          response,
+        });
+
+        const controller = new VaultController();
+
+        await templateService.apiHandler({
+          methodName: 'exportVault',
+          controller,
+          response,
+          next,
+          validatedArgs,
+          successStatus: undefined,
+        });
+      } catch (err) {
+        return next(err);
+      }
+    }
+  );
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+  app.post(
+    '/vault/import',
+    authenticateMiddleware([{ jwt: [] }]),
+    ...fetchMiddlewares<RequestHandler>(VaultController),
+    ...fetchMiddlewares<RequestHandler>(VaultController.prototype.importVault),
+
+    async function VaultController_importVault(
+      request: ExRequest,
+      response: ExResponse,
+      next: any
+    ) {
+      const args: Record<string, TsoaRoute.ParameterSchema> = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        requestBody: {
+          in: 'body',
+          name: 'requestBody',
+          required: true,
+          ref: 'VaultExportV1',
+        },
+      };
+
+      // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+      let validatedArgs: any[] = [];
+      try {
+        validatedArgs = templateService.getValidatedArgs({
+          args,
+          request,
+          response,
+        });
+
+        const controller = new VaultController();
+
+        await templateService.apiHandler({
+          methodName: 'importVault',
+          controller,
+          response,
+          next,
+          validatedArgs,
+          successStatus: undefined,
+        });
+      } catch (err) {
+        return next(err);
+      }
+    }
+  );
+  // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
   app.get(
     '/user',
     authenticateMiddleware([{ jwt: [] }]),

--- a/apps/backend/src/routes/user.test.ts
+++ b/apps/backend/src/routes/user.test.ts
@@ -4,6 +4,16 @@ import request from 'supertest';
 import userController from '../controllers/UserController';
 import userRouter from './user';
 
+jest.mock('../utils/passport', () => ({
+  __esModule: true,
+  default: {
+    authenticate: () => (req: any, _res: any, next: any) => {
+      req.user = { id: 'test-user' };
+      next();
+    },
+  },
+}));
+
 jest.mock('../controllers/UserController');
 
 beforeEach(() => {

--- a/apps/backend/src/services/VaultService.test.ts
+++ b/apps/backend/src/services/VaultService.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { VaultService } from './VaultService';
+
+function makePrismaMock() {
+  return {
+    encryptedVault: {
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+    },
+    encryptedVaultBlob: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      upsert: jest.fn(),
+    },
+  } as any;
+}
+
+describe('VaultService', () => {
+  let prisma: any;
+  let service: VaultService;
+
+  beforeEach(() => {
+    prisma = makePrismaMock();
+    service = new VaultService(prisma);
+    jest.clearAllMocks();
+  });
+
+  test('putVaultMeta returns 422 for invalid meta', async () => {
+    prisma.encryptedVault.findUnique.mockResolvedValue(null);
+
+    const result = await service.putVaultMeta('user-1', { nope: true });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(422);
+    }
+  });
+
+  test('putVaultMeta creates vault (201) when missing and no If-Match', async () => {
+    prisma.encryptedVault.findUnique.mockResolvedValue(null);
+    prisma.encryptedVault.upsert.mockResolvedValue({
+      updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+    });
+
+    const meta = {
+      version: 1,
+      kdf_name: 'PBKDF2',
+      kdf_salt: 'salt',
+      kdf_params: { iterations: 1 },
+      wrapped_mk_passphrase: { v: 1 },
+      wrapped_mk_recovery: { v: 1 },
+    };
+
+    const result = await service.putVaultMeta('user-1', meta);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.status).toBe(201);
+      expect(result.body.ok).toBe(true);
+      expect(result.body.etag).toContain('W/');
+    }
+  });
+
+  test('putVaultMeta returns 409 when If-Match provided but vault missing', async () => {
+    prisma.encryptedVault.findUnique.mockResolvedValue(null);
+
+    const meta = {
+      version: 1,
+      kdf_name: 'PBKDF2',
+      kdf_salt: 'salt',
+      kdf_params: { iterations: 1 },
+      wrapped_mk_passphrase: { v: 1 },
+      wrapped_mk_recovery: { v: 1 },
+    };
+
+    const result = await service.putVaultMeta('user-1', meta, 'W/"123"');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+    }
+  });
+
+  test('putBlob returns 404 when vault missing', async () => {
+    prisma.encryptedVault.findUnique.mockResolvedValue(null);
+
+    const blob = { version: 1, iv: 'iv', ciphertext: 'ct' };
+    const result = await service.putBlob('user-1', 'addresses', blob);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(404);
+    }
+  });
+
+  test('putBlob returns 409 on ETag mismatch', async () => {
+    prisma.encryptedVault.findUnique.mockResolvedValue({ userId: 'user-1' });
+    prisma.encryptedVaultBlob.findUnique.mockResolvedValue({
+      updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+    });
+
+    const blob = { version: 1, iv: 'iv', ciphertext: 'ct' };
+    const result = await service.putBlob(
+      'user-1',
+      'addresses',
+      blob,
+      'W/"999"'
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+    }
+  });
+});

--- a/apps/backend/src/services/VaultService.ts
+++ b/apps/backend/src/services/VaultService.ts
@@ -1,0 +1,445 @@
+import { Prisma, PrismaClient } from '../prisma';
+
+export type VaultBlobType = 'addresses' | 'mobileNumbers';
+
+export interface VaultMetaV1 {
+  version: number;
+  kdf_name: string;
+  kdf_salt: string;
+  kdf_params: Record<string, unknown>;
+  wrapped_mk_passphrase: unknown;
+  wrapped_mk_recovery: unknown;
+  [key: string]: unknown;
+}
+
+export interface EncryptedBlobV1 {
+  version: number;
+  iv: string;
+  ciphertext: string;
+  [key: string]: unknown;
+}
+
+export interface VaultExportV1 {
+  exportVersion: 1;
+  exportedAt: string;
+  meta: VaultMetaV1;
+  blobs: Partial<Record<VaultBlobType, EncryptedBlobV1>>;
+}
+
+type ServiceResult<T> =
+  | { ok: true; status: 200 | 201; body: T }
+  | {
+      ok: false;
+      status: 404 | 409 | 422;
+      body: { message: string; details?: unknown };
+    };
+
+const VAULT_META_MAX_BYTES = 32 * 1024;
+const VAULT_BLOB_MAX_BYTES = 256 * 1024;
+const VAULT_EXPORT_MAX_BYTES = 1024 * 1024;
+
+function etagFromDate(date: Date): string {
+  return `W/\"${date.getTime()}\"`;
+}
+
+function jsonByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isVaultMetaV1(value: unknown): value is VaultMetaV1 {
+  if (!isPlainObject(value)) return false;
+  return (
+    typeof value.version === 'number' &&
+    typeof value.kdf_name === 'string' &&
+    typeof value.kdf_salt === 'string' &&
+    isPlainObject(value.kdf_params) &&
+    'wrapped_mk_passphrase' in value &&
+    'wrapped_mk_recovery' in value
+  );
+}
+
+function isEncryptedBlobV1(value: unknown): value is EncryptedBlobV1 {
+  if (!isPlainObject(value)) return false;
+  return (
+    typeof value.version === 'number' &&
+    typeof value.iv === 'string' &&
+    typeof value.ciphertext === 'string'
+  );
+}
+
+export class VaultService {
+  constructor(private prisma: PrismaClient) {}
+
+  public getVaultMeta = async (
+    userId: string
+  ): Promise<
+    ServiceResult<{ meta: VaultMetaV1; updatedAt: string; etag: string }>
+  > => {
+    const vault = await this.prisma.encryptedVault.findUnique({
+      where: { userId },
+    });
+    if (!vault) {
+      return { ok: false, status: 404, body: { message: 'Vault not found' } };
+    }
+
+    const meta: VaultMetaV1 = {
+      version: vault.version,
+      kdf_name: vault.kdf_name,
+      kdf_salt: vault.kdf_salt,
+      kdf_params: vault.kdf_params as Record<string, unknown>,
+      wrapped_mk_passphrase: vault.wrapped_mk_passphrase,
+      wrapped_mk_recovery: vault.wrapped_mk_recovery,
+    };
+
+    return {
+      ok: true,
+      status: 200,
+      body: {
+        meta,
+        updatedAt: vault.updatedAt.toISOString(),
+        etag: etagFromDate(vault.updatedAt),
+      },
+    };
+  };
+
+  public putVaultMeta = async (
+    userId: string,
+    meta: unknown,
+    ifMatch?: string
+  ): Promise<ServiceResult<{ ok: true; etag: string; updatedAt: string }>> => {
+    if (!isVaultMetaV1(meta)) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Invalid vault meta shape' },
+      };
+    }
+
+    if (jsonByteLength(meta) > VAULT_META_MAX_BYTES) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Vault meta payload too large' },
+      };
+    }
+
+    const existing = await this.prisma.encryptedVault.findUnique({
+      where: { userId },
+    });
+    if (ifMatch) {
+      if (!existing) {
+        return {
+          ok: false,
+          status: 409,
+          body: { message: 'ETag mismatch' },
+        };
+      }
+
+      const currentEtag = etagFromDate(existing.updatedAt);
+      if (ifMatch !== currentEtag) {
+        return {
+          ok: false,
+          status: 409,
+          body: { message: 'ETag mismatch' },
+        };
+      }
+    }
+
+    const saved = await this.prisma.encryptedVault.upsert({
+      where: { userId },
+      create: {
+        userId,
+        version: meta.version,
+        kdf_name: meta.kdf_name,
+        kdf_salt: meta.kdf_salt,
+        kdf_params: meta.kdf_params as unknown as Prisma.InputJsonValue,
+        wrapped_mk_passphrase:
+          meta.wrapped_mk_passphrase as unknown as Prisma.InputJsonValue,
+        wrapped_mk_recovery:
+          meta.wrapped_mk_recovery as unknown as Prisma.InputJsonValue,
+      },
+      update: {
+        version: meta.version,
+        kdf_name: meta.kdf_name,
+        kdf_salt: meta.kdf_salt,
+        kdf_params: meta.kdf_params as unknown as Prisma.InputJsonValue,
+        wrapped_mk_passphrase:
+          meta.wrapped_mk_passphrase as unknown as Prisma.InputJsonValue,
+        wrapped_mk_recovery:
+          meta.wrapped_mk_recovery as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    const status: 200 | 201 = existing ? 200 : 201;
+
+    return {
+      ok: true,
+      status,
+      body: {
+        ok: true,
+        etag: etagFromDate(saved.updatedAt),
+        updatedAt: saved.updatedAt.toISOString(),
+      },
+    };
+  };
+
+  public getBlob = async (
+    userId: string,
+    type: VaultBlobType
+  ): Promise<
+    ServiceResult<{
+      type: VaultBlobType;
+      blob: EncryptedBlobV1;
+      updatedAt: string;
+      etag: string;
+    }>
+  > => {
+    const blobRow = await this.prisma.encryptedVaultBlob.findUnique({
+      where: { userId_type: { userId, type } },
+    });
+
+    if (!blobRow) {
+      return {
+        ok: false,
+        status: 404,
+        body: { message: 'Vault blob not found' },
+      };
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      body: {
+        type,
+        blob: blobRow.blob as EncryptedBlobV1,
+        updatedAt: blobRow.updatedAt.toISOString(),
+        etag: etagFromDate(blobRow.updatedAt),
+      },
+    };
+  };
+
+  public putBlob = async (
+    userId: string,
+    type: VaultBlobType,
+    blob: unknown,
+    ifMatch?: string
+  ): Promise<ServiceResult<{ ok: true; etag: string; updatedAt: string }>> => {
+    if (!isEncryptedBlobV1(blob)) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Invalid blob shape' },
+      };
+    }
+
+    if (jsonByteLength(blob) > VAULT_BLOB_MAX_BYTES) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Blob payload too large' },
+      };
+    }
+
+    const vault = await this.prisma.encryptedVault.findUnique({
+      where: { userId },
+    });
+    if (!vault) {
+      return { ok: false, status: 404, body: { message: 'Vault not found' } };
+    }
+
+    const existing = await this.prisma.encryptedVaultBlob.findUnique({
+      where: { userId_type: { userId, type } },
+    });
+
+    if (ifMatch) {
+      if (!existing) {
+        return { ok: false, status: 409, body: { message: 'ETag mismatch' } };
+      }
+      const currentEtag = etagFromDate(existing.updatedAt);
+      if (ifMatch !== currentEtag) {
+        return { ok: false, status: 409, body: { message: 'ETag mismatch' } };
+      }
+    }
+
+    const saved = await this.prisma.encryptedVaultBlob.upsert({
+      where: { userId_type: { userId, type } },
+      create: {
+        userId,
+        type,
+        blob: blob as unknown as Prisma.InputJsonValue,
+      },
+      update: {
+        blob: blob as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    return {
+      ok: true,
+      status: existing ? 200 : 201,
+      body: {
+        ok: true,
+        etag: etagFromDate(saved.updatedAt),
+        updatedAt: saved.updatedAt.toISOString(),
+      },
+    };
+  };
+
+  public exportVault = async (
+    userId: string
+  ): Promise<ServiceResult<VaultExportV1>> => {
+    const vault = await this.prisma.encryptedVault.findUnique({
+      where: { userId },
+    });
+    if (!vault) {
+      return { ok: false, status: 404, body: { message: 'Vault not found' } };
+    }
+
+    const blobs = await this.prisma.encryptedVaultBlob.findMany({
+      where: { userId },
+    });
+
+    const blobMap: Partial<Record<VaultBlobType, EncryptedBlobV1>> = {};
+    for (const blobRow of blobs) {
+      if (blobRow.type === 'addresses' || blobRow.type === 'mobileNumbers') {
+        blobMap[blobRow.type] = blobRow.blob as EncryptedBlobV1;
+      }
+    }
+
+    const meta: VaultMetaV1 = {
+      version: vault.version,
+      kdf_name: vault.kdf_name,
+      kdf_salt: vault.kdf_salt,
+      kdf_params: vault.kdf_params as Record<string, unknown>,
+      wrapped_mk_passphrase: vault.wrapped_mk_passphrase,
+      wrapped_mk_recovery: vault.wrapped_mk_recovery,
+    };
+
+    const payload: VaultExportV1 = {
+      exportVersion: 1,
+      exportedAt: new Date().toISOString(),
+      meta,
+      blobs: blobMap,
+    };
+
+    if (jsonByteLength(payload) > VAULT_EXPORT_MAX_BYTES) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Export payload too large' },
+      };
+    }
+
+    return { ok: true, status: 200, body: payload };
+  };
+
+  public importVault = async (
+    userId: string,
+    exportBundle: unknown
+  ): Promise<ServiceResult<{ ok: true }>> => {
+    if (!isPlainObject(exportBundle)) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Invalid import shape' },
+      };
+    }
+
+    if (jsonByteLength(exportBundle) > VAULT_EXPORT_MAX_BYTES) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Import payload too large' },
+      };
+    }
+
+    if (exportBundle.exportVersion !== 1) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Unsupported exportVersion' },
+      };
+    }
+
+    const meta = exportBundle.meta;
+    if (!isVaultMetaV1(meta)) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Invalid vault meta shape' },
+      };
+    }
+
+    const blobs = exportBundle.blobs;
+    if (blobs !== undefined && !isPlainObject(blobs)) {
+      return {
+        ok: false,
+        status: 422,
+        body: { message: 'Invalid blobs shape' },
+      };
+    }
+
+    await this.prisma.encryptedVault.upsert({
+      where: { userId },
+      create: {
+        userId,
+        version: meta.version,
+        kdf_name: meta.kdf_name,
+        kdf_salt: meta.kdf_salt,
+        kdf_params: meta.kdf_params as unknown as Prisma.InputJsonValue,
+        wrapped_mk_passphrase:
+          meta.wrapped_mk_passphrase as unknown as Prisma.InputJsonValue,
+        wrapped_mk_recovery:
+          meta.wrapped_mk_recovery as unknown as Prisma.InputJsonValue,
+      },
+      update: {
+        version: meta.version,
+        kdf_name: meta.kdf_name,
+        kdf_salt: meta.kdf_salt,
+        kdf_params: meta.kdf_params as unknown as Prisma.InputJsonValue,
+        wrapped_mk_passphrase:
+          meta.wrapped_mk_passphrase as unknown as Prisma.InputJsonValue,
+        wrapped_mk_recovery:
+          meta.wrapped_mk_recovery as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    if (blobs) {
+      for (const [type, blob] of Object.entries(blobs)) {
+        if (type !== 'addresses' && type !== 'mobileNumbers') continue;
+        if (!isEncryptedBlobV1(blob)) {
+          return {
+            ok: false,
+            status: 422,
+            body: { message: `Invalid blob for type ${type}` },
+          };
+        }
+        if (jsonByteLength(blob) > VAULT_BLOB_MAX_BYTES) {
+          return {
+            ok: false,
+            status: 422,
+            body: { message: `Blob payload too large for type ${type}` },
+          };
+        }
+
+        await this.prisma.encryptedVaultBlob.upsert({
+          where: { userId_type: { userId, type } },
+          create: {
+            userId,
+            type,
+            blob: blob as unknown as Prisma.InputJsonValue,
+          },
+          update: { blob: blob as unknown as Prisma.InputJsonValue },
+        });
+      }
+    }
+
+    return { ok: true, status: 200, body: { ok: true } };
+  };
+}
+
+const vaultService = new VaultService(new PrismaClient());
+export default vaultService;

--- a/apps/backend/src/swagger/swagger.json
+++ b/apps/backend/src/swagger/swagger.json
@@ -7,6 +7,228 @@
     "requestBodies": {},
     "responses": {},
     "schemas": {
+      "Record_string.unknown_": {
+        "properties": {},
+        "additionalProperties": {},
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "VaultMetaV1": {
+        "properties": {
+          "version": {
+            "type": "number",
+            "format": "double"
+          },
+          "kdf_name": {
+            "type": "string"
+          },
+          "kdf_salt": {
+            "type": "string"
+          },
+          "kdf_params": {
+            "$ref": "#/components/schemas/Record_string.unknown_"
+          },
+          "wrapped_mk_passphrase": {},
+          "wrapped_mk_recovery": {}
+        },
+        "required": [
+          "version",
+          "kdf_name",
+          "kdf_salt",
+          "kdf_params",
+          "wrapped_mk_passphrase",
+          "wrapped_mk_recovery"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ErrorResponse": {
+        "properties": {
+          "details": {},
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["message"],
+        "type": "object"
+      },
+      "GetVaultMetaResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "etag": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "meta": {
+                "$ref": "#/components/schemas/VaultMetaV1"
+              }
+            },
+            "required": ["etag", "updatedAt", "meta"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "PutVaultMetaResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "updatedAt": {
+                "type": "string"
+              },
+              "etag": {
+                "type": "string"
+              },
+              "ok": {
+                "type": "boolean",
+                "enum": [true],
+                "nullable": false
+              }
+            },
+            "required": ["updatedAt", "etag", "ok"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "VaultBlobType": {
+        "type": "string",
+        "enum": ["addresses", "mobileNumbers"]
+      },
+      "EncryptedBlobV1": {
+        "properties": {
+          "version": {
+            "type": "number",
+            "format": "double"
+          },
+          "iv": {
+            "type": "string"
+          },
+          "ciphertext": {
+            "type": "string"
+          }
+        },
+        "required": ["version", "iv", "ciphertext"],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "GetVaultBlobResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "etag": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "blob": {
+                "$ref": "#/components/schemas/EncryptedBlobV1"
+              },
+              "type": {
+                "$ref": "#/components/schemas/VaultBlobType"
+              }
+            },
+            "required": ["etag", "updatedAt", "blob", "type"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "PutVaultBlobResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "updatedAt": {
+                "type": "string"
+              },
+              "etag": {
+                "type": "string"
+              },
+              "ok": {
+                "type": "boolean",
+                "enum": [true],
+                "nullable": false
+              }
+            },
+            "required": ["updatedAt", "etag", "ok"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "Partial_Record_VaultBlobType.EncryptedBlobV1__": {
+        "properties": {
+          "addresses": {
+            "$ref": "#/components/schemas/EncryptedBlobV1"
+          },
+          "mobileNumbers": {
+            "$ref": "#/components/schemas/EncryptedBlobV1"
+          }
+        },
+        "type": "object",
+        "description": "Make all properties in T optional"
+      },
+      "VaultExportV1": {
+        "properties": {
+          "exportVersion": {
+            "type": "number",
+            "enum": [1],
+            "nullable": false
+          },
+          "exportedAt": {
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/VaultMetaV1"
+          },
+          "blobs": {
+            "$ref": "#/components/schemas/Partial_Record_VaultBlobType.EncryptedBlobV1__"
+          }
+        },
+        "required": ["exportVersion", "exportedAt", "meta", "blobs"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ExportVaultResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/VaultExportV1"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "ImportVaultResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "ok": {
+                "type": "boolean",
+                "enum": [true],
+                "nullable": false
+              }
+            },
+            "required": ["ok"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
       "User": {
         "properties": {
           "id": {
@@ -174,6 +396,226 @@
     "contact": {}
   },
   "paths": {
+    "/vault": {
+      "get": {
+        "operationId": "GetVaultMeta",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetVaultMetaResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      },
+      "put": {
+        "operationId": "PutVaultMeta",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutVaultMetaResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "if-match",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "meta": {
+                    "$ref": "#/components/schemas/VaultMetaV1"
+                  }
+                },
+                "required": ["meta"],
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vault/blob/{type}": {
+      "get": {
+        "operationId": "GetVaultBlob",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetVaultBlobResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VaultBlobType"
+            }
+          }
+        ]
+      },
+      "put": {
+        "operationId": "PutVaultBlob",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutVaultBlobResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VaultBlobType"
+            }
+          },
+          {
+            "in": "header",
+            "name": "if-match",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "blob": {
+                    "$ref": "#/components/schemas/EncryptedBlobV1"
+                  },
+                  "type": {
+                    "$ref": "#/components/schemas/VaultBlobType"
+                  }
+                },
+                "required": ["blob", "type"],
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vault/export": {
+      "post": {
+        "operationId": "ExportVault",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportVaultResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/vault/import": {
+      "post": {
+        "operationId": "ImportVault",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportVaultResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VaultExportV1"
+              }
+            }
+          }
+        }
+      }
+    },
     "/user": {
       "get": {
         "operationId": "GetAllUsers",

--- a/apps/backend/src/swagger/swagger.yaml
+++ b/apps/backend/src/swagger/swagger.yaml
@@ -6,6 +6,174 @@ components:
   requestBodies: {}
   responses: {}
   schemas:
+    Record_string.unknown_:
+      properties: {}
+      additionalProperties: {}
+      type: object
+      description: Construct a type with a set of properties K of type T
+    VaultMetaV1:
+      properties:
+        version:
+          type: number
+          format: double
+        kdf_name:
+          type: string
+        kdf_salt:
+          type: string
+        kdf_params:
+          $ref: '#/components/schemas/Record_string.unknown_'
+        wrapped_mk_passphrase: {}
+        wrapped_mk_recovery: {}
+      required:
+        - version
+        - kdf_name
+        - kdf_salt
+        - kdf_params
+        - wrapped_mk_passphrase
+        - wrapped_mk_recovery
+      type: object
+      additionalProperties: {}
+    ErrorResponse:
+      properties:
+        details: {}
+        message:
+          type: string
+      required:
+        - message
+      type: object
+    GetVaultMetaResponse:
+      anyOf:
+        - properties:
+            etag:
+              type: string
+            updatedAt:
+              type: string
+            meta:
+              $ref: '#/components/schemas/VaultMetaV1'
+          required:
+            - etag
+            - updatedAt
+            - meta
+          type: object
+        - $ref: '#/components/schemas/ErrorResponse'
+    PutVaultMetaResponse:
+      anyOf:
+        - properties:
+            updatedAt:
+              type: string
+            etag:
+              type: string
+            ok:
+              type: boolean
+              enum:
+                - true
+              nullable: false
+          required:
+            - updatedAt
+            - etag
+            - ok
+          type: object
+        - $ref: '#/components/schemas/ErrorResponse'
+    VaultBlobType:
+      type: string
+      enum:
+        - addresses
+        - mobileNumbers
+    EncryptedBlobV1:
+      properties:
+        version:
+          type: number
+          format: double
+        iv:
+          type: string
+        ciphertext:
+          type: string
+      required:
+        - version
+        - iv
+        - ciphertext
+      type: object
+      additionalProperties: {}
+    GetVaultBlobResponse:
+      anyOf:
+        - properties:
+            etag:
+              type: string
+            updatedAt:
+              type: string
+            blob:
+              $ref: '#/components/schemas/EncryptedBlobV1'
+            type:
+              $ref: '#/components/schemas/VaultBlobType'
+          required:
+            - etag
+            - updatedAt
+            - blob
+            - type
+          type: object
+        - $ref: '#/components/schemas/ErrorResponse'
+    PutVaultBlobResponse:
+      anyOf:
+        - properties:
+            updatedAt:
+              type: string
+            etag:
+              type: string
+            ok:
+              type: boolean
+              enum:
+                - true
+              nullable: false
+          required:
+            - updatedAt
+            - etag
+            - ok
+          type: object
+        - $ref: '#/components/schemas/ErrorResponse'
+    Partial_Record_VaultBlobType.EncryptedBlobV1__:
+      properties:
+        addresses:
+          $ref: '#/components/schemas/EncryptedBlobV1'
+        mobileNumbers:
+          $ref: '#/components/schemas/EncryptedBlobV1'
+      type: object
+      description: Make all properties in T optional
+    VaultExportV1:
+      properties:
+        exportVersion:
+          type: number
+          enum:
+            - 1
+          nullable: false
+        exportedAt:
+          type: string
+        meta:
+          $ref: '#/components/schemas/VaultMetaV1'
+        blobs:
+          $ref: '#/components/schemas/Partial_Record_VaultBlobType.EncryptedBlobV1__'
+      required:
+        - exportVersion
+        - exportedAt
+        - meta
+        - blobs
+      type: object
+      additionalProperties: false
+    ExportVaultResponse:
+      anyOf:
+        - $ref: '#/components/schemas/VaultExportV1'
+        - $ref: '#/components/schemas/ErrorResponse'
+    ImportVaultResponse:
+      anyOf:
+        - properties:
+            ok:
+              type: boolean
+              enum:
+                - true
+              nullable: false
+          required:
+            - ok
+          type: object
+        - $ref: '#/components/schemas/ErrorResponse'
     User:
       properties:
         id:
@@ -141,6 +309,145 @@ info:
     name: MIT
   contact: {}
 paths:
+  /vault:
+    get:
+      operationId: GetVaultMeta
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetVaultMetaResponse'
+      tags:
+        - Vault
+      security:
+        - jwt: []
+      parameters: []
+    put:
+      operationId: PutVaultMeta
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutVaultMetaResponse'
+      tags:
+        - Vault
+      security:
+        - jwt: []
+      parameters:
+        - in: header
+          name: if-match
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                meta:
+                  $ref: '#/components/schemas/VaultMetaV1'
+              required:
+                - meta
+              type: object
+  /vault/blob/{type}:
+    get:
+      operationId: GetVaultBlob
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetVaultBlobResponse'
+      tags:
+        - Vault
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            $ref: '#/components/schemas/VaultBlobType'
+    put:
+      operationId: PutVaultBlob
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutVaultBlobResponse'
+      tags:
+        - Vault
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: type
+          required: true
+          schema:
+            $ref: '#/components/schemas/VaultBlobType'
+        - in: header
+          name: if-match
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                blob:
+                  $ref: '#/components/schemas/EncryptedBlobV1'
+                type:
+                  $ref: '#/components/schemas/VaultBlobType'
+              required:
+                - blob
+                - type
+              type: object
+  /vault/export:
+    post:
+      operationId: ExportVault
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportVaultResponse'
+      tags:
+        - Vault
+      security:
+        - jwt: []
+      parameters: []
+  /vault/import:
+    post:
+      operationId: ImportVault
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportVaultResponse'
+      tags:
+        - Vault
+      security:
+        - jwt: []
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VaultExportV1'
   /user:
     get:
       operationId: GetAllUsers

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2021", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",


### PR DESCRIPTION
Implements the Phase 2 encrypted vault blind-storage API endpoints using tsoa.

- Adds `VaultController` with:
  - `GET/PUT /vault`
  - `GET/PUT /vault/blob/{type}` (addresses|mobileNumbers)
  - `POST /vault/export` and `POST /vault/import`
- Implements optimistic concurrency via `If-Match`/ETag (ETag derived from `updatedAt`)
- Adds basic size/shape validation for meta/blobs/import/export
- Regenerates tsoa routes + swagger specs
- Adds unit tests for vault service logic

Closes #22
Part of #20