### PR TITLE
feat(workflow): add shared AI commit and PR tooling

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,9 @@
+# Commit Command
+
+Use this workflow when the user asks Claude Code to commit the current staged changes.
+
+1. Draft the Conventional Commit message with the existing `Commit` sub-agent.
+2. Execute the commit with `corepack yarn ai:commit`.
+3. Wait for `git commit` to finish. Do not cancel the command while Husky pre-commit checks are running.
+4. If Husky fails, fix the reported issue, rerun the narrow validation, and retry the commit.
+5. Keep the final response concise.

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,9 @@
+# Create PR Command
+
+Use this workflow when the user asks Claude Code to create a pull request for the current branch.
+
+1. Gather the branch commits relative to the base branch.
+2. Execute `corepack yarn ai:create-pr`.
+3. If the user names reviewers, pass `--reviewer <login>` for each reviewer.
+4. Push the branch upstream if needed, assign the authenticated GitHub user, and leave reviewers empty when none are specified.
+5. Return only the PR URL on success.

--- a/.cursor/rules/commit-change-workflow.mdc
+++ b/.cursor/rules/commit-change-workflow.mdc
@@ -1,0 +1,12 @@
+---
+description: Commit staged MyOrganizer changes safely by reusing the Commit sub-agent for the message and the shared ai:commit runner for execution.
+alwaysApply: false
+---
+
+# Commit Change Workflow
+
+- Use the existing `Commit` sub-agent to draft the Conventional Commit message from the staged diff.
+- Run the actual commit with `corepack yarn ai:commit`.
+- Wait for `git commit` to finish. Do not cancel or background the process while Husky is running.
+- If Husky fails, fix the reported formatting, lint, typecheck, or test issue, rerun the narrow validation, and then retry the commit.
+- Do not auto-stage unrelated files.

--- a/.cursor/rules/create-pull-request-workflow.mdc
+++ b/.cursor/rules/create-pull-request-workflow.mdc
@@ -1,0 +1,12 @@
+---
+description: Create or reuse a MyOrganizer pull request from the current branch with the shared ai:create-pr runner, upstream push, authenticated-user assignment, and optional reviewers.
+alwaysApply: false
+---
+
+# Create Pull Request Workflow
+
+- Base the PR content on commits in the current branch relative to the base branch.
+- Run `corepack yarn ai:create-pr`.
+- If reviewers are explicitly provided, pass `--reviewer <login>` for each one.
+- Push upstream if needed, assign the authenticated GitHub user, and leave reviewers empty otherwise.
+- Return only the PR URL on success.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -232,6 +232,17 @@ When consuming the generated client:
 - Ensure tests pass: `yarn nx test`
 - Check TypeScript types (automatic during build)
 
+### Commit And PR Workflows
+
+- When the user asks to commit changes, use the repo-local commit workflow skill and the existing `Commit` sub-agent together:
+  - The `Commit` sub-agent drafts the Conventional Commit message only.
+  - The actual commit must run through `corepack yarn ai:commit`.
+- The commit workflow must wait for `git commit` to finish. Do not cancel, background, or move on while Husky pre-commit checks are still running.
+- If Husky fails because of linting, tests, formatting, or another validation issue, fix the reported problem first, rerun the narrow validation for that slice, and only then retry the commit.
+- Commit-time Nx output should remain readable. The Husky hook uses static output for Nx task execution; preserve that behavior when editing the hook.
+- When the user asks to open or create a PR, use `corepack yarn ai:create-pr` unless an IDE-native integration can satisfy the exact same behavior.
+- PR creation should gather the commit history from the current branch, push upstream if needed, assign the authenticated GitHub user, keep reviewers empty unless the user explicitly names one, and return only success plus the PR link.
+
 ## API Development
 
 ### Adding New Endpoints

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -20,6 +20,11 @@ Committed third wave:
 
 - `nx-monorepo-workflow`
 
+Committed fourth wave:
+
+- `commit-change-workflow`
+- `create-pull-request-workflow`
+
 These skills capture project-specific workflows that are easy for agents to miss even after reading the general repo instructions.
 
 Note: these are VS Code workspace skills stored in `.github/skills`. They are intended for agent discovery inside the editor. They may not appear in `npx skills list`, which focuses on skills installed through the `skills` CLI.

