### PR TITLE
feat: integrate grill-with-docs skill across all AI IDEs

### DIFF
--- a/.cursor/rules/grill-with-docs.mdc
+++ b/.cursor/rules/grill-with-docs.mdc
@@ -1,0 +1,91 @@
+---
+description: Grill-with-docs skill for stress-testing plans against the project's domain model, terminology, and documented decisions. Use when you have a design or feature plan that needs validation.
+alwaysApply: false
+---
+
+# Grill-with-Docs Skill
+
+## When to Use
+
+- You have a design or feature plan and want to stress-test it against MyOrganizer's existing domain model and terminology
+- You're making architectural decisions and want to document them alongside the planning process
+- You need to sharpen fuzzy requirements or resolve ambiguous concepts before implementation
+- You want to capture why certain decisions were made for future context
+
+## Core Approach
+
+1. **Interview relentlessly** — Ask one question at a time, providing recommended answers
+2. **Explore the codebase** — When questions can be answered by code inspection, do that instead of asking
+3. **Challenge terminology** — Check terminology against existing glossary in `CONTEXT.md`
+4. **Stress-test scenarios** — Invent edge cases that probe the boundaries between concepts
+5. **Update documentation inline** — Capture domain terms and architectural decisions as they're resolved
+
+## Key Artifacts
+
+### CONTEXT.md (Domain Glossary)
+
+Single source of truth for domain language in your project:
+
+```md
+# MyOrganizer Domain
+
+**Vault**: End-to-end encrypted storage for sensitive data on client; server stores ciphertext only.
+
+**Todo**: A task or item to organize (vault-backed in current architecture).
+_Avoid_: Task, item, note
+```
+
+- One-sentence definitions only
+- Include "Avoid" list for synonyms to reject
+- Purely conceptual, no implementation details
+- Create lazily — only when the first term is resolved
+
+### Architecture Decision Records (ADRs)
+
+Records of hard-to-reverse decisions with trade-off context:
+
+```md
+# We use vault encryption for sensitive data
+
+End-to-end encryption on the client side ensures plaintext never leaves the user's browser.
+The server stores ciphertext only and has no decryption keys, protecting user privacy even
+from internal systems.
+
+Considered: Server-side encryption, plaintext with TLS-only. Selected vault E2EE because
+privacy requirements demand zero-knowledge architecture.
+```
+
+- Live in `docs/adr/` with sequential numbering (`0001-*.md`, `0002-*.md`)
+- Only create ADRs when all three are true:
+  1. Hard to reverse (meaningful cost to change later)
+  2. Surprising without context (future reader would wonder "why?")
+  3. Result of a real trade-off (alternatives were considered)
+- Create lazily — only when an ADR is actually needed
+
+## MyOrganizer-specific Context
+
+Key domain terms already established:
+
+- **Vault** — End-to-end encrypted storage (ciphertext-only on server)
+- **Todo** — Task or item to organize (vault-backed)
+- **Subscription** — Recurring task or reminder (vault-backed)
+- **User** — Authenticated account holder
+- **Organization** — Group for organizing shared resources
+- **Ciphertext** — Encrypted blob format
+
+Tech stack to keep in mind:
+
+- Frontend: Next.js 14, React 18, TypeScript, Tailwind CSS
+- Backend: Express.js, Prisma ORM, TSOA (for OpenAPI docs)
+- Database: PostgreSQL
+- Monorepo: Nx with path aliases
+- Key constraint: Vault implies ciphertext-only on server (no plaintext indexing)
+
+## Skill Files
+
+- `SKILL.md` — Full skill definition and interview approach
+- `CONTEXT-FORMAT.md` — How to write domain glossaries
+- `ADR-FORMAT.md` — How to write architecture decision records
+- `README.md` — Quick reference guide
+
+See `.github/skills/grill-with-docs/` for details.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,6 +140,29 @@ When consuming the generated client:
 - Group related tests with `describe()` blocks
 - Use `beforeEach()` for test setup
 
