### PR TITLE
feat(web): server-backed vault sync client (ETag-aware)

### DIFF
--- a/apps/myorganizer/src/lib/vault/serverVaultSync.test.ts
+++ b/apps/myorganizer/src/lib/vault/serverVaultSync.test.ts
@@ -1,0 +1,195 @@
+import {
+  EncryptedBlobV1,
+  VaultBlobType,
+  VaultMetaV1,
+} from '@myorganizer/app-api-client';
+import {
+  getServerVaultBlob,
+  getServerVaultMeta,
+  putServerVaultBlobEtagAware,
+  putServerVaultMetaEtagAware,
+} from './serverVaultSync';
+
+function makeMeta(overrides: Partial<VaultMetaV1> = {}): VaultMetaV1 {
+  return {
+    version: 1,
+    kdf_name: 'PBKDF2',
+    kdf_salt: 'salt',
+    kdf_params: { iterations: 1, hash: 'SHA-256' },
+    wrapped_mk_passphrase: { iv: 'iv', ciphertext: 'ct' },
+    wrapped_mk_recovery: { iv: 'iv', ciphertext: 'ct' },
+    ...overrides,
+  } as VaultMetaV1;
+}
+
+function makeBlob(overrides: Partial<EncryptedBlobV1> = {}): EncryptedBlobV1 {
+  return { iv: 'iv', ciphertext: 'ciphertext', ...overrides };
+}
+
+function httpError(status: number): any {
+  const error = new Error(`HTTP ${status}`) as any;
+  error.response = { status };
+  return error;
+}
+
+describe('serverVaultSync', () => {
+  test('getServerVaultMeta returns meta on success', async () => {
+    const api = {
+      getVaultMeta: jest.fn().mockResolvedValue({
+        data: { etag: 'e1', updatedAt: 't1', meta: makeMeta() },
+      }),
+    } as any;
+
+    await expect(getServerVaultMeta(api)).resolves.toEqual({
+      etag: 'e1',
+      updatedAt: 't1',
+      meta: makeMeta(),
+    });
+  });
+
+  test('getServerVaultMeta returns null on 404', async () => {
+    const api = {
+      getVaultMeta: jest.fn().mockRejectedValue(httpError(404)),
+    } as any;
+
+    await expect(getServerVaultMeta(api)).resolves.toBeNull();
+  });
+
+  test('putServerVaultMetaEtagAware uses If-Match and returns updated', async () => {
+    const api = {
+      putVaultMeta: jest.fn().mockResolvedValue({
+        data: { ok: true, etag: 'e2', updatedAt: 't2', message: 'ok' },
+      }),
+    } as any;
+
+    const result = await putServerVaultMetaEtagAware({
+      api,
+      meta: makeMeta(),
+      ifMatch: 'e1',
+    });
+
+    expect(api.putVaultMeta).toHaveBeenCalledWith({
+      putVaultMetaRequest: { meta: makeMeta() },
+      ifMatch: 'e1',
+    });
+
+    expect(result).toEqual({ kind: 'updated', etag: 'e2', updatedAt: 't2' });
+  });
+
+  test('putServerVaultMetaEtagAware on 409 can keep remote', async () => {
+    const api = {
+      putVaultMeta: jest.fn().mockRejectedValue(httpError(409)),
+      getVaultMeta: jest.fn().mockResolvedValue({
+        data: { etag: 'remote-etag', updatedAt: 'rt', meta: makeMeta() },
+      }),
+    } as any;
+
+    const result = await putServerVaultMetaEtagAware({
+      api,
+      meta: makeMeta({ kdf_salt: 'local' }),
+      ifMatch: 'local-etag',
+      onConflict: async () => 'keep-remote',
+    });
+
+    expect(result.kind).toBe('kept-remote');
+    if (result.kind === 'kept-remote') {
+      expect(result.remote.etag).toBe('remote-etag');
+    }
+  });
+
+  test('putServerVaultMetaEtagAware on 409 can keep local (retry with remote etag)', async () => {
+    const api = {
+      putVaultMeta: jest
+        .fn()
+        .mockRejectedValueOnce(httpError(409))
+        .mockResolvedValueOnce({
+          data: { ok: true, etag: 'new-etag', updatedAt: 't3', message: 'ok' },
+        }),
+      getVaultMeta: jest.fn().mockResolvedValue({
+        data: { etag: 'remote-etag', updatedAt: 'rt', meta: makeMeta() },
+      }),
+    } as any;
+
+    const meta = makeMeta({ kdf_salt: 'local' });
+
+    const result = await putServerVaultMetaEtagAware({
+      api,
+      meta,
+      ifMatch: 'local-etag',
+      onConflict: async () => 'keep-local',
+    });
+
+    expect(api.putVaultMeta).toHaveBeenNthCalledWith(1, {
+      putVaultMetaRequest: { meta },
+      ifMatch: 'local-etag',
+    });
+
+    expect(api.putVaultMeta).toHaveBeenNthCalledWith(2, {
+      putVaultMetaRequest: { meta },
+      ifMatch: 'remote-etag',
+    });
+
+    expect(result).toEqual({
+      kind: 'updated',
+      etag: 'new-etag',
+      updatedAt: 't3',
+    });
+  });
+
+  test('getServerVaultBlob returns null on 404', async () => {
+    const api = {
+      getVaultBlob: jest.fn().mockRejectedValue(httpError(404)),
+    } as any;
+
+    await expect(
+      getServerVaultBlob(api, VaultBlobType.Addresses)
+    ).resolves.toBeNull();
+  });
+
+  test('putServerVaultBlobEtagAware on 409 can keep local (retry with remote etag)', async () => {
+    const api = {
+      putVaultBlob: jest
+        .fn()
+        .mockRejectedValueOnce(httpError(409))
+        .mockResolvedValueOnce({
+          data: { ok: true, etag: 'new-etag', updatedAt: 't3', message: 'ok' },
+        }),
+      getVaultBlob: jest.fn().mockResolvedValue({
+        data: {
+          etag: 'remote-etag',
+          updatedAt: 'rt',
+          type: VaultBlobType.Addresses,
+          blob: makeBlob({ ciphertext: 'remote' }),
+        },
+      }),
+    } as any;
+
+    const blob = makeBlob({ ciphertext: 'local' });
+
+    const result = await putServerVaultBlobEtagAware({
+      api,
+      type: VaultBlobType.Addresses,
+      blob,
+      ifMatch: 'local-etag',
+      onConflict: async () => 'keep-local',
+    });
+
+    expect(api.putVaultBlob).toHaveBeenNthCalledWith(1, {
+      type: VaultBlobType.Addresses,
+      putVaultBlobRequest: { type: VaultBlobType.Addresses, blob },
+      ifMatch: 'local-etag',
+    });
+
+    expect(api.putVaultBlob).toHaveBeenNthCalledWith(2, {
+      type: VaultBlobType.Addresses,
+      putVaultBlobRequest: { type: VaultBlobType.Addresses, blob },
+      ifMatch: 'remote-etag',
+    });
+
+    expect(result).toEqual({
+      kind: 'updated',
+      etag: 'new-etag',
+      updatedAt: 't3',
+    });
+  });
+});