--- a/.github/skills/commit-change-workflow/SKILL.md
+++ b/.github/skills/commit-change-workflow/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: commit-change-workflow
+description: 'Use when the user asks to commit changes, make a commit, git commit the current work, commit this branch, or save the current staged work as a commit in MyOrganizer. Use the existing Commit sub-agent to draft the message, then execute the commit through the shared workflow so Husky is allowed to finish.'
+---
+
+# Commit Change Workflow
+
+## Use This Skill When
+
+- The user asks you to commit the current work.
+- The user asks for `git commit`, a Conventional Commit, or to save the staged changes.
+- The user wants the agent to finish the commit, not only to draft the message.
+
+## Core Rules
+
+- Use the existing `Commit` sub-agent to draft the Conventional Commit message. Do not invent a message without checking the actual diff.
+- Treat the `Commit` sub-agent as read-only. It drafts the message only.
+- Execute the actual commit through `corepack yarn ai:commit`.
+- Wait for the `git commit` process to return. Do not cancel it, detach it, move on, or start other work while Husky pre-commit checks are still running.
+- Do not auto-stage unrelated files. If nothing is staged, stop and ask the user whether the intended files should be staged first.
+- If Husky fails, fix the reported formatting, linting, typecheck, test, or other validation issue before retrying the commit.
+- After fixing a Husky failure, rerun the narrowest relevant validation for the touched slice before re-running `corepack yarn ai:commit`.
+
+## Workflow
+
+1. Inspect the current git state and confirm which files are staged.
+2. Call the `Commit` sub-agent to draft the Conventional Commit message from the staged diff.
+3. Write the drafted message to a temporary file or pipe it over stdin.
+4. Run one of these commands:
+
+```sh
+corepack yarn ai:commit --message-file <path-to-message-file>
+```
+
+or
+
+```sh
+printf '%s\n' '<commit-message>' | corepack yarn ai:commit
+```
+
+5. Wait for completion.
+6. If the commit fails because Husky fails:
+   - read the actual error output
+   - fix the reported issue
+   - rerun the narrowest relevant validation
+   - rerun `corepack yarn ai:commit`
+7. Report the final commit result concisely.
+
+## Validation
+
+- Prefer the exact failing check reported by Husky.
+- If Husky reports lint issues, rerun the relevant lint target or affected lint command.
+- If Husky reports formatting issues, rerun the narrowest formatter or repo formatter that matches the touched files.
+- Only retry the commit after the focused validation passes.
+
+## References
+
+- `.github/agents/commit.agent.md` — message generation only
+- `tools/scripts/ai/commit-change.mjs` — shared commit runner
+- `.husky/pre-commit` — commit-time formatting and lint checks
+- `AGENTS.md` — repo-wide workflow routing

--- a/.github/skills/create-pull-request-workflow/SKILL.md
+++ b/.github/skills/create-pull-request-workflow/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: create-pull-request-workflow
+description: 'Use when the user asks to create a pull request, open a PR, raise a PR for the current branch, publish this branch as a PR, or submit the current branch for review in MyOrganizer. Gather commit history from the branch, ensure upstream push, assign the authenticated GitHub user, and keep reviewers empty unless the user explicitly names one.'
+---
+
+# Create Pull Request Workflow
+
+## Use This Skill When
+
+- The user asks to create, open, or publish a pull request.
+- The user wants a PR for the current branch.
+- The user asks to assign reviewers or create a PR from the current work.
+
+## Core Rules
+
+- Base the PR title and description on the commits in the current branch relative to the base branch, not on the unstaged working tree.
+- Use the shared workflow command `corepack yarn ai:create-pr`.
+- Push the branch upstream if it is not already tracked.
+- Assign the PR to the authenticated GitHub user.
+- If the user does not specify reviewers, leave the reviewer list empty.
+- If the user specifies one or more reviewers, pass them explicitly with `--reviewer`.
+- If an open PR already exists for the current branch, reuse it and return the existing PR URL.
+- Keep the final user-facing output terse: success plus the PR link.
+
+## Workflow
+
+1. Confirm the current branch is not the base branch.
+2. Gather the branch commit history relative to the default base branch.
+3. Draft or refine the PR title and description from those commits when needed.
+4. Run:
+
+```sh
+corepack yarn ai:create-pr
+```
+
+5. If reviewers were specified, run:
+
+```sh
+corepack yarn ai:create-pr --reviewer <login>
+```
+
+Repeat `--reviewer` for multiple reviewers.
+
+6. Return only the success status and the PR URL.
+
+## Validation
+
+- Confirm the branch has commits relative to the base branch.
+- Confirm the PR command succeeded and returned a URL.
+- If the command reports authentication or push failures, fix that blocker before claiming the PR is created.
+
+## References
+
+- `tools/scripts/ai/create-pr.mjs` — shared PR runner
+- `DEVELOPMENT.md` — human-facing PR workflow
+- `AGENTS.md` — repo-wide workflow routing

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,9 @@
 . .husky/common.sh
 
 corepack yarn format:write --uncommitted
-corepack yarn affected:lint --uncommitted
+corepack yarn affected:lint --uncommitted --outputStyle=static
 
 # .husky/pre-commit
+
 corepack yarn prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\ |g') --write --ignore-unknown
 git update-index --again

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - Test one project: `yarn nx test <project-name>`.
 - Lint: `yarn nx lint <project-name>` or `yarn lint`.
 - Format: `yarn format:write`.
+- AI commit workflow: `corepack yarn ai:commit --message-file <path>` (or pipe the message on stdin).
+- AI PR workflow: `corepack yarn ai:create-pr [--reviewer <login>]`.
 - API sync after backend contract changes: `yarn openapi:sync`; check drift with `yarn openapi:check`.
 - Prisma (backend): prefer Nx targets `yarn nx run backend:migrate` and `yarn nx run backend:generate-types`.
 - Prisma (manual): run from `apps/backend/src` and pass schema path, e.g. `npx prisma migrate dev --schema prisma/schema --name <migration_name>` and `npx prisma generate --schema prisma/schema`.