+## Design & Planning
+
+### Grilling Sessions with Documentation
+
+When designing new features or making architectural decisions, use the **grill-with-docs** skill (`.github/skills/grill-with-docs/SKILL.md`) to:
+
+- Stress-test plans against the project's existing domain model and terminology
+- Sharpen fuzzy language and resolve ambiguous concepts
+- Challenge assumptions through concrete scenario discussions
+- Create or update `CONTEXT.md` to document domain language and glossary
+- Create Architecture Decision Records (ADRs) in `docs/adr/` for major decisions
+
+**When to use:**
+- You have a plan and want to validate it against MyOrganizer's language and architecture
+- You're designing a new feature that introduces new domain terms or concepts
+- You want to capture why architectural decisions were made
+
+**Key artifacts:**
+- `CONTEXT.md` — Single source of truth for domain language (what terms mean, what to avoid)
+- `docs/adr/` — Records of hard-to-reverse decisions with trade-off context
+
+See `.github/skills/grill-with-docs/` for templates and detailed guidance.
+
 ## Security Best Practices
 
 ### Environment Variables

--- a/.github/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.github/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording _that_ a decision was made and _why_ — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.github/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.github/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.github/skills/grill-with-docs/README.md
+++ b/.github/skills/grill-with-docs/README.md
@@ -1,0 +1,35 @@
+# grill-with-docs Skill
+
+**What**: A grilling session that stress-tests your plan against the project's domain model, terminology, and documented decisions.
+
+**When to use**: 
+- You have a plan and want to challenge it against MyOrganizer's existing language and architecture
+- You want to sharpen fuzzy design decisions before committing to code
+- You're designing a new feature and need to align terminology across the team
+- You want to capture architectural decisions as ADRs
+
+**How to invoke**:
+- In Claude: Reference this skill when you want to grill a plan
+- In Cursor/GitHub Copilot: Ask to "grill this plan" or "stress-test against docs"
+- In Gemini: Use this skill for domain-driven design conversations
+
+## Key Files
+
+- **SKILL.md** - Main skill definition with interview approach
+- **CONTEXT-FORMAT.md** - How to write and structure domain glossaries
+- **ADR-FORMAT.md** - How to write architecture decision records
+
+## How It Works
+
+1. **Relentless interviewing** - Ask one question at a time, providing recommended answers
+2. **Code exploration** - Check claims against actual codebase (don't just ask)
+3. **Terminology sharpening** - Challenge fuzzy language and align with CONTEXT.md
+4. **Inline documentation** - Update CONTEXT.md and create ADRs as decisions are made
+
+## MyOrganizer-specific
+
+The skill is pre-configured with:
+- MyOrganizer's key domain terms (Vault, Todo, Subscription, User, Organization, Ciphertext)
+- Project structure (single-context, Nx monorepo, DDD-influenced)
+- Technology stack (Next.js, Express, Prisma, TSOA, Playwright)
+- Key architectural constraints (vault = ciphertext-only on server)

--- a/.github/skills/grill-with-docs/SKILL.md
+++ b/.github/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when you want to stress-test a plan against the project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview relentlessly about every aspect of the plan until reaching a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead of asking.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness for MyOrganizer
+
+During codebase exploration, look for existing documentation:
+
+### File structure
+
+MyOrganizer uses a single context structure:
+
+```
+/
+├── CONTEXT.md              (if exists - domain language glossary)
+├── docs/
+│   ├── ARCHITECTURE.md     (high-level overview)
+│   └── adr/                (architecture decision records)
+│       ├── 0001-*.md
+│       └── 0002-*.md
+├── .github/
+│   ├── copilot-instructions.md
+│   └── skills/
+└── src/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first domain term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When a term is used that might conflict with existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'vault' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When vague or overloaded terms are used, propose a precise canonical term. "You're saying 'user' — do you mean the authenticated User in the database or the system User entity? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force precision about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If a contradiction is found, surface it: "Your code stores Todos in vault ciphertext, but you just said they should also be indexed — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+## Project-specific context
+
+### MyOrganizer Domain Terms
+
+These are key concepts already present in the codebase:
+
+- **Vault**: End-to-end encrypted storage for sensitive data on client; server stores ciphertext only
+- **Todo**: A task or item to organize (vault-backed in current architecture)
+- **Subscription**: Recurring task or reminder (vault-backed)
+- **User**: Authenticated account holder
+- **Organization**: Group for organizing shared resources (emerging context)
+- **Ciphertext**: Encrypted blob format for vault-backed types
+
+Refer to `CONTEXT.md` (if present) for canonical definitions.
+
+### Technology Stack
+
+- **Frontend**: Next.js 14, React 18, TypeScript, Tailwind CSS, React Hook Form + Zod
+- **Backend**: Express.js, Prisma ORM, TSOA (decorators for API docs)
+- **Database**: PostgreSQL (Prisma as data access layer)
+- **Monorepo**: Nx with path aliases
+- **Testing**: Jest (unit/integration), Playwright (E2E)
+- **Architecture**: DDD-influenced with vault-backed end-to-end encryption
+
+When making architectural decisions, consider:
+- Vault implications (ciphertext-only sync, no plaintext server-side indexing)
+- Database schema impact (Prisma migrations, model shape)
+- API contract surface (TSOA controllers, OpenAPI spec generation)
+- Nx module boundaries (avoid circular dependencies between contexts)
+
+</supporting-info>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - For Jest unit or integration test creation/update requests, follow `.github/skills/unit-test-delegation-workflow/SKILL.md` and delegate implementation to `TestScaffold` first. The brief must include a behavior matrix from the actual implementation plus explicit in-scope and out-of-scope scenarios. Main agent must review behavior correctness, side effects, failures, boundaries, security-sensitive paths, mock hygiene, duplicate output, and validation before finalizing. Use `docs/testing/README.md` as the project-aware tooling reference.
 - For Playwright E2E creation/update requests, follow `.github/skills/playwright-e2e-workflow/SKILL.md`; use `E2EPlanner` for broad flows and delegate implementation to `TestScaffold` only with a precise flow matrix.
 - For release requests, follow the `.github/skills/release-and-deploy-workflow/SKILL.md` skill. Delegate: pre-flight → `PreflightCheck` agent, version proposal → `VersionBump` agent, notes drafting → `ReleaseNotes` agent.
+- For design and planning sessions, use `.github/skills/grill-with-docs/SKILL.md` to stress-test plans against the domain model, sharpen terminology, and document decisions. This skill helps create/update `CONTEXT.md` (domain glossary) and `docs/adr/` (architecture decisions).
 
 ## Do Not
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,20 @@ Use the repo-local command files under `.claude/commands/` for commit, PR, test,
 - Commit-message drafting still belongs to the existing `Commit` sub-agent; commit execution belongs to the shared `ai:commit` runner.
 - Jest test implementation is delegated to the `TestScaffold` sub-agent (`.github/agents/test-scaffold.agent.md` and `.claude/agents/test-scaffold.md`). Always provide a behavior matrix from the actual implementation, including unsupported scenarios to avoid. Consult `docs/testing/README.md` for per-project tooling, integration scope, mock patterns, and validation checks.
 - Storybook implementation is delegated to the `StorybookCurator` sub-agent (`.claude/agents/storybook-curator.md`); require requirement-readiness analysis before edits and route clarification questions to the human-in-the-loop.
+
+## Design & Planning Workflows
+
+When you need to stress-test a plan against the project's domain model and documented decisions, use the **grill-with-docs** skill:
+
+- **Skill location**: `.github/skills/grill-with-docs/SKILL.md`
+- **When to use**: You have a design or feature plan that needs validation against MyOrganizer's terminology, architecture, and existing decisions.
+- **What it does**:
+  - Interviews relentlessly to sharpen fuzzy requirements and terminology
+  - Challenges plans against the domain glossary in `CONTEXT.md`
+  - Cross-references claims with actual codebase implementation
+  - Creates or updates `CONTEXT.md` to document domain language
+  - Proposes Architecture Decision Records (ADRs) for hard-to-reverse decisions
+- **Key documents to maintain**:
+  - `CONTEXT.md` — Domain language glossary (one-sentence definitions, preferred terms, what to avoid)
+  - `docs/adr/` — Architecture Decision Records for major design choices
+- **Reference formats**: See `CONTEXT-FORMAT.md` and `ADR-FORMAT.md` in the skill directory

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,6 +18,23 @@ Use these repo-local workflows for commit, pull request, test, and Storybook-sui
 - Leave reviewers empty unless the user explicitly supplies them with `--reviewer <login>`.
 - Return only the PR URL on success.
 
+## Design & Planning Workflows
+
+When you need to stress-test a plan against the project's domain model and documented decisions, use the **grill-with-docs** skill:
+
+- **Skill location**: `.github/skills/grill-with-docs/SKILL.md`
+- **When to use**: You have a design or feature plan that needs validation against MyOrganizer's terminology, architecture, and existing decisions.
+- **What it does**:
+  - Interviews relentlessly to sharpen fuzzy requirements and terminology
+  - Challenges plans against the domain glossary in `CONTEXT.md`
+  - Cross-references claims with actual codebase implementation
+  - Creates or updates `CONTEXT.md` to document domain language
+  - Proposes Architecture Decision Records (ADRs) for hard-to-reverse decisions
+- **Key documents to maintain**:
+  - `CONTEXT.md` — Domain language glossary (one-sentence definitions, preferred terms, what to avoid)
+  - `docs/adr/` — Architecture Decision Records for major design choices
+- **Reference formats**: See `CONTEXT-FORMAT.md` and `ADR-FORMAT.md` in the skill directory
+
 ## Jest Test Delegation
 
 When a task requires Jest unit tests or Jest integration tests to be created or updated, delegate to the `test-scaffold` sub-agent (`.gemini/agents/test-scaffold.md`) rather than writing tests inline. The agent runs on `gemini-2.5-flash` to keep costs low.

--- a/docs/internal/GRILL_WITH_DOCS_INTEGRATION.md
+++ b/docs/internal/GRILL_WITH_DOCS_INTEGRATION.md
@@ -1,0 +1,163 @@
+# Grill-with-Docs Skill Integration Summary
+
+## ✅ Integration Complete
+
+The `grill-with-docs` skill from [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) has been successfully integrated into MyOrganizer and made available across all AI IDEs.
+
+## 📁 Files Created
+
+### Main Skill Directory: `.github/skills/grill-with-docs/`
+
+1. **SKILL.md** — Core skill definition
+   - Grilling interview approach (ask one question at a time)
+   - Domain awareness specific to MyOrganizer
+   - Guidance on challenging terminology, discussing scenarios, and updating documentation
+   - Instructions for creating/updating CONTEXT.md and ADRs
+
+2. **CONTEXT-FORMAT.md** — Template for domain glossaries
+   - How to write `CONTEXT.md` (domain language single source of truth)
+   - Rules for being opinionated, keeping definitions tight, including only domain-specific terms
+   - Single vs multi-context repo patterns
+
+3. **ADR-FORMAT.md** — Template for architecture decisions
+   - How to write ADRs in `docs/adr/` (numbered sequentially)
+   - When to offer an ADR (hard to reverse, surprising, result of trade-off)
+   - What qualifies as an ADR (architectural shape, integration patterns, technology choices, boundaries, deliberate deviations)
+
+4. **README.md** — Quick reference guide
+   - Overview of what the skill does and when to use it
+   - MyOrganizer-specific context (domain terms, tech stack)
+   - Pointer to full skill files
+
+## 🔧 IDE Configuration Updates
+
+### 1. GitHub Copilot (`.github/copilot-instructions.md`)
+
+- ✅ Added "Design & Planning" section
+- ✅ Documented when to use grill-with-docs
+- ✅ Explained key artifacts (CONTEXT.md, ADRs)
+- ✅ Linked to skill templates
+
+### 2. Claude (CLAUDE.md)
+
+- ✅ Added "Design & Planning Workflows" section
+- ✅ Explained skill purpose, use cases, and workflow
+- ✅ Documented key documents to maintain
+- ✅ Referenced format templates
+
+### 3. Gemini (GEMINI.md)
+
+- ✅ Added "Design & Planning Workflows" section
+- ✅ Documented skill purpose, use cases, and workflow
+- ✅ Explained key documents to maintain
+- ✅ Referenced format templates
+
+### 4. Cursor (`.cursor/rules/grill-with-docs.mdc`)
+
+- ✅ Created new rule file with MDC frontmatter
+- ✅ When to use instructions with concrete examples
+- ✅ Core approach (relentless interviewing, code exploration, terminology sharpening)
+- ✅ MyOrganizer-specific context and tech stack
+
+### 5. Project Agents Guide (AGENTS.md)
+
+- ✅ Added bullet point for design/planning requests
+- ✅ Links to `.github/skills/grill-with-docs/SKILL.md`
+- ✅ Explains CONTEXT.md and ADR documentation
+
+## 🎯 How to Use
+
+### For Claude Users
+
+```
+"I want to design a new feature for [X].
+Can you grill this plan using the grill-with-docs skill?"
+```
+
+### For GitHub Copilot Users
+
+```
+"Let's use the grill-with-docs skill to stress-test
+this architectural decision against our domain model."
+```
+
+### For Cursor Users
+
+The grill-with-docs rule is enabled in `.cursor/rules/` and will be applied to relevant conversations.
+
+### For Gemini Users
+
+Reference the skill when you want to validate a design against existing domain language and architecture.
+
+## 📚 Key Concepts
+
+### CONTEXT.md (Domain Glossary)
+
+Single source of truth for project-specific domain language:
+
+```md
+**Vault**: End-to-end encrypted storage for sensitive data on client;
+server stores ciphertext only.
+_Avoid_: Safe, encrypted storage, secure container
+```
+
+- One-sentence definitions only
+- Include "Avoid" list (synonyms to reject)
+- No implementation details
+- Created lazily, updated inline during planning sessions
+
+### ADRs (Architecture Decision Records)
+
+Documents of hard-to-reverse decisions made during planning:
+
+```md
+# We use vault encryption for sensitive data
+
+End-to-end encryption ensures plaintext never leaves the browser...
+Considered: Server-side encryption, plaintext with TLS. Selected vault...
+```
+
+- Live in `docs/adr/` numbered sequentially
+- Only created when all three criteria are met:
+  1. Hard to reverse (meaningful cost to change)
+  2. Surprising without context (future reader wonders "why?")
+  3. Result of real trade-off (alternatives were considered)
+- Created lazily, only when actually needed
+
+## 🚀 MyOrganizer-Specific Context Pre-loaded
+
+The skill is pre-configured with MyOrganizer's:
+
+**Domain Terms:**
+
+- Vault (E2EE storage, ciphertext-only on server)
+- Todo (task/item, vault-backed)
+- Subscription (recurring, vault-backed)
+- User (authenticated account holder)
+- Organization (group for resources)
+- Ciphertext (encrypted blob format)
+
+**Technology Stack:**
+
+- Frontend: Next.js 14, React 18, TypeScript, Tailwind CSS
+- Backend: Express.js, Prisma ORM, TSOA
+- Database: PostgreSQL
+- Monorepo: Nx with path aliases
+- Testing: Jest, Playwright
+
+**Key Constraints:**
+
+- Vault = ciphertext-only on server (no plaintext indexing)
+- Todos are vault-backed (not a plaintext Prisma model)
+
+## ✨ What's Next?
+
+The skill is now ready to use for:
+
+- 🎨 Design review sessions ("Grill this feature plan")
+- 📖 Domain language refinement ("Let's define this term")
+- 🏗️ Architecture discussions ("Should we use X or Y?")
+- 📝 Documentation ("What should this ADR say?")
+- 🤔 Terminology sharpening ("Is 'user' the right word here?")
+
+Start by invoking the skill with a feature plan or design question in any of the supported IDEs!


### PR DESCRIPTION
## Overview

This PR integrates the **grill-with-docs** skill from [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) into MyOrganizer, making it available across all AI IDEs (Claude, GitHub Copilot, Cursor, Gemini).

## What's the grill-with-docs skill?

A domain-driven design skill that enables relentless interviewing and planning sessions. It helps teams:

- ✅ Stress-test plans against existing domain models and terminology
- ✅ Sharpen fuzzy requirements and resolve ambiguous concepts
- ✅ Challenge assumptions through concrete scenario discussions
- ✅ Document domain language in `CONTEXT.md` (single source of truth)
- ✅ Create Architecture Decision Records (ADRs) for hard-to-reverse decisions

## Changes

### New Files

- **`.github/skills/grill-with-docs/SKILL.md`** — Core skill definition with MyOrganizer-specific context
- **`.github/skills/grill-with-docs/CONTEXT-FORMAT.md`** — Template for domain glossaries
- **`.github/skills/grill-with-docs/ADR-FORMAT.md`** — Template for architecture decision records
- **`.github/skills/grill-with-docs/README.md`** — Quick reference guide
- **`.cursor/rules/grill-with-docs.mdc`** — Cursor IDE integration
- **`docs/internal/GRILL_WITH_DOCS_INTEGRATION.md`** — Integration summary and usage guide

### Updated Files

- **`.github/copilot-instructions.md`** — Added Design & Planning section with grill-with-docs guidance
- **`CLAUDE.md`** — Added Design & Planning Workflows section
- **`GEMINI.md`** — Added Design & Planning Workflows section  
- **`AGENTS.md`** — Added grill-with-docs reference for design/planning requests

## How to Use

### Claude
```
"I want to design a new feature for [X]. 
Can you grill this plan using the grill-with-docs skill?"
```

### GitHub Copilot
```
"Let's use the grill-with-docs skill to stress-test 
this architectural decision against our domain model."
```

### Cursor
The grill-with-docs rule is enabled in `.cursor/rules/` and will be automatically applied to relevant conversations.

### Gemini
Reference the skill when you want to validate a design against existing domain language and architecture.

## Pre-configured for MyOrganizer

The skill comes pre-configured with MyOrganizer's:

**Domain Terms:**
- Vault (E2E encrypted storage, ciphertext-only on server)
- Todo (task/item, vault-backed)
- Subscription (recurring, vault-backed)
- User (authenticated account holder)
- Organization (group for resources)

**Technology Stack:**
- Frontend: Next.js 14, React 18, TypeScript, Tailwind CSS
- Backend: Express.js, Prisma ORM, TSOA
- Database: PostgreSQL
- Monorepo: Nx with path aliases

**Key Constraints:**
- Vault = ciphertext-only on server (no plaintext indexing)
- Todos are vault-backed (not plaintext Prisma model)

## Key Artifacts Created

### CONTEXT.md (Domain Glossary)
Single source of truth for project-specific domain language. Example:

```md
# MyOrganizer Domain

**Vault**: End-to-end encrypted storage for sensitive data on client; server stores ciphertext only.
_Avoid_: Safe, encrypted storage

**Todo**: A task or item to organize (vault-backed).
_Avoid_: Task, item, note
```

### ADRs (Architecture Decision Records)
Documents of hard-to-reverse decisions. Lives in `docs/adr/` with sequential numbering. Example:

```md
# We use vault encryption for sensitive data

End-to-end encryption ensures plaintext never leaves the browser. 
Server stores ciphertext only, protecting user privacy.

Considered: Server-side encryption, plaintext with TLS.
Selected vault E2EE because privacy requirements demand zero-knowledge architecture.
```

## Benefits

1. **Consistency** — All AI IDEs can run the same grill-with-docs planning sessions
2. **Documentation** — Domain decisions are captured in code alongside planning
3. **Clarity** — Team terminology is documented and shared across all developers
4. **Quality** — Plans are stress-tested before implementation begins
5. **Context** — Future developers understand "why" decisions were made

## Next Steps

1. Merge this PR to `main`
2. Start using grill-with-docs for new feature planning
3. Create `CONTEXT.md` and `docs/adr/` as domain terms and architectural decisions emerge

See `docs/internal/GRILL_WITH_DOCS_INTEGRATION.md` for the complete integration summary.

---

**Related:** [mattpocock/skills - grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs)