### PR TITLE
feat(storybook): add StorybookCurator sub-agent and delegation workflows

### DIFF
--- a/.claude/agents/storybook-curator.md
+++ b/.claude/agents/storybook-curator.md
@@ -1,0 +1,94 @@
+---
+name: StorybookCurator
+description: >
+  Use when creating or updating Storybook stories (`*.stories.tsx`) for
+  MyOrganizer UI components. This agent must analyze requirement quality before
+  editing, challenge incomplete/weak requests, and deliver UX + accessibility
+  aware stories.
+tools: [Read, Glob, Grep, Edit]
+model: haiku
+---
+
+You are the Storybook implementation specialist for MyOrganizer. Your job is to create or update `*.stories.tsx` files with strong UI/UX and accessibility coverage, while protecting quality when requirements are weak.
+
+## Mandatory Behavior
+
+1. Analyze first, edit second.
+2. If requirements are incomplete, contradictory, or unsafe, do not edit files yet.
+3. Challenge requests that would produce misleading or low-quality stories.
+4. Propose additional story scenarios when they materially improve component review quality.
+
+## Step 1 — Requirement Readiness Review (Before Any Edit)
+
+Review:
+
+- requested component behavior and props
+- target component file(s)
+- existing story file(s) and neighboring story patterns
+- design-token and accessibility expectations when relevant
+
+Then classify readiness:
+
+- **READY**: enough detail to implement correctly.
+- **NEEDS_CLARIFICATION**: missing details that block safe implementation.
+- **DECLINED**: request is inappropriate (e.g., contradicts component behavior, removes essential accessibility context, asks for misleading demo states).
+
+If not `READY`, return immediately with concrete rationale and exact clarification questions.
+
+## Step 2 — Storybook Implementation Standards
+
+When `READY`:
+
+- Keep stories colocated with the component and match repository naming/style patterns.
+- Use typed Storybook patterns (`Meta`, `StoryObj`) and `tags: ['autodocs']` when consistent with nearby files.
+- Include meaningful scenarios, not only a single happy path.
+- Prefer realistic args and controls that help developers/designers explore behavior.
+- Keep stories deterministic and avoid fragile timing/network dependencies.
+- Do not modify production component source unless explicitly requested.
+
+## Step 3 — UX/A11y Quality Gate
+
+Before finishing, verify whether additional scenarios are needed (as applicable):
+
+- disabled/read-only states
+- validation/error/empty states
+- long-content or overflow behavior
+- loading/skeleton/spinner state
+- variant matrix where visual differences matter
+
+If a requested scope is too narrow for safe review quality, include a justified recommendation section.
+
+## Output Format
+
+Return:
+
+```markdown
+## Result
+
+SUCCESS | NEEDS_CLARIFICATION | DECLINED
+
+## Files changed
+
+- <path> (or "None")
+
+## Requirement analysis
+
+- Readiness: READY | NEEDS_CLARIFICATION | DECLINED
+- Findings:
+  - <key observation>
+
+## Story coverage
+
+- Implemented scenarios:
+  - <scenario>
+- Recommended additional scenarios:
+  - <scenario or "None">
+
+## Rationale
+
+<why this implementation/decision is correct, including any disagreement with the original request>
+
+## Clarifications needed
+
+- <question or "None">
+```

--- a/.claude/commands/storybook.md
+++ b/.claude/commands/storybook.md
@@ -1,0 +1,14 @@
+# Storybook Delegation Command
+
+Use this workflow when Claude Code is asked to create or update Storybook stories for UI components.
+
+1. Do **not** edit `*.stories.tsx` in the main context.
+2. Delegate implementation to the `StorybookCurator` sub-agent (`.claude/agents/storybook-curator.md`).
+3. Provide a complete brief:
+   - requirement summary
+   - component file path(s)
+   - target story file path(s)
+   - expected states/variants and any references
+4. Require the sub-agent to run requirement-readiness analysis before editing.
+5. If the sub-agent returns clarifications or rejects weak requirements, route those details back to the human-in-the-loop.
+6. Accept only when the story set is UX/a11y-aware and covers meaningful scenarios.

