### PR TITLE
Backend: vault payload validation, limits, and rate limiting (#24)

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -10,6 +10,7 @@ import session from 'express-session';
 import * as path from 'path';
 import swaggerUi from 'swagger-ui-express';
 import { ValidateError } from 'tsoa';
+import { vaultRateLimiter } from './middleware/vaultRateLimit';
 import authRouter from './routes/auth';
 import { RegisterRoutes } from './routes/routes';
 import todosRouter from './routes/todo';
@@ -30,7 +31,7 @@ const corsOptions = {
 
 // Middleware to parse JSON bodies
 app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: '2mb' }));
 
 // Serve the Swagger UI at /docs
 app.use('/docs', swaggerUi.serve, async (_req: ExRequest, res: ExResponse) => {
@@ -67,6 +68,9 @@ app.use(passport.initialize());
 app.use(`${routerPrefix}/todo`, todosRouter);
 app.use(`${routerPrefix}/user`, usersRouter);
 app.use(`${routerPrefix}/auth`, authRouter);
+
+// Apply additional protections for blind-storage endpoints.
+app.use('/vault', vaultRateLimiter);
 
 // Register the routes
 RegisterRoutes(app);

--- a/apps/backend/src/middleware/vaultRateLimit.ts
+++ b/apps/backend/src/middleware/vaultRateLimit.ts
@@ -1,0 +1,38 @@
+import type { RequestHandler } from 'express';
+
+type Counter = { windowStartMs: number; count: number };
+
+const WINDOW_MS = 60 * 1000;
+const MAX_REQUESTS_PER_WINDOW = 120;
+
+const counters = new Map<string, Counter>();
+
+function getKey(req: Parameters<RequestHandler>[0]): string {
+  const userId = (req as any)?.user?.id;
+  if (typeof userId === 'string' && userId.length > 0) {
+    return `user:${userId}`;
+  }
+
+  const ip = req.ip || (req.socket?.remoteAddress ?? 'unknown');
+  return `ip:${ip}`;
+}
+
+export const vaultRateLimiter: RequestHandler = (req, res, next) => {
+  const now = Date.now();
+  const key = getKey(req);
+
+  const current = counters.get(key);
+  if (!current || now - current.windowStartMs >= WINDOW_MS) {
+    counters.set(key, { windowStartMs: now, count: 1 });
+    next();
+    return;
+  }
+
+  current.count += 1;
+  if (current.count > MAX_REQUESTS_PER_WINDOW) {
+    res.status(429).json({ message: 'Too many requests' });
+    return;
+  }
+
+  next();
+};


### PR DESCRIPTION
Implements issue #24 hardening for blind-storage vault endpoints.

- Adds strict base64 validation for `iv` and `ciphertext` and enforces decoded `iv` size (12–24 bytes)
- Enforces explicit payload size limits:
  - Vault meta <= 32KB
  - Vault blobs <= 256KB
  - Export/Import <= 1MB
- Adds request rate limiting for `/vault*` endpoints
- Updates backend unit tests for new validation rules

Notes:
- Rate limiting is implemented as a lightweight in-memory limiter (no external dependency), keyed by authenticated user id when available, otherwise by IP.
- Logging: no ciphertext is logged by these changes.

Closes #24.