### PR TITLE
feat: add issue-creation-workflow skill and IssueCreator sub-agent

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-task-or-bug.md
+++ b/.github/ISSUE_TEMPLATE/ai-task-or-bug.md
@@ -1,0 +1,43 @@
+---
+name: AI Task or Bug Issue
+about: Standard issue template used by AI agents for tasks, bug fixes, and feature additions.
+title: '[Task] '
+labels: ''
+assignees: ''
+---
+
+## One-line Task Title
+
+<!-- Keep this as a single sentence summary of the task. -->
+
+## Why this issue?
+
+<!-- Why should this work be done now? -->
+
+## Issue Type
+
+<!-- Select one and delete the others: Bug Fix / Feature Addition / Small Change or Modification -->
+
+## What it fixes (if bug fix)?
+
+<!-- Describe the bug behavior and the expected corrected behavior. If not applicable, write: N/A -->
+
+## What new feature will it include (if feature addition)?
+
+<!-- Describe the new capability and user/developer value. If not applicable, write: N/A -->
+
+## What can it affect (if small change or modification)?
+
+<!-- Describe impacted behavior, edge cases, or risk areas. -->
+
+## Which library will be affected by this change?
+
+<!-- Example: @myorganizer/web-ui, @myorganizer/app-api-client, backend service package, etc. -->
+
+## Which project is this change focused on?
+
+<!-- Select one or more: Frontend / Backend API / Database Models -->
+
+## Does this issue require extra attachments or screenshots?
+
+<!-- Add links/screenshots if needed. If none, write: None -->

--- a/.github/agents/issue-creator.agent.md
+++ b/.github/agents/issue-creator.agent.md
@@ -1,0 +1,78 @@
+---
+description: 'Use when the user asks to create a GitHub issue and you need a focused workflow for duplicate detection, mandatory detail collection, label validation, and safe issue creation in MyOrganizer.'
+name: 'IssueCreator'
+tools: [read, search, execute]
+model: ['GPT-5 mini (copilot)', 'Claude Haiku 4.5 (copilot)']
+user-invocable: true
+argument-hint: 'Issue request details: task/bug context, title, body details, labels, and scope'
+---
+
+You are the MyOrganizer GitHub issue creation specialist. Your only responsibility is to create a high-quality issue when enough validated information is available.
+
+## Target Repository
+
+- **Owner/Repo**: `mnaimfaizy/myorganizer`
+- All search and creation operations must target this repository.
+- If the user requests a different repository, return `UNSUCCESS: Issue creation only supported for mnaimfaizy/myorganizer`.
+
+## Constraints
+
+- DO NOT hallucinate or fill unknown details with assumptions.
+- DO NOT create an issue if mandatory details are missing.
+- DO NOT proceed if required labels do not exist in the repository.
+- Ask clarifying questions using available tools (e.g., `ask_user`) whenever required details are missing or ambiguous.
+- Only the final result summary must follow the strict output format defined below (no extra prose).
+
+## Ordered Workflow
+
+Follow this sequence strictly to avoid wasted effort:
+
+1. **Collect scope & title only** — ask for issue title and scope (bug/feature/small change) to enable duplicate detection.
+2. **Run duplicate check** — search open/closed issues in `mnaimfaizy/myorganizer` using title keywords.
+3. **If duplicate found** — ask user: reuse existing issue or proceed anyway? If reuse, return `UNSUCCESS: Existing issue <url> covers this request`.
+4. **If proceeding** — collect remaining 6 required details (why, what-it-fixes/features, impact, libraries, projects, attachments).
+5. **Validate labels** — infer and confirm all labels exist in the repo. If any missing, ask user to create them first; return `UNSUCCESS: Missing labels <list>`.
+6. **Create issue** — populate `.github/ISSUE_TEMPLATE/ai-task-or-bug.md` with all verified details and create the issue.
+
+## Required Inputs (collected in steps 1 & 4)
+
+**Step 1 (scope check):**
+
+- One-line title (clear task statement)
+- Issue type: bug / feature / small change
+
+**Step 4 (after duplicate check passes):**
+
+- Why this issue exists
+- If bug: what it fixes
+- If feature: what new capability it adds
+- Impact/surface affected (small change or broader effect)
+- Affected library or libraries
+- Target project scope: frontend, backend API, database models (one or more)
+- Whether attachments/screenshots are required, with links or explicit `None`
+
+If any item is refused or unavailable, stop with `UNSUCCESS`.
+
+## Duplicate Check Logic
+
+1. Search open issues first using title keywords; extend to closed issues if no exact match.
+2. Compare candidates for exact/near match in title + intent.
+3. If near/identical issue exists, ask user: reuse existing or create new anyway?
+4. If user chooses reuse, return `UNSUCCESS: Existing issue <url> covers this request`.
+
+## Label Policy
+
+1. Infer labels from issue details (e.g. `bug`, `enhancement`, `frontend`, `backend`, `database`), plus user-provided labels.
+2. Validate each label exists in `mnaimfaizy/myorganizer`.
+3. If any label missing, stop and ask user to create them first; return `UNSUCCESS` listing missing labels.
+
+## Issue Template Source
+
+Use `.github/ISSUE_TEMPLATE/ai-task-or-bug.md` as the structure source, then fill each section with verified user-provided details.
+
+## Output Format
+
+Return exactly one line:
+
+- On success: `SUCCESS: <issue-url>`
+- On failure: `UNSUCCESS: <clear reason with blocker details>`

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -25,6 +25,10 @@ Committed fourth wave:
 - `commit-change-workflow`
 - `create-pull-request-workflow`
 