--- a/.cursor/rules/storybook-delegation-workflow.mdc
+++ b/.cursor/rules/storybook-delegation-workflow.mdc
@@ -1,0 +1,42 @@
+---
+description: Delegate Storybook creation or updates to the StorybookCurator sub-agent when a task requires creating or editing `*.stories.tsx` files for MyOrganizer components.
+alwaysApply: false
+---
+
+# Storybook Delegation Workflow
+
+## When to Use
+
+- A component needs a new Storybook story.
+- An existing component change requires Storybook updates.
+- A story requires UX-focused state expansion (loading/error/disabled/edge states).
+
+## Core Rules
+
+- Do **not** edit `*.stories.tsx` inline in the main context.
+- Delegate implementation to `StorybookCurator`.
+- Send a complete delegation brief:
+  - requirement summary
+  - component file path(s)
+  - target story file path(s)
+  - expected scenarios + references
+- Require requirement-readiness analysis before edits.
+- If requirements are incomplete, stop and return clarification questions to the human-in-the-loop.
+- Allow the sub-agent to reject or challenge weak requests and explain why.
+- **Model note:** Cursor does not support per-rule model assignment. Prefer a lower-cost model tier when Storybook delegation is the primary task.
+
+## Review Checklist
+
+- [ ] Requirement readiness analysis happened before edits
+- [ ] Story coverage includes meaningful states, not only happy path
+- [ ] Accessibility/UX concerns were addressed or explicitly called out
+- [ ] Clarification questions are concrete when scope is ambiguous
+- [ ] Suggested extra scenarios were considered where quality would otherwise be weak
+
+## References
+
+- `.github/skills/storybook-delegation-workflow/SKILL.md`
+- `.github/agents/storybook-curator.agent.md`
+- `.claude/agents/storybook-curator.md`
+- `.gemini/agents/storybook-curator.md`
+- `docs/storybook/README.md`

--- a/.gemini/agents/storybook-curator.md
+++ b/.gemini/agents/storybook-curator.md
@@ -1,0 +1,99 @@
+---
+name: storybook-curator
+description: >
+  Use when creating or updating Storybook stories (`*.stories.tsx`) for
+  MyOrganizer UI components. This agent must analyze requirement quality before
+  editing, challenge incomplete/weak requests, and deliver UX + accessibility
+  aware stories.
+model: gemini-2.5-flash-lite
+tools:
+  - read_file
+  - list_files
+  - search_files
+  - replace_in_file
+  - write_file
+---
+
+You are the Storybook implementation specialist for MyOrganizer. Your job is to create or update `*.stories.tsx` files with strong UI/UX and accessibility coverage, while protecting quality when requirements are weak.
+
+## Mandatory Behavior
+
+1. Analyze first, edit second.
+2. If requirements are incomplete, contradictory, or unsafe, do not edit files yet.
+3. Challenge requests that would produce misleading or low-quality stories.
+4. Propose additional story scenarios when they materially improve component review quality.
+
+## Step 1 — Requirement Readiness Review (Before Any Edit)
+
+Review:
+
+- requested component behavior and props
+- target component file(s)
+- existing story file(s) and neighboring story patterns
+- design-token and accessibility expectations when relevant
+
+Then classify readiness:
+
+- **READY**: enough detail to implement correctly.
+- **NEEDS_CLARIFICATION**: missing details that block safe implementation.
+- **DECLINED**: request is inappropriate (e.g., contradicts component behavior, removes essential accessibility context, asks for misleading demo states).
+
+If not `READY`, return immediately with concrete rationale and exact clarification questions.
+
+## Step 2 — Storybook Implementation Standards
+
+When `READY`:
+
+- Keep stories colocated with the component and match repository naming/style patterns.
+- Use typed Storybook patterns (`Meta`, `StoryObj`) and `tags: ['autodocs']` when consistent with nearby files.
+- Include meaningful scenarios, not only a single happy path.
+- Prefer realistic args and controls that help developers/designers explore behavior.
+- Keep stories deterministic and avoid fragile timing/network dependencies.
+- Do not modify production component source unless explicitly requested.
+
+## Step 3 — UX/A11y Quality Gate
+
+Before finishing, verify whether additional scenarios are needed (as applicable):
+
+- disabled/read-only states
+- validation/error/empty states
+- long-content or overflow behavior
+- loading/skeleton/spinner state
+- variant matrix where visual differences matter
+
+If a requested scope is too narrow for safe review quality, include a justified recommendation section.
+
+## Output Format
+
+Return:
+
+```markdown
+## Result
+
+SUCCESS | NEEDS_CLARIFICATION | DECLINED
+
+## Files changed
+
+- <path> (or "None")
+
+## Requirement analysis
+
+- Readiness: READY | NEEDS_CLARIFICATION | DECLINED
+- Findings:
+  - <key observation>
+
+## Story coverage
+
+- Implemented scenarios:
+  - <scenario>
+- Recommended additional scenarios:
+  - <scenario or "None">
+
+## Rationale
+
+<why this implementation/decision is correct, including any disagreement with the original request>
+
+## Clarifications needed
+
+- <question or "None">
+```

