### PR TITLE
Test: stabilize vault integration suite (Epic #20)

### DIFF
--- a/apps/backend/src/controllers/VaultController.int.test.ts
+++ b/apps/backend/src/controllers/VaultController.int.test.ts
@@ -4,6 +4,8 @@ import express from 'express';
 import request from 'supertest';
 import { ValidateError } from 'tsoa';
 
+jest.setTimeout(30_000);
+
 jest.mock('../middleware/authentication', () => {
   return {
     expressAuthentication: async (req: any) => {

--- a/libs/core/project.json
+++ b/libs/core/project.json
@@ -16,7 +16,8 @@
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/libs/core"],
       "options": {
-        "jestConfig": "libs/core/jest.config.ts"
+        "jestConfig": "libs/core/jest.config.ts",
+        "passWithNoTests": true
       }
     }
   }


### PR DESCRIPTION
Closes #20

## What changed
- Stabilized backend vault HTTP integration tests by increasing Jest timeout.
- Made `core:test` non-blocking when the library has zero tests (`passWithNoTests`).

## Why
- The Epic #20 validation run (`nx run-many -t test --all`) was failing due to:
  - `VaultController.int.test.ts` occasionally exceeding the default 5s Jest timeout.
  - `core:test` exiting non-zero when no tests exist.

## Verification
- Ran: `yarn nx run-many -t test --all` (PASS)

## Notes
- No production runtime code changes; test/config-only.