### PR TITLE
feat: replace static user data with authenticated user info in sidebar

### DIFF
--- a/libs/web/pages/dashboard/src/components/app-sidebar.tsx
+++ b/libs/web/pages/dashboard/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import { getCurrentUser } from '@myorganizer/auth';
 import {
   Sidebar,
   SidebarContent,
@@ -20,59 +21,59 @@ import {
 import { NavMain } from './nav-main';
 import { NavUser } from './nav-user';
 
-const data = {
-  user: {
-    name: 'shadcn',
-    email: 'm@example.com',
-    avatar: '/avatars/shadcn.jpg',
+const navMain = [
+  {
+    title: 'Home',
+    url: '/dashboard',
+    icon: Home,
   },
-  navMain: [
-    {
-      title: 'Home',
-      url: '/dashboard',
-      icon: Home,
-    },
-    {
-      title: 'Todos',
-      url: '/dashboard/todo',
-      icon: ListChecks,
-    },
-    {
-      title: 'Addresses',
-      url: '/dashboard/addresses',
-      icon: MapPin,
-    },
-    {
-      title: 'Mobile Numbers',
-      url: '/dashboard/mobile-numbers',
-      icon: Phone,
-    },
-    {
-      title: 'Subscriptions',
-      url: '/dashboard/subscriptions',
-      icon: CreditCard,
-    },
-    {
-      title: 'YouTube',
-      url: '/dashboard/youtube',
-      icon: Youtube,
-    },
-    {
-      title: 'Vault Export/Import',
-      url: '/dashboard/vault-export',
-      icon: FileDown,
-    },
-  ],
-};
+  {
+    title: 'Todos',
+    url: '/dashboard/todo',
+    icon: ListChecks,
+  },
+  {
+    title: 'Addresses',
+    url: '/dashboard/addresses',
+    icon: MapPin,
+  },
+  {
+    title: 'Mobile Numbers',
+    url: '/dashboard/mobile-numbers',
+    icon: Phone,
+  },
+  {
+    title: 'Subscriptions',
+    url: '/dashboard/subscriptions',
+    icon: CreditCard,
+  },
+  {
+    title: 'YouTube',
+    url: '/dashboard/youtube',
+    icon: Youtube,
+  },
+  {
+    title: 'Vault Export/Import',
+    url: '/dashboard/vault-export',
+    icon: FileDown,
+  },
+];
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const currentUser = getCurrentUser();
+  const user = {
+    name: currentUser?.name ?? '',
+    email: currentUser?.email ?? '',
+    avatar: '',
+  };
+
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
-        <NavUser user={data.user} />
+        <NavUser user={user} />
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
+        <NavMain items={navMain} />
       </SidebarContent>
       <SidebarRail />
     </Sidebar>

--- a/libs/web/pages/dashboard/src/components/nav-user.tsx
+++ b/libs/web/pages/dashboard/src/components/nav-user.tsx
@@ -46,6 +46,13 @@ export function NavUser({
     router.push('/login');
   }
 
+  const initials = user.name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
   return (
     <SidebarMenu>
       <SidebarMenuItem>
@@ -57,7 +64,9 @@ export function NavUser({
             >
               <Avatar className="h-8 w-8 rounded-lg">
                 <AvatarImage src={user.avatar} alt={user.name} />
-                <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                <AvatarFallback className="rounded-lg">
+                  {initials}
+                </AvatarFallback>
               </Avatar>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-semibold">{user.name}</span>
@@ -76,7 +85,9 @@ export function NavUser({
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <Avatar className="h-8 w-8 rounded-lg">
                   <AvatarImage src={user.avatar} alt={user.name} />
-                  <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                  <AvatarFallback className="rounded-lg">
+                    {initials}
+                  </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-semibold">{user.name}</span>


### PR DESCRIPTION
## Summary

Replaces hardcoded placeholder user data in the dashboard sidebar and user dropdown with real authenticated user information read from the auth session.

## Changes

### `libs/web/pages/dashboard/src/components/app-sidebar.tsx`
- Removed static `data.user` object containing the placeholder values `shadcn`, `m@example.com`, and `/avatars/shadcn.jpg`
- Added `getCurrentUser()` call from `@myorganizer/auth` inside the `AppSidebar` component to read the logged-in user's `name` and `email` at render time
- `avatar` is set to an empty string since the API model (`FilteredUserInterface`) does not expose a profile picture field — the `AvatarImage` gracefully falls back to the initials avatar

### `libs/web/pages/dashboard/src/components/nav-user.tsx`
- Replaced the hardcoded `"CN"` `AvatarFallback` (which appeared in both the sidebar trigger and the dropdown label) with dynamically computed initials derived from `user.name` (e.g. `"John Doe"` → `"JD"`, `"Alice"` → `"AL"`)

## Motivation

The sidebar and user dropdown were displaying static placeholder content (`shadcn`, `m@example.com`, `CN`) regardless of which user was logged in. This change ensures the UI reflects the real authenticated user's identity.

## Testing

- Log in with any account and verify the sidebar header shows the correct name and email
- Verify the avatar fallback displays the correct initials for the logged-in user
- Verify logout still works as expected