--- a/apps/myorganizer/src/lib/vault/serverVaultSync.ts
+++ b/apps/myorganizer/src/lib/vault/serverVaultSync.ts
@@ -1,0 +1,219 @@
+import {
+  EncryptedBlobV1,
+  GetVaultBlobResponse,
+  GetVaultMetaResponse,
+  PutVaultBlobResponse,
+  PutVaultMetaResponse,
+  VaultApi,
+  VaultBlobType,
+  VaultMetaV1,
+} from '@myorganizer/app-api-client';
+
+type VaultApiLike = Pick<
+  VaultApi,
+  'getVaultMeta' | 'putVaultMeta' | 'getVaultBlob' | 'putVaultBlob'
+>;
+
+export type ServerVaultMeta = {
+  etag: string;
+  updatedAt: string;
+  meta: VaultMetaV1;
+};
+
+export type ServerVaultBlob = {
+  etag: string;
+  updatedAt: string;
+  type: VaultBlobType;
+  blob: EncryptedBlobV1;
+};
+
+export type ConflictDecision = 'keep-local' | 'keep-remote';
+
+export type VaultMetaConflictHandler = (params: {
+  local: VaultMetaV1;
+  remote: ServerVaultMeta;
+}) => Promise<ConflictDecision> | ConflictDecision;
+
+export type VaultBlobConflictHandler = (params: {
+  local: EncryptedBlobV1;
+  remote: ServerVaultBlob;
+}) => Promise<ConflictDecision> | ConflictDecision;
+
+function getHttpStatus(error: unknown): number | undefined {
+  const maybeAny = error as any;
+  const status = maybeAny?.response?.status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+function defaultMetaConflictHandler(params: {
+  local: VaultMetaV1;
+  remote: ServerVaultMeta;
+}): ConflictDecision {
+  void params;
+  if (typeof window === 'undefined' || typeof window.confirm !== 'function') {
+    return 'keep-remote';
+  }
+
+  const overwrite = window.confirm(
+    'Your vault was updated in another session. Overwrite the server version with your local changes?' // minimum acceptable UX
+  );
+
+  return overwrite ? 'keep-local' : 'keep-remote';
+}
+
+function defaultBlobConflictHandler(params: {
+  local: EncryptedBlobV1;
+  remote: ServerVaultBlob;
+}): ConflictDecision {
+  void params;
+  if (typeof window === 'undefined' || typeof window.confirm !== 'function') {
+    return 'keep-remote';
+  }
+
+  const overwrite = window.confirm(
+    'Your vault data was updated in another session. Overwrite the server version with your local changes?' // minimum acceptable UX
+  );
+
+  return overwrite ? 'keep-local' : 'keep-remote';
+}
+
+function toServerVaultMeta(data: GetVaultMetaResponse): ServerVaultMeta {
+  return {
+    etag: data.etag,
+    updatedAt: data.updatedAt,
+    meta: data.meta,
+  };
+}
+
+function toServerVaultBlob(data: GetVaultBlobResponse): ServerVaultBlob {
+  return {
+    etag: data.etag,
+    updatedAt: data.updatedAt,
+    type: data.type,
+    blob: data.blob,
+  };
+}
+
+export async function getServerVaultMeta(
+  api: VaultApiLike
+): Promise<ServerVaultMeta | null> {
+  try {
+    const response = await api.getVaultMeta();
+    return toServerVaultMeta(response.data as GetVaultMetaResponse);
+  } catch (error) {
+    if (getHttpStatus(error) === 404) return null;
+    throw error;
+  }
+}
+
+export async function getServerVaultBlob(
+  api: VaultApiLike,
+  type: VaultBlobType
+): Promise<ServerVaultBlob | null> {
+  try {
+    const response = await api.getVaultBlob({ type });
+    return toServerVaultBlob(response.data as GetVaultBlobResponse);
+  } catch (error) {
+    if (getHttpStatus(error) === 404) return null;
+    throw error;
+  }
+}
+
+export type PutVaultMetaResult =
+  | {
+      kind: 'updated';
+      etag: string;
+      updatedAt: string;
+    }
+  | {
+      kind: 'kept-remote';
+      remote: ServerVaultMeta;
+    };
+
+export async function putServerVaultMetaEtagAware(options: {
+  api: VaultApiLike;
+  meta: VaultMetaV1;
+  ifMatch?: string;
+  onConflict?: VaultMetaConflictHandler;
+}): Promise<PutVaultMetaResult> {
+  const onConflict = options.onConflict ?? defaultMetaConflictHandler;
+
+  try {
+    const response = await options.api.putVaultMeta({
+      putVaultMetaRequest: { meta: options.meta },
+      ifMatch: options.ifMatch,
+    });
+
+    const data = response.data as PutVaultMetaResponse;
+    return { kind: 'updated', etag: data.etag, updatedAt: data.updatedAt };
+  } catch (error) {
+    if (getHttpStatus(error) !== 409) throw error;
+
+    const remote = await getServerVaultMeta(options.api);
+    if (!remote) throw error;
+
+    const decision = await onConflict({ local: options.meta, remote });
+    if (decision === 'keep-remote') {
+      return { kind: 'kept-remote', remote };
+    }
+
+    const retry = await options.api.putVaultMeta({
+      putVaultMetaRequest: { meta: options.meta },
+      ifMatch: remote.etag,
+    });
+
+    const data = retry.data as PutVaultMetaResponse;
+    return { kind: 'updated', etag: data.etag, updatedAt: data.updatedAt };
+  }
+}
+
+export type PutVaultBlobResult =
+  | {
+      kind: 'updated';
+      etag: string;
+      updatedAt: string;
+    }
+  | {
+      kind: 'kept-remote';
+      remote: ServerVaultBlob;
+    };
+
+export async function putServerVaultBlobEtagAware(options: {
+  api: VaultApiLike;
+  type: VaultBlobType;
+  blob: EncryptedBlobV1;
+  ifMatch?: string;
+  onConflict?: VaultBlobConflictHandler;
+}): Promise<PutVaultBlobResult> {
+  const onConflict = options.onConflict ?? defaultBlobConflictHandler;
+
+  try {
+    const response = await options.api.putVaultBlob({
+      type: options.type,
+      putVaultBlobRequest: { type: options.type, blob: options.blob },
+      ifMatch: options.ifMatch,
+    });
+
+    const data = response.data as PutVaultBlobResponse;
+    return { kind: 'updated', etag: data.etag, updatedAt: data.updatedAt };
+  } catch (error) {
+    if (getHttpStatus(error) !== 409) throw error;
+
+    const remote = await getServerVaultBlob(options.api, options.type);
+    if (!remote) throw error;
+
+    const decision = await onConflict({ local: options.blob, remote });
+    if (decision === 'keep-remote') {
+      return { kind: 'kept-remote', remote };
+    }
+
+    const retry = await options.api.putVaultBlob({
+      type: options.type,
+      putVaultBlobRequest: { type: options.type, blob: options.blob },
+      ifMatch: remote.etag,
+    });
+
+    const data = retry.data as PutVaultBlobResponse;
+    return { kind: 'updated', etag: data.etag, updatedAt: data.updatedAt };
+  }
+}


### PR DESCRIPTION
Implements the web-app wrapper for server-backed vault meta/blob sync with optimistic concurrency via ETags (If-Match) and explicit conflict handling (409).

- Adds ETag-aware helpers for GET/PUT vault meta and blobs
- On 409, refetches remote and requires an explicit decision (keep remote vs overwrite)
- Adds Jest tests covering success + conflict paths

Closes #26