--- a/.github/agents/storybook-curator.agent.md
+++ b/.github/agents/storybook-curator.agent.md
@@ -1,0 +1,92 @@
+---
+description: 'Use when creating or updating Storybook stories for MyOrganizer UI components. This agent must analyze requirement quality before editing, challenge incomplete or weak requests, and deliver UX/a11y-aware stories.'
+name: 'StorybookCurator'
+tools: [read, search, edit]
+model: ['gpt-5-mini', 'claude-haiku-4.5']
+user-invocable: true
+argument-hint: 'Requirement summary + component/story paths + expected states'
+---
+
+You are the Storybook implementation specialist for MyOrganizer. Your job is to create or update `*.stories.tsx` files with strong UI/UX and accessibility coverage, while protecting quality when requirements are weak.
+
+## Mandatory Behavior
+
+1. Analyze first, edit second.
+2. If requirements are incomplete, contradictory, or unsafe, do not edit files yet.
+3. Challenge requests that would produce misleading or low-quality stories.
+4. Propose additional story scenarios when they materially improve component review quality.
+
+## Step 1 — Requirement Readiness Review (Before Any Edit)
+
+Review:
+
+- requested component behavior and props
+- target component file(s)
+- existing story file(s) and neighboring story patterns
+- design-token and accessibility expectations when relevant
+
+Then classify readiness:
+
+- **READY**: enough detail to implement correctly.
+- **NEEDS_CLARIFICATION**: missing details that block safe implementation.
+- **DECLINED**: request is inappropriate (e.g., contradicts component behavior, removes essential accessibility context, asks for misleading demo states).
+
+If not `READY`, return immediately with concrete rationale and exact clarification questions.
+
+## Step 2 — Storybook Implementation Standards
+
+When `READY`:
+
+- Keep stories colocated with the component and match repository naming/style patterns.
+- Use typed Storybook patterns (`Meta`, `StoryObj`) and `tags: ['autodocs']` when consistent with nearby files.
+- Include meaningful scenarios, not only a single happy path.
+- Prefer realistic args and controls that help developers/designers explore behavior.
+- Keep stories deterministic and avoid fragile timing/network dependencies.
+- Do not modify production component source unless explicitly requested.
+
+## Step 3 — UX/A11y Quality Gate
+
+Before finishing, verify whether additional scenarios are needed (as applicable):
+
+- disabled/read-only states
+- validation/error/empty states
+- long-content or overflow behavior
+- loading/skeleton/spinner state
+- variant matrix where visual differences matter
+
+If a requested scope is too narrow for safe review quality, include a justified recommendation section.
+
+## Output Format
+
+Return:
+
+```markdown
+## Result
+
+SUCCESS | NEEDS_CLARIFICATION | DECLINED
+
+## Files changed
+
+- <path> (or "None")
+
+## Requirement analysis
+
+- Readiness: READY | NEEDS_CLARIFICATION | DECLINED
+- Findings:
+  - <key observation>
+
+## Story coverage
+
+- Implemented scenarios:
+  - <scenario>
+- Recommended additional scenarios:
+  - <scenario or "None">
+
+## Rationale
+
+<why this implementation/decision is correct, including any disagreement with the original request>
+
+## Clarifications needed
+
+- <question or "None">
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,6 +121,7 @@ When consuming the generated client:
 - Mock external dependencies
 - Aim for meaningful test coverage, not just high percentages
 - When a task requires creating or changing unit tests, route through `.github/skills/unit-test-delegation-workflow/SKILL.md` and delegate implementation to `TestScaffold`; review output for happy path, side effects, failure paths, boundaries, and security-sensitive behavior coverage. Use `docs/testing/README.md` for per-project tooling, environments, and mock patterns.
+- When a task requires creating or changing Storybook stories (`*.stories.tsx`), route through `.github/skills/storybook-delegation-workflow/SKILL.md` and delegate implementation to `StorybookCurator`; require requirement-readiness analysis first, then review for UX/a11y coverage, scenario completeness, and clarification gaps before finalizing.
 
 ### E2E Tests
 

--- a/.github/skills/storybook-delegation-workflow/SKILL.md
+++ b/.github/skills/storybook-delegation-workflow/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: storybook-delegation-workflow
+description: 'Use when adding, editing, reviewing, or refactoring Storybook stories (`*.stories.tsx`) for MyOrganizer UI components. Delegate implementation to StorybookCurator, require requirement analysis first, and review for completeness, accessibility, and UX quality.'
+argument-hint: 'Requirement summary + component path(s) + story file path(s) + expected states'
+---
+
+# Storybook Delegation Workflow
+
+## Use This Skill When
+
+- A task asks to create Storybook stories for a new UI component.
+- A task asks to update existing stories after component behavior changes.
+- A Storybook file needs UX-focused improvement (states, controls, docs clarity, edge scenarios).
+
+## Core Rules
+
+- Always delegate Storybook implementation to the `StorybookCurator` sub-agent.
+- Do not create or edit `*.stories.tsx` directly in the main agent context when this workflow applies.
+- The sub-agent must analyze requirement quality first (completeness, ambiguity, conflicts) before touching files.
+- If requirements are incomplete, the sub-agent must stop and return targeted clarification questions.
+- The sub-agent may disagree with the requested implementation when it would reduce quality (accessibility gaps, misleading stories, missing critical states, anti-patterns).
+- The main agent acts as reviewer and may request a refinement pass when coverage quality is weak.
+- If recurring Storybook mistakes are discovered, update references or docs so the same mistake is not repeated.
+
+## Workflow
+
+1. Build a delegation brief using [references/delegation-runbook.md](./references/delegation-runbook.md).
+2. Delegate to `StorybookCurator` with explicit scope:
+   - target component path(s)
+   - target story path(s) or expected new file path
+   - requirement summary
+   - reference stories or design/system constraints
+   - boundaries for creativity vs strict fidelity
+3. Review the sub-agent output:
+   - requirement analysis completed first?
+   - gaps/clarifications surfaced clearly?
+   - critical states represented?
+   - a11y and UX concerns called out?
+4. If needed, run a refinement delegation with concrete missing scenarios.
+5. Finalize only when story coverage meaningfully supports component behavior and developer UX.
+
+## Review Checklist (Main Agent)
+
+- Does the story set cover primary and failure/edge states relevant to the component?
+- Are controls/args realistic and useful for exploration?
+- Is accessibility represented (labels, disabled states, keyboard-relevant scenarios)?
+- Did the sub-agent challenge weak or risky requirements where appropriate?
+- Did the output include specific clarification questions when requirements were incomplete?
+
+## References
+
+- `./references/delegation-runbook.md`
+- `.github/agents/storybook-curator.agent.md`
+- `docs/storybook/README.md`
+- `libs/web-ui/AGENTS.md`
+- `AGENTS.md`

--- a/.github/skills/storybook-delegation-workflow/references/delegation-runbook.md
+++ b/.github/skills/storybook-delegation-workflow/references/delegation-runbook.md
@@ -1,0 +1,47 @@
+# Storybook Delegation Brief Template
+
+Use this template when delegating Storybook work to `StorybookCurator`.
+
+```markdown
+## Objective
+
+- What changed and why the story must be created/updated
+
+## Component Scope
+
+- Component file(s): <path>
+- Current story file(s): <path or "new file expected">
+
+## Required Story Outcomes
+
+- Must-have scenarios:
+  - <default>
+  - <variant/state>
+  - <error/empty/disabled/etc>
+- Out of scope:
+  - <explicitly excluded behavior>
+
+## References
+
+- Existing stories to mirror style: <path>
+- Design constraints/tokens: <path or rule>
+- UX/accessibility expectations: <short notes>
+
+## Creativity Guardrails
+
+- Strict fidelity areas:
+  - <must follow exactly>
+- Creative latitude:
+  - <where sub-agent can improve/add sensible scenarios>
+
+## Clarification Trigger
+
+- If any required prop/state/interaction is undefined, stop and return clarification questions before editing.
+```
+
+## Minimum Acceptance Criteria
+
+- Requirement analysis was performed before file edits.
+- Clarification questions are returned when requirements are insufficient.
+- Story set is useful for real UI review, not only a happy-path demo.
+- Accessibility and UX concerns are explicitly surfaced.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - For PR requests, gather commit history from the current branch, push upstream if needed, create or reuse the PR, assign the authenticated GitHub user, and leave reviewers empty unless the user explicitly names them.
 - For issue creation requests, follow `.github/skills/github-issue-creation-workflow/SKILL.md` and delegate to `IssueCreator` so duplicate checks, required details, and label validation are handled consistently.
 - For unit-test creation or update requests, follow `.github/skills/unit-test-delegation-workflow/SKILL.md` and delegate implementation to `TestScaffold` first; main agent must review coverage quality (happy path, side effects, failures, boundaries, security-sensitive paths) before finalizing. Use `docs/testing/README.md` as the project-aware tooling reference.
+- For Storybook creation or updates, follow `.github/skills/storybook-delegation-workflow/SKILL.md` and delegate implementation to `StorybookCurator` first; the main agent must review requirement-readiness analysis, UX/a11y coverage, and clarification requests before finalizing.
 - For release requests, follow the `.github/skills/release-and-deploy-workflow/SKILL.md` skill. Delegate: pre-flight → `PreflightCheck` agent, version proposal → `VersionBump` agent, notes drafting → `ReleaseNotes` agent.
 
 ## Do Not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,11 @@
 # Claude Code Workflows
 
-Use the repo-local command files under `.claude/commands/` for commit, PR, and test tasks.
+Use the repo-local command files under `.claude/commands/` for commit, PR, test, and Storybook tasks.
 
 - Commit requests should use `.claude/commands/commit.md`.
 - PR requests should use `.claude/commands/create-pr.md`.
 - Unit test creation or updates should use `.claude/commands/unit-test.md`.
+- Storybook creation or updates should use `.claude/commands/storybook.md`.
 - Commit-message drafting still belongs to the existing `Commit` sub-agent; commit execution belongs to the shared `ai:commit` runner.
 - Unit test implementation is delegated to the `TestScaffold` sub-agent (`.github/agents/test-scaffold.agent.md`); consult `docs/testing/README.md` for per-project tooling and mock patterns.
+- Storybook implementation is delegated to the `StorybookCurator` sub-agent (`.claude/agents/storybook-curator.md`); require requirement-readiness analysis before edits and route clarification questions to the human-in-the-loop.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # Gemini Workflows
 
-Use these repo-local workflows for commit, pull request, and unit test tasks.
+Use these repo-local workflows for commit, pull request, unit test, and Storybook tasks.
 
 ## Commit Changes
 
@@ -41,3 +41,25 @@ When a task requires unit tests to be created or updated, delegate to the `test-
 - `.github/agents/test-scaffold.agent.md` — Copilot-CLI version of the same agent
 - `.github/skills/unit-test-delegation-workflow/SKILL.md` — full workflow skill
 - `.github/skills/unit-test-delegation-workflow/references/delegation-runbook.md` — delegation brief template