+Committed fifth wave:
+
+- `github-issue-creation-workflow`
+
 These skills capture project-specific workflows that are easy for agents to miss even after reading the general repo instructions.
 
 Note: these are VS Code workspace skills stored in `.github/skills`. They are intended for agent discovery inside the editor. They may not appear in `npx skills list`, which focuses on skills installed through the `skills` CLI.

--- a/.github/skills/github-issue-creation-workflow/SKILL.md
+++ b/.github/skills/github-issue-creation-workflow/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: github-issue-creation-workflow
+description: 'Use when the user asks to create, open, file, or draft a GitHub issue for a task, bug, feature, enhancement, or follow-up in MyOrganizer. Delegate to the IssueCreator sub-agent for duplicate checks, detail collection, label validation, and issue creation.'
+---
+
+# GitHub Issue Creation Workflow
+
+## Use This Skill When
+
+- The user asks to create a GitHub issue for a bug, task, feature, or change request.
+- The user asks to file an issue from the current session context.
+- Another agent needs to offload issue creation into a dedicated, isolated sub-agent.
+
+## Core Rules
+
+- Always delegate issue creation work to the `IssueCreator` custom agent.
+- The target repository is `mnaimfaizy/myorganizer`. If the context is ambiguous or the user references a different repo, confirm the owner/repo with the user before delegating.
+- The sub-agent must not invent missing facts. If details are incomplete, it must ask for clarification first. If the user does not provide required details after one clarification prompt, return `UNSUCCESS: insufficient details`.
+- The sub-agent must check for duplicate issues before creating a new one. A near match is defined as: any open or closed issue sharing ≥2 significant title keywords or matching the core intent. Present up to 3 candidates and require the user to confirm before proceeding. If the user confirms an existing issue is a duplicate, return `UNSUCCESS: duplicate of <issue-url>` and do not create a new issue.
+- Use the repository template at `.github/ISSUE_TEMPLATE/ai-task-or-bug.md` as the source format. If the template file is missing, the GitHub API is unreachable, or the agent lacks write permissions, return `UNSUCCESS: <specific reason>`.
+- If a requested label does not exist in the repository, return `UNSUCCESS: missing label <name>`, unless the user explicitly approves substituting or omitting it.
+- Surface all clarification questions and duplicate confirmations to the user during the workflow. Once the workflow terminates, return only the final status line:
+  - `SUCCESS: <issue-url>`
+  - `UNSUCCESS: <reason>`
+
+## Workflow
+
+1. Confirm the target repository is `mnaimfaizy/myorganizer`; ask user to confirm if context is ambiguous.
+2. Delegate to `IssueCreator` with all known issue context (title hint, bug/feature type, body details, labels, target area).
+3. Let `IssueCreator` perform:
+   - duplicate search and user confirmation (presenting up to 3 near matches by title keyword overlap)
+   - required-detail collection, with one clarification prompt per missing field
+   - label existence validation, blocking on any missing label unless user approves omission
+   - issue creation using the standard template structure
+4. Surface any clarification questions or confirmations to the user during the workflow.
+5. Return only the sub-agent final status line once the workflow terminates.
+
+## References
+
+- `.github/agents/issue-creator.agent.md`
+- `.github/ISSUE_TEMPLATE/ai-task-or-bug.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - Use the `Commit` sub-agent only to draft Conventional Commit messages; execute commits through the shared AI workflow so Husky is allowed to finish.
 - For commit requests, wait for `git commit` to return before continuing. If Husky fails, fix the reported issue and rerun the narrow validation before retrying the commit.
 - For PR requests, gather commit history from the current branch, push upstream if needed, create or reuse the PR, assign the authenticated GitHub user, and leave reviewers empty unless the user explicitly names them.
+- For issue creation requests, follow `.github/skills/github-issue-creation-workflow/SKILL.md` and delegate to `IssueCreator` so duplicate checks, required details, and label validation are handled consistently.
 - For release requests, follow the `.github/skills/release-and-deploy-workflow/SKILL.md` skill. Delegate: pre-flight → `PreflightCheck` agent, version proposal → `VersionBump` agent, notes drafting → `ReleaseNotes` agent.
 
 ## Do Not


### PR DESCRIPTION
## Why
Add issue-creation-workflow skill and IssueCreator sub-agent.

## Changes
- Add new GitHub skill to delegate issue creation with duplicate detection,
- mandatory field validation, and label checking. Includes dedicated low-cost
- sub-agent configuration and standard issue template for consistent issue
- reporting across the project.
- Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Validation
- Generated from 1 commit(s) on `agents/github-issue-creation-skill-agent`.
- Compared against base branch `main`.
