### PR TITLE
fix: align Vercel staging deploy heredoc

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -148,20 +148,20 @@ jobs:
           #
           # Nx recommends keeping the Vercel project's Root Directory at the
           # workspace root and setting the Build Command to `npx nx build myorganizer --prod`.
-            set -euo pipefail
-            VERCEL_CLI_VERSION='41.7.8'
+          set -euo pipefail
+          VERCEL_CLI_VERSION='41.7.8'
 
-            corepack yarn dlx -p "vercel@${VERCEL_CLI_VERSION}" vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
+          corepack yarn dlx -p "vercel@${VERCEL_CLI_VERSION}" vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
 
-            echo '--- Vercel diagnostics (sanitized) ---'
-            if [ -d .vercel ]; then
-              echo 'Vercel metadata files (names only):'
-              find .vercel -maxdepth 2 -type f -print
-            else
-              echo 'No .vercel directory found after vercel pull.'
-            fi
+          echo '--- Vercel diagnostics (sanitized) ---'
+          if [ -d .vercel ]; then
+            echo 'Vercel metadata files (names only):'
+            find .vercel -maxdepth 2 -type f -print
+          else
+            echo 'No .vercel directory found after vercel pull.'
+          fi
 
-            node <<'NODE'
+          node <<'NODE'
             const fs = require('fs');
             const path = '.vercel/project.json';
             if (!fs.existsSync(path)) {
@@ -186,11 +186,11 @@ jobs:
             };
 
             console.log(JSON.stringify(sanitized, null, 2));
-            NODE
+          NODE
 
-            echo 'NOTE: Not printing any .vercel/.env* files to avoid leaking secrets.'
-            echo '--- end Vercel diagnostics ---'
+          echo 'NOTE: Not printing any .vercel/.env* files to avoid leaking secrets.'
+          echo '--- end Vercel diagnostics ---'
 
-            # Avoid `--prebuilt`: prebuilt bundles can fail in monorepos when
-            # file-trace references point outside the uploaded artifact set.
-            corepack yarn dlx -p "vercel@${VERCEL_CLI_VERSION}" vercel deploy --prod --yes --token "$VERCEL_TOKEN"
+          # Avoid `--prebuilt`: prebuilt bundles can fail in monorepos when
+          # file-trace references point outside the uploaded artifact set.
+          corepack yarn dlx -p "vercel@${VERCEL_CLI_VERSION}" vercel deploy --prod --yes --token "$VERCEL_TOKEN"


### PR DESCRIPTION
Align the heredoc in the Vercel staging deploy script for improved readability and consistency. This change enhances the overall structure without altering functionality.