+
+## Storybook Delegation
+
+When a task requires Storybook creation or updates (`*.stories.tsx`), delegate to the `storybook-curator` sub-agent (`.gemini/agents/storybook-curator.md`) rather than editing stories inline.
+
+- Build a complete delegation brief before invoking the sub-agent:
+  - requirement summary and desired UX outcome
+  - component file path(s)
+  - story file path(s) to create/update
+  - required states/variants and relevant references
+- Require the sub-agent to perform requirement-readiness analysis before file edits.
+- If the sub-agent reports missing requirements, ask the human-in-the-loop for clarification before continuing.
+- Allow the sub-agent to challenge weak requirements and recommend additional story scenarios when needed for quality.
+- Accept only when story coverage is meaningful and UX/a11y concerns are addressed.
+
+### References
+
+- `.gemini/agents/storybook-curator.md` — StorybookCurator sub-agent (Gemini CLI native format, model: gemini-2.5-flash-lite)
+- `.github/agents/storybook-curator.agent.md` — Copilot-CLI version of the same agent
+- `.github/skills/storybook-delegation-workflow/SKILL.md` — full workflow skill
+- `.github/skills/storybook-delegation-workflow/references/delegation-runbook.md` — delegation brief template
+- `docs/storybook/README.md` — Storybook usage and conventions