@@ -44,6 +46,9 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - Use the generated API client when it covers the endpoint.
 - Add or update focused tests for changed behavior.
 - Keep docs concise and link to existing docs when possible.
+- Use the `Commit` sub-agent only to draft Conventional Commit messages; execute commits through the shared AI workflow so Husky is allowed to finish.
+- For commit requests, wait for `git commit` to return before continuing. If Husky fails, fix the reported issue and rerun the narrow validation before retrying the commit.
+- For PR requests, gather commit history from the current branch, push upstream if needed, create or reuse the PR, assign the authenticated GitHub user, and leave reviewers empty unless the user explicitly names them.
 
 ## Do Not
 
@@ -52,6 +57,8 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - Do not store vault plaintext on the server or add plaintext todo APIs.
 - Do not hand-edit generated API client code.
 - Do not commit secrets or production credentials.
+- Do not cancel, background, or abandon a running `git commit` while Husky checks are still executing.
+- Do not open pull requests from `main` or another base branch directly.
 
 ## Spec-driven changes (OpenSpec)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Workflows
+
+Use the repo-local command files under `.claude/commands/` for commit and PR tasks.
+
+- Commit requests should use `.claude/commands/commit.md`.
+- PR requests should use `.claude/commands/create-pr.md`.
+- Commit-message drafting still belongs to the existing `Commit` sub-agent; commit execution belongs to the shared `ai:commit` runner.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -728,10 +728,12 @@ Good issues help maintainers understand and address problems quickly. Here's how
 
    ```bash
    git add .
-   git commit -m "feat: add user profile settings page"
+   corepack yarn ai:commit --message "feat: add user profile settings page"
    ```
 
    Use [Conventional Commits](https://www.conventionalcommits.org/) format.
+   The shared commit workflow waits for Husky pre-commit checks to finish and uses static Nx output so lint failures stay readable in terminal-based AI tools.
+   If Husky fails, fix the reported formatting, linting, test, or typecheck issue before retrying the commit.
 
 6. **Keep Your Branch Up to Date**
 
@@ -747,54 +749,25 @@ Good issues help maintainers understand and address problems quickly. Here's how
    ```
 
 8. **Create the Pull Request**
-   - Go to your fork on GitHub
-   - Click "Compare & pull request"
-   - **Write a Clear PR Title**: Same format as commits
-     - `feat: add user profile settings`
-     - `fix: resolve database connection timeout`
-     - `docs: update API documentation`
+   - Use the shared PR workflow:
 
-   - **Fill in the PR Description**:
-
-     ```markdown
-     ## Description
-
-     Brief description of what this PR does.
-
-     ## Related Issue
-
-     Closes #123
-
-     ## Changes Made
-
-     - Added user profile settings page
-     - Updated user service to support profile updates
-     - Added tests for profile update functionality
-
-     ## Testing Done
-
-     - [ ] Unit tests pass
-     - [ ] E2E tests pass
-     - [ ] Manual testing completed
-     - [ ] Documentation updated
-
-     ## Screenshots (if applicable)
-
-     [Add screenshots of UI changes]
-
-     ## Checklist
-
-     - [ ] Code follows project style guidelines
-     - [ ] Self-review completed
-     - [ ] Comments added for complex code
-     - [ ] Documentation updated
-     - [ ] Tests added/updated
-     - [ ] All tests passing
-     - [ ] No new warnings introduced
+     ```bash
+     corepack yarn ai:create-pr
      ```
 
-   - **Request Reviewers** (if you have permission)
-   - **Add Labels** (if you have permission)
+   - Add reviewers only when you need them:
+
+     ```bash
+     corepack yarn ai:create-pr --reviewer teammate-login
+     ```
+
+   - The shared PR workflow:
+     - gathers the commits in the current branch relative to the default base branch
+     - pushes the branch upstream if it is not already tracked
+     - creates the PR description from the branch commits
+     - assigns the authenticated GitHub user to the PR
+     - leaves reviewers empty unless you explicitly pass one
+     - returns only the PR URL on success
 
 9. **Submit the Pull Request**
 
@@ -816,7 +789,7 @@ Good issues help maintainers understand and address problems quickly. Here's how
    ```bash
    # Make requested changes
    git add .
-   git commit -m "fix: address review feedback"
+   corepack yarn ai:commit --message "fix: address review feedback"
    git push origin feature/your-feature-name
    ```
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,19 @@
+# Gemini Workflows
+
+Use these repo-local workflows for commit and pull request tasks.
+
+## Commit Changes
+
+- Draft the Conventional Commit message with the existing `Commit` sub-agent or equivalent diff-based commit-message generator.
+- Execute the commit with `corepack yarn ai:commit`.
+- Wait for the commit process to finish; do not cancel the command while Husky is running.
+- If Husky fails, fix the reported issue, rerun the narrow validation, and retry the commit.
+
+## Create Pull Request
+
+- Build the PR title and description from the current branch commits.
+- Execute `corepack yarn ai:create-pr`.
+- Push upstream if needed.
+- Assign the authenticated GitHub user.
+- Leave reviewers empty unless the user explicitly supplies them with `--reviewer <login>`.
+- Return only the PR URL on success.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "format:check": "nx format:check",
     "format:write": "nx format:write",
     "format": "nx format",
+    "ai:commit": "node tools/scripts/ai/commit-change.mjs",
+    "ai:create-pr": "node tools/scripts/ai/create-pr.mjs",
     "nx": "nx",
     "postinstall": "husky"
   },

