### PR TITLE
chore(copilot-hooks): add repo guardrail hooks

### DIFF
--- a/.github/hooks/contract-drift-reminder.json
+++ b/.github/hooks/contract-drift-reminder.json
@@ -3,8 +3,8 @@
   "hooks": {
     "postToolUse": [
       {
-        "type": "command",
-        "command": "node tools/scripts/copilot-hooks/post-tool-use.mjs",
+        "bash": "node tools/scripts/copilot-hooks/post-tool-use.mjs",
+        "powershell": "node tools/scripts/copilot-hooks/post-tool-use.mjs",
         "cwd": ".",
         "timeoutSec": 5
       }

--- a/.github/hooks/contract-drift-reminder.json
+++ b/.github/hooks/contract-drift-reminder.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "type": "command",
+        "command": "node tools/scripts/copilot-hooks/post-tool-use.mjs",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.github/hooks/secret-scanner.json
+++ b/.github/hooks/secret-scanner.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "command": "node tools/scripts/copilot-hooks/secret-scan.mjs",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.github/hooks/secret-scanner.json
+++ b/.github/hooks/secret-scanner.json
@@ -3,8 +3,8 @@
   "hooks": {
     "preToolUse": [
       {
-        "type": "command",
-        "command": "node tools/scripts/copilot-hooks/secret-scan.mjs",
+        "bash": "node tools/scripts/copilot-hooks/secret-scan.mjs",
+        "powershell": "node tools/scripts/copilot-hooks/secret-scan.mjs",
         "cwd": ".",
         "timeoutSec": 5
       }

--- a/.github/hooks/security-guardrails.json
+++ b/.github/hooks/security-guardrails.json
@@ -3,8 +3,8 @@
   "hooks": {
     "preToolUse": [
       {
-        "type": "command",
-        "command": "node tools/scripts/copilot-hooks/pre-tool-use.mjs",
+        "bash": "node tools/scripts/copilot-hooks/pre-tool-use.mjs",
+        "powershell": "node tools/scripts/copilot-hooks/pre-tool-use.mjs",
         "cwd": ".",
         "timeoutSec": 5
       }

--- a/.github/hooks/security-guardrails.json
+++ b/.github/hooks/security-guardrails.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "command": "node tools/scripts/copilot-hooks/pre-tool-use.mjs",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/tools/scripts/copilot-hooks/post-tool-use.mjs
+++ b/tools/scripts/copilot-hooks/post-tool-use.mjs
@@ -1,0 +1,153 @@
+import process from 'node:process';
+
+const MUTATING_TOOL_NAMES = new Set([
+  'apply_patch',
+  'applypatch',
+  'bash',
+  'command',
+  'delete',
+  'execute',
+  'edit',
+  'move',
+  'patch',
+  'run',
+  'replace',
+  'rename',
+  'multiedit',
+  'multi_edit',
+  'shell',
+  'write',
+]);
+
+const CONTRACT_TARGETS = [
+  {
+    pattern: /(^|[^a-z0-9])apps\/backend\/src\/controllers(?:\/|$)/i,
+    additionalContext:
+      'You changed backend contract sources.\n- Run `yarn openapi:sync`\n- Run `yarn api:generate`\n- Run the relevant backend tests',
+  },
+  {
+    pattern: /(^|[^a-z0-9])apps\/backend\/src\/prisma\/schema(?:\/|$)/i,
+    additionalContext:
+      'You changed Prisma schema files.\n- Run `yarn nx run backend:generate-types`\n- Run `yarn nx run backend:migrate`\n- Run the relevant backend tests',
+  },
+];
+
+function normalizeText(value) {
+  return value.replace(/\\/g, '/').toLowerCase();
+}
+
+function getToolName(payload) {
+  const value =
+    payload?.toolName ??
+    payload?.tool_name ??
+    payload?.tool ??
+    payload?.name ??
+    '';
+
+  return typeof value === 'string' ? value.toLowerCase() : '';
+}
+
+function getToolInput(payload) {
+  return (
+    payload?.toolArgs ??
+    payload?.tool_args ??
+    payload?.toolInput ??
+    payload?.tool_input ??
+    payload?.input ??
+    payload?.args ??
+    payload?.arguments ??
+    null
+  );
+}
+
+function collectStrings(node, output = []) {
+  if (node === null || node === undefined) {
+    return output;
+  }
+
+  if (typeof node === 'string') {
+    output.push(node);
+    return output;
+  }
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectStrings(item, output);
+    }
+
+    return output;
+  }
+
+  if (typeof node === 'object') {
+    for (const value of Object.values(node)) {
+      collectStrings(value, output);
+    }
+  }
+
+  return output;
+}
+
+function getAdditionalContext(strings) {
+  const matches = new Set();
+
+  for (const text of strings) {
+    const normalized = normalizeText(text);
+
+    for (const target of CONTRACT_TARGETS) {
+      if (target.pattern.test(normalized)) {
+        matches.add(target.additionalContext);
+      }
+    }
+  }
+
+  if (matches.size === 0) {
+    return null;
+  }
+
+  return Array.from(matches).join('\n\n');
+}
+
+function main() {
+  let rawInput = '';
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => {
+    rawInput += chunk;
+  });
+
+  process.stdin.on('end', () => {
+    if (!rawInput.trim()) {
+      process.exit(0);
+      return;
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(rawInput);
+    } catch (error) {
+      console.error('[copilot-hooks] Unable to parse postToolUse payload.');
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+      return;
+    }
+
+    const toolName = getToolName(payload);
+    if (!MUTATING_TOOL_NAMES.has(toolName)) {
+      process.exit(0);
+      return;
+    }
+
+    const additionalContext = getAdditionalContext(
+      collectStrings(getToolInput(payload)),
+    );
+
+    if (!additionalContext) {
+      process.exit(0);
+      return;
+    }
+
+    process.stdout.write(JSON.stringify({ additionalContext }));
+  });
+}
+
+main();

--- a/tools/scripts/copilot-hooks/pre-tool-use.mjs
+++ b/tools/scripts/copilot-hooks/pre-tool-use.mjs
@@ -1,0 +1,300 @@
+import process from 'node:process';
+
+const MUTATING_TOOL_NAMES = new Set([
+  'apply_patch',
+  'applypatch',
+  'bash',
+  'command',
+  'delete',
+  'execute',
+  'edit',
+  'move',
+  'patch',
+  'run',
+  'replace',
+  'rename',
+  'multiedit',
+  'multi_edit',
+  'shell',
+  'write',
+]);
+
+const COMMAND_KEYS = new Set(['cmd', 'command', 'script', 'shell']);
+const PATH_KEYS = new Set([
+  'dest',
+  'destination',
+  'dir',
+  'directory',
+  'file',
+  'files',
+  'filename',
+  'filenames',
+  'filepath',
+  'filePath',
+  'folder',
+  'glob',
+  'path',
+  'paths',
+  'pattern',
+  'source',
+  'sources',
+  'target',
+  'targets',
+]);
+
+const PROTECTED_PATTERNS = [
+  {
+    pattern: /(^|[^a-z0-9])libs\/app-api-client(?:\/|$)/i,
+    reason:
+      'Direct edits to the generated API client are blocked. Regenerate it with `yarn api:generate` after syncing the API contract.',
+  },
+  {
+    pattern: /(^|[^a-z0-9])libs\/api-specs(?:\/|$)/i,
+    reason:
+      'Direct edits to the synced OpenAPI spec are blocked. Update backend controllers/DTOs and run `yarn openapi:sync`.',
+  },
+  {
+    pattern: /(^|[^a-z0-9])apps\/backend\/src\/swagger(?:\/|$)/i,
+    reason:
+      'Direct edits to generated Swagger output are blocked. Update backend controllers/DTOs and regenerate API docs.',
+  },
+  {
+    pattern: /(^|[^a-z0-9])libs\/design-tokens\/src\/generated(?:\/|$)/i,
+    reason:
+      'Direct edits to generated design token files are blocked. Edit `libs/design-tokens/src/tokens.json` and rebuild tokens.',
+  },
+  {
+    pattern: /(^|[^a-z0-9])apps\/backend\/src\/prisma\/migrations(?:\/|$)/i,
+    reason:
+      'Direct edits to Prisma migrations are blocked. Update the schema and use the migration workflow instead.',
+  },
+  {
+    pattern: /(^|[^a-z0-9])(?:\.env(?:\.[^\/]+)?|[^\/]+\.env)(?:$|[^a-z0-9])/i,
+    reason:
+      'Direct edits to environment files are blocked. Keep secrets in local env files or managed secret storage.',
+  },
+  {
+    pattern:
+      /(^|[^a-z0-9])(?:\.npmrc|\.yarnrc(?:\.yml)?|credentials|secrets)(?:\/|$)/i,
+    reason:
+      'Direct edits to secret or credentials files are blocked. Keep secrets out of the repository.',
+  },
+  {
+    pattern: /\.(?:pem|key|p8|p12|pfx|der|crt|cer)$/i,
+    reason:
+      'Direct edits to key or certificate files are blocked. Keep secret material out of the repository.',
+  },
+];
+
+function normalizeText(value) {
+  return value.replace(/\\/g, '/').toLowerCase();
+}
+
+function looksLikePath(text) {
+  const normalized = normalizeText(text);
+
+  return (
+    normalized.includes('/') ||
+    normalized.startsWith('.') ||
+    /\.[a-z0-9]{1,5}(?:[?*].*)?$/i.test(normalized)
+  );
+}
+
+function getToolName(payload) {
+  const value =
+    payload?.toolName ??
+    payload?.tool_name ??
+    payload?.tool ??
+    payload?.name ??
+    '';
+
+  return typeof value === 'string' ? value.toLowerCase() : '';
+}
+
+function getToolInput(payload) {
+  return (
+    payload?.toolArgs ??
+    payload?.tool_args ??
+    payload?.toolInput ??
+    payload?.tool_input ??
+    payload?.input ??
+    payload?.args ??
+    payload?.arguments ??
+    null
+  );
+}
+
+function isLikelyWriteCommand(command) {
+  const normalized = normalizeText(command);
+
+  return (
+    />/.test(normalized) ||
+    /\btee\b/.test(normalized) ||
+    /\b(?:cp|mv|rm|touch|truncate)\b/.test(normalized) ||
+    /\bgit\s+(?:restore|checkout|reset)\b/.test(normalized) ||
+    /\bsed\b[^\n]*\s-i\b/.test(normalized) ||
+    /\bperl\b[^\n]*\s-i\b/.test(normalized)
+  );
+}
+
+function getProtectedPathReason(text) {
+  const normalized = normalizeText(text);
+
+  for (const rule of PROTECTED_PATTERNS) {
+    if (rule.pattern.test(normalized)) {
+      return rule.reason;
+    }
+  }
+
+  return null;
+}
+
+function inspectPatchText(text) {
+  const lines = text.split(/\r?\n/);
+
+  for (const line of lines) {
+    const match =
+      line.match(/^\*\*\*\s+(?:add|update|delete)\s+file:\s+(.+)$/i) ??
+      line.match(/^\*\*\*\s+move\s+to:\s+(.+)$/i);
+
+    if (!match) {
+      continue;
+    }
+
+    const reason = getProtectedPathReason(match[1] ?? match[2] ?? '');
+    if (reason) {
+      return reason;
+    }
+  }
+
+  return null;
+}
+
+function inspectNode(node, key = '') {
+  if (node === null || node === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const reason = inspectNode(item, key);
+      if (reason) {
+        return reason;
+      }
+    }
+
+    return null;
+  }
+
+  if (typeof node === 'object') {
+    for (const [childKey, childValue] of Object.entries(node)) {
+      const reason = inspectNode(childValue, childKey);
+      if (reason) {
+        return reason;
+      }
+    }
+
+    return null;
+  }
+
+  if (typeof node !== 'string') {
+    return null;
+  }
+
+  if (COMMAND_KEYS.has(key)) {
+    if (!isLikelyWriteCommand(node)) {
+      return null;
+    }
+
+    return getProtectedPathReason(node);
+  }
+
+  if (PATH_KEYS.has(key)) {
+    return getProtectedPathReason(node);
+  }
+
+  return null;
+}
+
+function inspectToolInput(toolName, toolInput) {
+  if (!toolName) {
+    return null;
+  }
+
+  if (
+    toolName === 'apply_patch' ||
+    toolName === 'applypatch' ||
+    toolName === 'patch'
+  ) {
+    if (typeof toolInput === 'string') {
+      return inspectPatchText(toolInput);
+    }
+
+    return getProtectedPathReason(JSON.stringify(toolInput ?? {}));
+  }
+
+  if (typeof toolInput === 'string') {
+    if (toolName === 'bash' || toolName === 'command' || toolName === 'shell') {
+      if (!isLikelyWriteCommand(toolInput)) {
+        return null;
+      }
+
+      return getProtectedPathReason(toolInput);
+    }
+
+    if (!looksLikePath(toolInput)) {
+      return null;
+    }
+
+    return getProtectedPathReason(toolInput);
+  }
+
+  return inspectNode(toolInput);
+}
+
+function main() {
+  let rawInput = '';
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => {
+    rawInput += chunk;
+  });
+
+  process.stdin.on('end', () => {
+    if (!rawInput.trim()) {
+      process.exit(0);
+      return;
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(rawInput);
+    } catch (error) {
+      console.error('[copilot-hooks] Unable to parse preToolUse payload.');
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+      return;
+    }
+
+    const toolName = getToolName(payload);
+    if (!MUTATING_TOOL_NAMES.has(toolName)) {
+      process.exit(0);
+      return;
+    }
+
+    const reason = inspectToolInput(toolName, getToolInput(payload));
+    if (!reason) {
+      process.exit(0);
+      return;
+    }
+
+    process.stdout.write(
+      JSON.stringify({
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      }),
+    );
+  });
+}
+
+main();

--- a/tools/scripts/copilot-hooks/pre-tool-use.mjs
+++ b/tools/scripts/copilot-hooks/pre-tool-use.mjs
@@ -70,6 +70,7 @@ const PROTECTED_PATTERNS = [
   },
   {
     pattern: /(^|[^a-z0-9])(?:\.env(?:\.[^\/]+)?|[^\/]+\.env)(?:$|[^a-z0-9])/i,
+    exclude: (normalized) => /\.env\.example(?:$|[^a-z0-9])/.test(normalized),
     reason:
       'Direct edits to environment files are blocked. Keep secrets in local env files or managed secret storage.',
   },
@@ -141,6 +142,10 @@ function getProtectedPathReason(text) {
   const normalized = normalizeText(text);
 
   for (const rule of PROTECTED_PATTERNS) {
+    if (typeof rule.exclude === 'function' && rule.exclude(normalized)) {
+      continue;
+    }
+
     if (rule.pattern.test(normalized)) {
       return rule.reason;
     }

--- a/tools/scripts/copilot-hooks/secret-scan.mjs
+++ b/tools/scripts/copilot-hooks/secret-scan.mjs
@@ -1,0 +1,161 @@
+import process from 'node:process';
+
+const MUTATING_TOOL_NAMES = new Set([
+  'apply_patch',
+  'applypatch',
+  'bash',
+  'command',
+  'delete',
+  'execute',
+  'edit',
+  'move',
+  'patch',
+  'run',
+  'replace',
+  'rename',
+  'multiedit',
+  'multi_edit',
+  'shell',
+  'write',
+]);
+
+const SECRET_PATTERNS = [
+  {
+    pattern: /-----BEGIN [A-Z0-9 ]+PRIVATE KEY-----/i,
+    reason:
+      'Private key material was detected in the tool input. Keep private keys out of the repository and use a secret manager instead.',
+  },
+  {
+    pattern: /\b(?:ghp|github_pat|gho|ghu|ghs)_[A-Za-z0-9_]{20,}\b/i,
+    reason:
+      'A GitHub token-like secret was detected in the tool input. Remove it and store it outside the repository.',
+  },
+  {
+    pattern:
+      /\b(?:sk-[A-Za-z0-9]{20,}|sk_(?:live|test)_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|ya29\.[A-Za-z0-9\-_]+|xox[baprs]-[A-Za-z0-9-]{10,})\b/i,
+    reason:
+      'A secret-looking credential was detected in the tool input. Remove it and keep it in a secret manager or local env file instead.',
+  },
+  {
+    pattern:
+      /\b[A-Za-z0-9\-_]{20,}\.[A-Za-z0-9\-_]{20,}\.[A-Za-z0-9\-_]{20,}\b/,
+    reason:
+      'A JWT-like token was detected in the tool input. Remove it and avoid pasting credentials into the repository.',
+  },
+  {
+    pattern:
+      /(?:client[_-]?secret|refresh[_-]?token|access[_-]?token|api[_-]?key|password|passphrase)\s*[:=]\s*['"`][^'"`\n]{16,}['"`]/i,
+    reason:
+      'A literal credential-like value was detected in the tool input. Remove it and keep secrets out of source files and prompts.',
+  },
+];
+
+function getToolName(payload) {
+  const value =
+    payload?.toolName ??
+    payload?.tool_name ??
+    payload?.tool ??
+    payload?.name ??
+    '';
+
+  return typeof value === 'string' ? value.toLowerCase() : '';
+}
+
+function getToolInput(payload) {
+  return (
+    payload?.toolArgs ??
+    payload?.tool_args ??
+    payload?.toolInput ??
+    payload?.tool_input ??
+    payload?.input ??
+    payload?.args ??
+    payload?.arguments ??
+    null
+  );
+}
+
+function collectStrings(node, output = []) {
+  if (node === null || node === undefined) {
+    return output;
+  }
+
+  if (typeof node === 'string') {
+    output.push(node);
+    return output;
+  }
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectStrings(item, output);
+    }
+
+    return output;
+  }
+
+  if (typeof node === 'object') {
+    for (const value of Object.values(node)) {
+      collectStrings(value, output);
+    }
+  }
+
+  return output;
+}
+
+function getSecretReason(strings) {
+  for (const text of strings) {
+    for (const secretPattern of SECRET_PATTERNS) {
+      if (secretPattern.pattern.test(text)) {
+        return secretPattern.reason;
+      }
+    }
+  }
+
+  return null;
+}
+
+function main() {
+  let rawInput = '';
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => {
+    rawInput += chunk;
+  });
+
+  process.stdin.on('end', () => {
+    if (!rawInput.trim()) {
+      process.exit(0);
+      return;
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(rawInput);
+    } catch (error) {
+      console.error('[copilot-hooks] Unable to parse preToolUse payload.');
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+      return;
+    }
+
+    const toolName = getToolName(payload);
+    if (!MUTATING_TOOL_NAMES.has(toolName)) {
+      process.exit(0);
+      return;
+    }
+
+    const secretReason = getSecretReason(collectStrings(getToolInput(payload)));
+    if (!secretReason) {
+      process.exit(0);
+      return;
+    }
+
+    process.stdout.write(
+      JSON.stringify({
+        permissionDecision: 'deny',
+        permissionDecisionReason: secretReason,
+      }),
+    );
+  });
+}
+
+main();


### PR DESCRIPTION
## Why
Add repo guardrail hooks.

## Changes
- add pre-tool checks for protected paths and secret-like input
- add post-tool reminders for backend contract changes
- wire the new hook configs to the scripts
- Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Validation
- Generated from 1 commit(s) on `agents/github-copilot-hooks-update`.
- Compared against base branch `main`.