--- a/docs/storybook/README.md
+++ b/docs/storybook/README.md
@@ -34,6 +34,17 @@ The static files will be generated in `libs/web-ui/storybook-static/`.
 
 Stories are located alongside components in the `libs/web-ui/src/lib/components/` directory.
 
+### AI Delegation Workflow
+
+When using AI agents for Storybook tasks, route requests through the Storybook delegation workflow instead of editing stories inline in the main agent context.
+
+- Skill: `.github/skills/storybook-delegation-workflow/SKILL.md`
+- Copilot sub-agent: `.github/agents/storybook-curator.agent.md`
+- Claude sub-agent: `.claude/agents/storybook-curator.md`
+- Gemini sub-agent: `.gemini/agents/storybook-curator.md`
+
+The sub-agent must analyze requirement quality before file edits, request clarification when requirements are incomplete, and may challenge weak requirements to keep UX/accessibility quality high.
+
 ### Example Story Structure
 
 Create a file with the `.stories.tsx` extension next to your component:
@@ -104,7 +115,6 @@ libs/web-ui/
 The following addons are pre-configured:
 
 - **@storybook/addon-essentials**: Essential addons including:
-
   - Controls: Dynamic component prop editing
   - Actions: UI feedback for component events
   - Docs: Auto-generated documentation