--- a/tools/scripts/ai/commit-change.mjs
+++ b/tools/scripts/ai/commit-change.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const usage = `Usage:
+  corepack yarn ai:commit --message "type(scope): subject"
+  corepack yarn ai:commit --message-file path/to/message.txt
+  cat message.txt | corepack yarn ai:commit
+
+Options:
+  --message <text>       Commit message text to use.
+  --message-file <path>  Read the commit message from a file.
+  --help                 Show this help text.
+`;
+
+function fail(message, exitCode = 1) {
+  process.stderr.write(`${message}\n`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const options = {
+    help: false,
+    message: null,
+    messageFile: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === '--message') {
+      options.message = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--message-file') {
+      options.messageFile = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function run(command, args, capture = false) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: capture ? 'pipe' : 'inherit',
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    fail(`Failed to run ${command}: ${result.error.message}`);
+  }
+
+  return result;
+}
+
+function readCommitMessage(options) {
+  if (options.message && options.messageFile) {
+    fail('Provide either --message or --message-file, not both.');
+  }
+
+  if (options.messageFile) {
+    return readFileSync(options.messageFile, 'utf8');
+  }
+
+  if (options.message) {
+    return options.message;
+  }
+
+  if (!process.stdin.isTTY) {
+    return readFileSync(0, 'utf8');
+  }
+
+  fail(
+    'A commit message is required. Use --message, --message-file, or stdin.',
+  );
+}
+
+function ensureStagedChanges() {
+  const result = run('git', ['diff', '--cached', '--quiet', '--exit-code']);
+
+  if (result.status === 1) {
+    return;
+  }
+
+  if (result.status === 0) {
+    fail(
+      'No staged changes found. Stage the intended files before running ai:commit.',
+    );
+  }
+
+  fail('Unable to inspect staged changes before committing.');
+}
+
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  process.stdout.write(usage);
+  process.exit(0);
+}
+
+const commitMessage = readCommitMessage(options).trimEnd();
+
+if (!commitMessage.trim()) {
+  fail('Commit message cannot be empty.');
+}
+
+ensureStagedChanges();
+
+const tempDir = mkdtempSync(join(tmpdir(), 'myorganizer-ai-commit-'));
+const messagePath = join(tempDir, 'COMMIT_EDITMSG');
+
+writeFileSync(messagePath, `${commitMessage}\n`, 'utf8');
+
+const commitResult = run('git', ['commit', '--file', messagePath]);
+
+rmSync(tempDir, { force: true, recursive: true });
+
+if (typeof commitResult.status === 'number') {
+  process.exit(commitResult.status);
+}
+
+process.exit(1);

--- a/tools/scripts/ai/create-pr.mjs
+++ b/tools/scripts/ai/create-pr.mjs
@@ -118,7 +118,28 @@ function normalizeReviewers(reviewers) {
   return reviewers
     .flatMap((reviewer) => reviewer.split(','))
     .map((reviewer) => reviewer.trim())
-    .filter(Boolean);
+    .filter(Boolean)
+    .map((reviewer) => {
+      if (reviewer.startsWith('@') && !/^@(copilot|me)$/i.test(reviewer)) {
+        return reviewer.slice(1);
+      }
+
+      return reviewer;
+    });
+}
+
+function validateReviewers(reviewers) {
+  const unsupportedReviewers = reviewers.filter((reviewer) =>
+    /^@(copilot|me)$/i.test(reviewer),
+  );
+
+  if (unsupportedReviewers.length === 0) {
+    return;
+  }
+
+  fail(
+    'GitHub review requests do not support @copilot or @me as reviewer handles through this workflow. Use a real GitHub login for --reviewer, or keep Copilot in the IDE/web review flow instead.',
+  );
 }
 
 function ensureGhAvailable() {
@@ -250,6 +271,22 @@ function extractCommitBodyBullets(body) {
     .filter(Boolean);
 }
 
+function buildFallbackWhy(commits, branch, baseBranch) {
+  const primaryIntent = toSentence(stripConventionalPrefix(commits[0].subject));
+
+  if (commits.length === 1) {
+    return primaryIntent;
+  }
+
+  const followUpLabel =
+    commits.length === 2 ? 'A follow-up commit' : 'Follow-up commits';
+
+  return [
+    primaryIntent,
+    `${followUpLabel} refine the branch before merging \`${branch}\` into \`${baseBranch}\`.`,
+  ].join(' ');
+}
+
 function buildFallbackTitle(commits, branch) {
   const commitSubjects = commits.map((commit) => commit.subject);
 
@@ -262,26 +299,21 @@ function buildFallbackTitle(commits, branch) {
 }
 
 function buildFallbackBody(commits, branch, baseBranch) {
-  const summary =
-    commits.length === 1
-      ? toSentence(stripConventionalPrefix(commits[0].subject))
-      : `This PR includes ${commits.length} commits from \`${branch}\` into \`${baseBranch}\`.`;
-
   const detailBullets = commits.flatMap((commit) =>
     extractCommitBodyBullets(commit.body),
   );
 
-  const whatChangedLines =
+  const changeLines =
     detailBullets.length > 0
       ? detailBullets.map((detail) => `- ${detail}`)
       : commits.map((commit) => `- ${commit.subject}`);
 
   return [
-    '## Summary',
-    summary,
+    '## Why',
+    buildFallbackWhy(commits, branch, baseBranch),
     '',
-    '## What Changed',
-    ...whatChangedLines,
+    '## Changes',
+    ...changeLines,
     '',
     '## Validation',
     `- Generated from ${commits.length} commit(s) on \`${branch}\`.`,
@@ -442,6 +474,7 @@ const reviewers = normalizeReviewers(options.reviewers);
 const commits = getBranchCommits(baseBranch);
 
 ensureNotBaseBranch(branch, baseBranch);
+validateReviewers(reviewers);
 ensureUpstreamBranch();
 
 if (commits.length === 0) {

--- a/tools/scripts/ai/create-pr.mjs
+++ b/tools/scripts/ai/create-pr.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const usage = `Usage:
+  corepack yarn ai:create-pr [options]
+
+Options:
+  --base <branch>         Base branch for the pull request. Defaults to origin/HEAD or main.
+  --title <text>          Pull request title. Falls back to commit-derived text when omitted.
+  --body <text>           Pull request body text.
+  --body-file <path>      Read the pull request body from a file.
+  --reviewer <login>      Reviewer to request. Repeat the flag or pass a comma-separated list.
+  --draft                 Create the pull request as a draft.
+  --help                  Show this help text.
+`;
+
+function fail(message, exitCode = 1) {
+  process.stderr.write(`${message}\n`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const options = {
+    base: null,
+    body: null,
+    bodyFile: null,
+    draft: false,
+    help: false,
+    reviewers: [],
+    title: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === '--base') {
+      options.base = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--title') {
+      options.title = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--body') {
+      options.body = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--body-file') {
+      options.bodyFile = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--reviewer') {
+      options.reviewers.push(argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--draft') {
+      options.draft = true;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function run(command, args, options = {}) {
+  const { allowFailure = false } = options;
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    fail(`Failed to run ${command}: ${result.error.message}`);
+  }
+
+  if (!allowFailure && result.status !== 0) {
+    if (result.stdout) {
+      process.stdout.write(result.stdout);
+    }
+
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
+
+    process.exit(result.status ?? 1);
+  }
+
+  return result;
+}
+
+function trimStdout(command, args, options = {}) {
+  return run(command, args, options).stdout.trim();
+}
+
+function normalizeReviewers(reviewers) {
+  return reviewers
+    .flatMap((reviewer) => reviewer.split(','))
+    .map((reviewer) => reviewer.trim())
+    .filter(Boolean);
+}
+
+function ensureGhAvailable() {
+  run('gh', ['--version']);
+}
+
+function getCurrentBranch() {
+  const branch = trimStdout('git', ['branch', '--show-current']);
+
+  if (!branch) {
+    fail('Unable to determine the current branch.');
+  }
+
+  return branch;
+}
+
+function getDefaultBaseBranch() {
+  const result = run('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+    allowFailure: true,
+  });
+
+  if (result.status === 0) {
+    return result.stdout.trim().replace(/^refs\/remotes\/origin\//, '');
+  }
+
+  return 'main';
+}
+
+function ensureNotBaseBranch(branch, baseBranch) {
+  if (branch === baseBranch) {
+    fail(
+      `Refusing to create a pull request from the base branch '${baseBranch}'.`,
+    );
+  }
+}
+
+function ensureUpstreamBranch() {
+  const upstreamResult = run(
+    'git',
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'],
+    { allowFailure: true },
+  );
+
+  if (upstreamResult.status === 0) {
+    return;
+  }
+
+  run('git', ['push', '-u', 'origin', 'HEAD']);
+}
+
+function resolveBaseRef(baseBranch) {
+  const remoteRef = `refs/remotes/origin/${baseBranch}`;
+  const remoteCheck = run('git', ['rev-parse', '--verify', remoteRef], {
+    allowFailure: true,
+  });
+
+  if (remoteCheck.status === 0) {
+    return `origin/${baseBranch}`;
+  }
+
+  return baseBranch;
+}
+
+function getBranchCommitSubjects(baseBranch) {
+  const baseRef = resolveBaseRef(baseBranch);
+  const mergeBase = trimStdout('git', ['merge-base', baseRef, 'HEAD']);
+  const logOutput = trimStdout('git', [
+    'log',
+    '--format=%s',
+    '--reverse',
+    `${mergeBase}..HEAD`,
+  ]);
+
+  return logOutput
+    .split('\n')
+    .map((subject) => subject.trim())
+    .filter(Boolean);
+}
+
+function buildFallbackTitle(commitSubjects, branch) {
+  if (commitSubjects.length === 1) {
+    return commitSubjects[0];
+  }
+
+  const normalizedBranch = branch.replace(/[\/_-]+/g, ' ').trim();
+  return normalizedBranch ? `Update ${normalizedBranch}` : commitSubjects[0];
+}
+
+function buildFallbackBody(commitSubjects, baseBranch) {
+  const summaryLines = commitSubjects
+    .map((subject) => `- ${subject}`)
+    .join('\n');
+
+  return [
+    '## Summary',
+    summaryLines,
+    '',
+    '## Validation',
+    `- Derived from commits targeting ${baseBranch}.`,
+  ].join('\n');
+}
+
+function readBody(options, commitSubjects, branch, baseBranch) {
+  if (options.body && options.bodyFile) {
+    fail('Provide either --body or --body-file, not both.');
+  }
+
+  if (options.bodyFile) {
+    return options.bodyFile;
+  }
+
+  const bodyText =
+    options.body ?? buildFallbackBody(commitSubjects, baseBranch);
+  const tempDir = mkdtempSync(join(tmpdir(), 'myorganizer-ai-pr-'));
+  const bodyPath = join(
+    tempDir,
+    `${branch.replace(/[^a-zA-Z0-9_-]/g, '-')}-body.md`,
+  );
+
+  writeFileSync(bodyPath, `${bodyText.trimEnd()}\n`, 'utf8');
+
+  return { bodyPath, tempDir };
+}
+
+function getAuthenticatedLogin() {
+  const login = trimStdout('gh', ['api', 'user', '--jq', '.login']);
+
+  if (!login) {
+    fail('Unable to resolve the authenticated GitHub user.');
+  }
+
+  return login;
+}
+
+function findExistingPullRequest(branch, baseBranch) {
+  const response = trimStdout('gh', [
+    'pr',
+    'list',
+    '--head',
+    branch,
+    '--base',
+    baseBranch,
+    '--state',
+    'open',
+    '--json',
+    'number,url',
+  ]);
+
+  if (!response) {
+    return null;
+  }
+
+  const pullRequests = JSON.parse(response);
+  return pullRequests[0] ?? null;
+}
+
+function updateExistingPullRequest(pullRequestNumber, assignee, reviewers) {
+  const editArgs = [
+    'pr',
+    'edit',
+    String(pullRequestNumber),
+    '--add-assignee',
+    assignee,
+  ];
+
+  reviewers.forEach((reviewer) => {
+    editArgs.push('--add-reviewer', reviewer);
+  });
+
+  run('gh', editArgs);
+}
+
+function createPullRequest(
+  branch,
+  baseBranch,
+  assignee,
+  reviewers,
+  title,
+  bodyPath,
+  draft,
+) {
+  const args = [
+    'pr',
+    'create',
+    '--base',
+    baseBranch,
+    '--head',
+    branch,
+    '--title',
+    title,
+    '--body-file',
+    bodyPath,
+    '--assignee',
+    assignee,
+  ];
+
+  if (draft) {
+    args.push('--draft');
+  }
+
+  reviewers.forEach((reviewer) => {
+    args.push('--reviewer', reviewer);
+  });
+
+  const result = run('gh', args);
+  const urls = result.stdout.match(/https?:\/\/\S+/g) ?? [];
+  const pullRequestUrl = urls.at(-1)?.trim();
+
+  if (!pullRequestUrl) {
+    fail(
+      'Pull request creation succeeded, but no pull request URL was returned.',
+    );
+  }
+
+  return pullRequestUrl;
+}
+
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  process.stdout.write(usage);
+  process.exit(0);
+}
+
+ensureGhAvailable();
+
+const branch = getCurrentBranch();
+const baseBranch = options.base ?? getDefaultBaseBranch();
+const reviewers = normalizeReviewers(options.reviewers);
+
+ensureNotBaseBranch(branch, baseBranch);
+ensureUpstreamBranch();
+
+const assignee = getAuthenticatedLogin();
+const existingPullRequest = findExistingPullRequest(branch, baseBranch);
+
+if (existingPullRequest) {
+  updateExistingPullRequest(existingPullRequest.number, assignee, reviewers);
+  process.stdout.write(`${existingPullRequest.url}\n`);
+  process.exit(0);
+}
+
+const commitSubjects = getBranchCommitSubjects(baseBranch);
+
+if (commitSubjects.length === 0) {
+  fail(`No commits found between ${baseBranch} and ${branch}.`);
+}
+
+const title = options.title ?? buildFallbackTitle(commitSubjects, branch);
+const bodySource = readBody(options, commitSubjects, branch, baseBranch);
+
+if (typeof bodySource === 'string') {
+  const pullRequestUrl = createPullRequest(
+    branch,
+    baseBranch,
+    assignee,
+    reviewers,
+    title,
+    bodySource,
+    options.draft,
+  );
+  process.stdout.write(`${pullRequestUrl}\n`);
+  process.exit(0);
+}
+
+try {
+  const pullRequestUrl = createPullRequest(
+    branch,
+    baseBranch,
+    assignee,
+    reviewers,
+    title,
+    bodySource.bodyPath,
+    options.draft,
+  );
+  process.stdout.write(`${pullRequestUrl}\n`);
+} finally {
+  rmSync(bodySource.tempDir, { force: true, recursive: true });
+}

--- a/tools/scripts/ai/create-pr.mjs
+++ b/tools/scripts/ai/create-pr.mjs
@@ -163,6 +163,27 @@ function ensureUpstreamBranch() {
   );
 
   if (upstreamResult.status === 0) {
+    const aheadBehind = trimStdout('git', [
+      'rev-list',
+      '--left-right',
+      '--count',
+      '@{u}...HEAD',
+    ]);
+    const [behindCountText = '0', aheadCountText = '0'] =
+      aheadBehind.split(/\s+/);
+    const behindCount = Number.parseInt(behindCountText, 10);
+    const aheadCount = Number.parseInt(aheadCountText, 10);
+
+    if (Number.isInteger(aheadCount) && aheadCount > 0) {
+      run('git', ['push', 'origin', 'HEAD']);
+    }
+
+    if (Number.isInteger(behindCount) && behindCount > 0 && aheadCount === 0) {
+      fail(
+        'The local branch is behind its upstream branch. Pull or rebase before creating the PR.',
+      );
+    }
+
     return;
   }
 
@@ -232,7 +253,7 @@ function extractCommitBodyBullets(body) {
 function buildFallbackTitle(commits, branch) {
   const commitSubjects = commits.map((commit) => commit.subject);
 
-  if (commitSubjects.length === 1) {
+  if (commitSubjects.length >= 1) {
     return commitSubjects[0];
   }
 

--- a/tools/scripts/ai/create-pr.mjs
+++ b/tools/scripts/ai/create-pr.mjs
@@ -182,46 +182,93 @@ function resolveBaseRef(baseBranch) {
   return baseBranch;
 }
 
-function getBranchCommitSubjects(baseBranch) {
+function getBranchCommits(baseBranch) {
   const baseRef = resolveBaseRef(baseBranch);
   const mergeBase = trimStdout('git', ['merge-base', baseRef, 'HEAD']);
   const logOutput = trimStdout('git', [
     'log',
-    '--format=%s',
+    '--format=%s%x1f%b%x1e',
     '--reverse',
     `${mergeBase}..HEAD`,
   ]);
 
   return logOutput
+    .split('\x1e')
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [subject = '', body = ''] = record.split('\x1f');
+
+      return {
+        body: body.trim(),
+        subject: subject.trim(),
+      };
+    })
+    .filter((commit) => Boolean(commit.subject));
+}
+
+function stripConventionalPrefix(subject) {
+  return subject.replace(/^[a-z]+(?:\([^)]+\))?!?:\s*/i, '').trim();
+}
+
+function toSentence(text) {
+  if (!text) {
+    return '';
+  }
+
+  const normalizedText = `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
+  return /[.!?]$/.test(normalizedText) ? normalizedText : `${normalizedText}.`;
+}
+
+function extractCommitBodyBullets(body) {
+  return body
     .split('\n')
-    .map((subject) => subject.trim())
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s+/, '').trim())
     .filter(Boolean);
 }
 
-function buildFallbackTitle(commitSubjects, branch) {
+function buildFallbackTitle(commits, branch) {
+  const commitSubjects = commits.map((commit) => commit.subject);
+
   if (commitSubjects.length === 1) {
     return commitSubjects[0];
   }
 
-  const normalizedBranch = branch.replace(/[\/_-]+/g, ' ').trim();
+  const normalizedBranch = branch.replace(/[/_-]+/g, ' ').trim();
   return normalizedBranch ? `Update ${normalizedBranch}` : commitSubjects[0];
 }
 
-function buildFallbackBody(commitSubjects, baseBranch) {
-  const summaryLines = commitSubjects
-    .map((subject) => `- ${subject}`)
-    .join('\n');
+function buildFallbackBody(commits, branch, baseBranch) {
+  const summary =
+    commits.length === 1
+      ? toSentence(stripConventionalPrefix(commits[0].subject))
+      : `This PR includes ${commits.length} commits from \`${branch}\` into \`${baseBranch}\`.`;
+
+  const detailBullets = commits.flatMap((commit) =>
+    extractCommitBodyBullets(commit.body),
+  );
+
+  const whatChangedLines =
+    detailBullets.length > 0
+      ? detailBullets.map((detail) => `- ${detail}`)
+      : commits.map((commit) => `- ${commit.subject}`);
 
   return [
     '## Summary',
-    summaryLines,
+    summary,
+    '',
+    '## What Changed',
+    ...whatChangedLines,
     '',
     '## Validation',
-    `- Derived from commits targeting ${baseBranch}.`,
+    `- Generated from ${commits.length} commit(s) on \`${branch}\`.`,
+    `- Compared against base branch \`${baseBranch}\`.`,
   ].join('\n');
 }
 
-function readBody(options, commitSubjects, branch, baseBranch) {
+function readBody(options, commits, branch, baseBranch) {
   if (options.body && options.bodyFile) {
     fail('Provide either --body or --body-file, not both.');
   }
@@ -231,7 +278,7 @@ function readBody(options, commitSubjects, branch, baseBranch) {
   }
 
   const bodyText =
-    options.body ?? buildFallbackBody(commitSubjects, baseBranch);
+    options.body ?? buildFallbackBody(commits, branch, baseBranch);
   const tempDir = mkdtempSync(join(tmpdir(), 'myorganizer-ai-pr-'));
   const bodyPath = join(
     tempDir,
@@ -264,7 +311,7 @@ function findExistingPullRequest(branch, baseBranch) {
     '--state',
     'open',
     '--json',
-    'number,url',
+    'number,url,reviewRequests',
   ]);
 
   if (!response) {
@@ -275,17 +322,40 @@ function findExistingPullRequest(branch, baseBranch) {
   return pullRequests[0] ?? null;
 }
 
-function updateExistingPullRequest(pullRequestNumber, assignee, reviewers) {
+function updateExistingPullRequest(
+  pullRequest,
+  assignee,
+  reviewers,
+  title,
+  bodyPath,
+) {
+  const existingReviewers = (pullRequest.reviewRequests ?? [])
+    .map((reviewRequest) => reviewRequest.login)
+    .filter(Boolean);
+  const reviewersToAdd = reviewers.filter(
+    (reviewer) => !existingReviewers.includes(reviewer),
+  );
+  const reviewersToRemove = existingReviewers.filter(
+    (reviewer) => !reviewers.includes(reviewer),
+  );
   const editArgs = [
     'pr',
     'edit',
-    String(pullRequestNumber),
+    String(pullRequest.number),
+    '--title',
+    title,
+    '--body-file',
+    bodyPath,
     '--add-assignee',
     assignee,
   ];
 
-  reviewers.forEach((reviewer) => {
+  reviewersToAdd.forEach((reviewer) => {
     editArgs.push('--add-reviewer', reviewer);
+  });
+
+  reviewersToRemove.forEach((reviewer) => {
+    editArgs.push('--remove-reviewer', reviewer);
   });
 
   run('gh', editArgs);
@@ -348,27 +418,49 @@ ensureGhAvailable();
 const branch = getCurrentBranch();
 const baseBranch = options.base ?? getDefaultBaseBranch();
 const reviewers = normalizeReviewers(options.reviewers);
+const commits = getBranchCommits(baseBranch);
 
 ensureNotBaseBranch(branch, baseBranch);
 ensureUpstreamBranch();
+
+if (commits.length === 0) {
+  fail(`No commits found between ${baseBranch} and ${branch}.`);
+}
+
+const title = options.title ?? buildFallbackTitle(commits, branch);
+const bodySource = readBody(options, commits, branch, baseBranch);
 
 const assignee = getAuthenticatedLogin();
 const existingPullRequest = findExistingPullRequest(branch, baseBranch);
 
 if (existingPullRequest) {
-  updateExistingPullRequest(existingPullRequest.number, assignee, reviewers);
+  if (typeof bodySource === 'string') {
+    updateExistingPullRequest(
+      existingPullRequest,
+      assignee,
+      reviewers,
+      title,
+      bodySource,
+    );
+    process.stdout.write(`${existingPullRequest.url}\n`);
+    process.exit(0);
+  }
+
+  try {
+    updateExistingPullRequest(
+      existingPullRequest,
+      assignee,
+      reviewers,
+      title,
+      bodySource.bodyPath,
+    );
+  } finally {
+    rmSync(bodySource.tempDir, { force: true, recursive: true });
+  }
+
   process.stdout.write(`${existingPullRequest.url}\n`);
   process.exit(0);
 }
-
-const commitSubjects = getBranchCommitSubjects(baseBranch);
-
-if (commitSubjects.length === 0) {
-  fail(`No commits found between ${baseBranch} and ${branch}.`);
-}
-
-const title = options.title ?? buildFallbackTitle(commitSubjects, branch);
-const bodySource = readBody(options, commitSubjects, branch, baseBranch);
 
 if (typeof bodySource === 'string') {
   const pullRequestUrl = createPullRequest(


### PR DESCRIPTION
## Why
Add shared AI commit and PR tooling. Follow-up commits refine the branch before merging `feature/ai-commit-pr-workflows` into `main`.

## Changes
- add ai:commit and ai:create-pr scripts for branch-aware commit and PR flows
- document Copilot, Cursor, Claude Code, and Gemini workflow routing
- keep Husky lint output static so commit-time failures stay readable
- derive fallback PR summaries from commit subjects and bodies
- refresh title, body, and reviewer assignments when reusing open PRs
- push HEAD to origin when the local branch is ahead of upstream
- keep the first commit subject as the fallback title for reused multi-commit PRs
- strip leading @ from standard GitHub reviewer logins
- fail clearly for unsupported @copilot and @me reviewer aliases
- refine the fallback PR body to use Why and Changes sections

## Validation
- Generated from 4 commit(s) on `feature/ai-commit-pr-workflows`.
- Compared against base branch `main`.