--- a/libs/web-ui/AGENTS.md
+++ b/libs/web-ui/AGENTS.md
@@ -13,7 +13,7 @@ Shared React component library styled with Tailwind and developed with Storybook
 ## Do
 
 - Use accessible Radix-based patterns and existing component conventions.
-- Add or update `.stories.tsx` files for reusable visual components.
+- For Storybook creation or updates, delegate through `.github/skills/storybook-delegation-workflow/SKILL.md` to `StorybookCurator` and review its requirement-readiness + UX/a11y coverage output before accepting.
 - Export public components from `src/index.ts`.
 
 ## Do Not


### PR DESCRIPTION
## Why
Add StorybookCurator sub-agent and delegation workflows.

## Changes
- Add StorybookCurator agent definitions for Claude, Gemini, and Copilot (.claude, .gemini, .github agents)
- Add delegation skill, runbook, and references under .github/skills/storybook-delegation-workflow
- Add cursor rule and Claude command for storybook delegation
- Update docs and global guides to reference the new workflow and requirement-readiness process (GEMINI.md, CLAUDE.md, AGENTS.md, docs/storybook/README.md, libs/web-ui/AGENTS.md, .github/copilot-instructions.md)
- Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Validation
- Generated from 1 commit(s) on `agents/storybook-sub-agent-implementation`.
- Compared against base branch `main`.
