### PR TITLE
test(myorganizer-e2e): add groceries export/import E2E tests and helpers

### DIFF
--- a/.claude/checklist.md
+++ b/.claude/checklist.md
@@ -1,0 +1,149 @@
+# Task Classification & Delegation Checklist
+
+**CRITICAL:** Use this checklist BEFORE making ANY file edits.
+
+## Step 1: Pre-Action Decision Tree
+
+Before editing ANY file, answer these questions:
+
+### Q1: What file type am I modifying?
+
+- **`*.spec.ts` (Playwright E2E tests)** → Go to "E2E Tests" section
+- **`*.test.ts` (Jest unit/integration tests)** → Go to "Jest Tests" section
+- **`*.stories.tsx` (Storybook stories)** → Go to "Storybook Stories" section
+- **Component in `libs/web-ui/` (UI Primitives)** → Go to "React Components" section
+- **Component in `libs/web/pages/` (Feature Components)** → Go to "React Components" section
+- **Other files** → Proceed to Step 2
+
+### Q2: Am I UPDATING existing code or CREATING new code?
+
+- **Updating test behavior or fixing test logic** → DELEGATE (even small fixes)
+- **Creating new test files** → DELEGATE
+- **Updating component implementation** → DELEGATE
+- **Other infrastructure/config** → Check "Red Flags" section
+
+---
+
+## Step 2: Red Flags — Stop and Delegate If You See Any
+
+Before calling `replace_string_in_file` or `create_file`, check for these patterns:
+
+- ☐ The file extension is `.spec.ts` or `.test.ts`
+- ☐ The file path contains `/helpers/` within an E2E test directory
+- ☐ The code contains `setupBackend()`, `setupVault*()`, test fixtures, or mock helpers
+- ☐ The word "fixture", "setup", "mock", "beforeEach", "afterEach", "test.describe" appears
+- ☐ Playwright page object or browser automation code (`page.goto()`, `page.click()`, etc.)
+- ☐ Jest mock configuration or test structure (`jest.mock()`, `.mock()`)
+- ☐ Storybook story definition (`export const MyStory`)
+- ☐ React component JSX in `libs/web-ui/` or `libs/web/pages/`
+- ☐ UI behavior changes (styling, interactivity, props)
+- ☐ Test assertions being added or changed
+
+**If ANY of these apply: STOP → READ SKILL FILE → DELEGATE to sub-agent**
+
+---
+
+## Step 3: Task Classification Matrix
+
+| File Pattern               | Operation         | Skill/Agent                                                                    | Delegated?                                  |
+| -------------------------- | ----------------- | ------------------------------------------------------------------------------ | ------------------------------------------- |
+| `*.spec.ts` (E2E)          | Create/Update/Fix | `.github/skills/playwright-e2e-workflow/SKILL.md` → E2EPlanner + TestScaffold  | ✅ **Always**                               |
+| `*.test.ts` (Jest)         | Create/Update/Fix | `.github/skills/unit-test-delegation-workflow/SKILL.md` → TestScaffold         | ✅ **Always**                               |
+| `*.stories.tsx`            | Create/Update     | `.github/skills/storybook-delegation-workflow/SKILL.md` → StorybookCurator     | ✅ **Always**                               |
+| Component (libs/web-ui)    | Create/Edit       | `.claude/commands/component-builder.md` → ComponentBuilder → ComponentReviewer | ✅ **Always**                               |
+| Component (libs/web/pages) | Create/Edit       | `.claude/commands/component-builder.md` → ComponentBuilder → ComponentReviewer | ✅ **Always**                               |
+| Config/Infrastructure      | Edit              | Direct edit OK                                                                 | ⚠️ Only if no test/component files involved |
+| Docs/README                | Create/Update     | Direct edit OK                                                                 | ⚠️ Can delegate to Docs agent if complex    |
+| Type definitions           | Create/Update     | Direct edit OK                                                                 | ⚠️ Unless tests need updating too           |
+
+---
+
+## Step 4: Mandatory Delegation Rules
+
+### **NO EXCEPTIONS** — These tasks ALWAYS require delegation:
+
+1. **E2E Test Changes** (`.spec.ts` files)
+   - Skill: `.github/skills/playwright-e2e-workflow/SKILL.md`
+   - Agent flow: E2EPlanner → TestScaffold
+   - What this means: Even a one-line bug fix in an E2E test must go through delegation
+
+2. **Jest Test Changes** (`.test.ts` files)
+   - Skill: `.github/skills/unit-test-delegation-workflow/SKILL.md`
+   - Agent flow: TestScaffold (with behavior matrix)
+   - What this means: Any test creation, update, or fix uses TestScaffold
+
+3. **Storybook Stories** (`*.stories.tsx` files)
+   - Skill: `.github/skills/storybook-delegation-workflow/SKILL.md`
+   - Agent flow: StorybookCurator
+   - What this means: New or updated story files go through StorybookCurator
+
+4. **React Components** (libs/web-ui/_, libs/web/pages/_)
+   - Workflow: ComponentBuilder → ComponentReviewer (no exceptions)
+   - What this means: Component creation/edits follow the compound pattern via agents
+
+---
+
+## Step 5: Common Failure Pattern (What We're Preventing)
+
+### ❌ **Anti-Pattern to Avoid:**
+
+```
+"I see a bug in the E2E tests. Let me:
+1. Read the similar test file to find the pattern
+2. Understand what needs fixing
+3. Apply the fix directly with replace_string_in_file"
+```
+
+### ✅ **Correct Pattern:**
+
+```
+"I see a bug in the E2E tests. This is an E2E test UPDATE, so I need to:
+1. Read .github/skills/playwright-e2e-workflow/SKILL.md
+2. Use E2EPlanner to outline the fix (flow matrix + issues)
+3. Delegate to TestScaffold with a precise E2E brief
+4. TestScaffold executes the changes
+5. I verify the result"
+```
+
+---
+
+## Step 6: Tool-Level Gatekeeping
+
+**BEFORE calling these tools on test/component files:**
+
+- `replace_string_in_file` on `*.spec.ts`, `*.test.ts`, `*.stories.tsx`, or component files → DELEGATE FIRST
+- `create_file` for test or story files → DELEGATE FIRST
+- `read_file` (if 3+ consecutive reads needed for exploration) → Use CodeExplorer instead
+
+---
+
+## Quick Reference: What to Do Next
+
+| Scenario                         | Action                                                                                  |
+| -------------------------------- | --------------------------------------------------------------------------------------- |
+| "Fix a bug in an E2E test"       | → Read `.github/skills/playwright-e2e-workflow/SKILL.md`, use E2EPlanner + TestScaffold |
+| "Update a Jest test"             | → Read `.github/skills/unit-test-delegation-workflow/SKILL.md`, use TestScaffold        |
+| "Create a new Storybook story"   | → Read `.github/skills/storybook-delegation-workflow/SKILL.md`, use StorybookCurator    |
+| "Edit a React component"         | → Build Structured Spec, use ComponentBuilder → ComponentReviewer                       |
+| "Explore codebase for a pattern" | → Use CodeExplorer (not 3+ manual reads)                                                |
+| "Fix a config file"              | → Direct edit OK (but check for tests that might break)                                 |
+| "Update documentation"           | → Direct edit OK (or use Docs agent for complex docs)                                   |
+
+---
+
+## How to Use This Checklist
+
+1. **Before starting work:** Run through Step 1 & 2 mentally
+2. **If any red flag triggers:** Skip to Step 3, find your file type, follow the delegation flow
+3. **If no red flags:** Proceed with direct edit (but still verify with Step 4)
+4. **If you're ever unsure:** Re-read Step 4 — if it's a test/component/story file, delegate
+
+---
+
+## Reference Links
+
+- E2E Workflow: `.github/skills/playwright-e2e-workflow/SKILL.md`
+- Jest Workflow: `.github/skills/unit-test-delegation-workflow/SKILL.md`
+- Storybook Workflow: `.github/skills/storybook-delegation-workflow/SKILL.md`
+- Component Workflow: `CLAUDE.md` → "UI Component Workflows"
+- This checklist: `.claude/checklist.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,40 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - For design and planning sessions, use `.github/skills/grill-with-docs/SKILL.md` to stress-test plans against the domain model, sharpen terminology, and document decisions. This skill helps create/update `CONTEXT.md` (domain glossary) and `docs/adr/` (architecture decisions).
 - Before issuing 3 or more consecutive read/search operations to locate something in the codebase, stop and delegate to `CodeExplorer` (`.github/agents/explore.agent.md`) instead. Provide an Explore Request with a `Goal` sentence; optionally include `Known Locations`, `Search Hints`, `Out of Scope`, and `Expected Output`. CodeExplorer returns a structured Explore Summary with `[found]`/`[inferred]` tagged findings and ranked file paths.
 
+## ⚠️ Mandatory Delegation Rules (NO EXCEPTIONS)
+
+**ALWAYS delegate tasks for these file types.** Do NOT skip delegation even if the change seems small or obvious.
+
+| File Pattern                    | Skill                                                   | Agent Flow                           | Rule                   |
+| ------------------------------- | ------------------------------------------------------- | ------------------------------------ | ---------------------- |
+| `*.spec.ts` (Playwright E2E)    | `.github/skills/playwright-e2e-workflow/SKILL.md`       | E2EPlanner → TestScaffold            | ✅ **Always delegate** |
+| `*.test.ts` (Jest tests)        | `.github/skills/unit-test-delegation-workflow/SKILL.md` | TestScaffold                         | ✅ **Always delegate** |
+| `*.stories.tsx` (Storybook)     | `.github/skills/storybook-delegation-workflow/SKILL.md` | StorybookCurator                     | ✅ **Always delegate** |
+| Components in `libs/web-ui/`    | Component workflow                                      | ComponentBuilder → ComponentReviewer | ✅ **Always delegate** |
+| Components in `libs/web/pages/` | Component workflow                                      | ComponentBuilder → ComponentReviewer | ✅ **Always delegate** |
+
+### Key Anti-Pattern to Avoid
+
+❌ **DO NOT do this:**
+
+```
+"I see a bug in an E2E test. Let me read the similar test, find the pattern, and fix it directly."
+```
+
+✅ **DO THIS INSTEAD:**
+
+```
+"I see a bug in an E2E test. This is an E2E test UPDATE.
+1. Read .github/skills/playwright-e2e-workflow/SKILL.md
+2. Use E2EPlanner to outline the fix
+3. Delegate to TestScaffold with a precise brief
+4. Apply changes from TestScaffold output"
+```
+
+### Before You Edit Any File
+
+Use the decision tree in [`.claude/checklist.md`](.claude/checklist.md) to verify you're not skipping delegation.
+
 ## Do Not
 
 - Do not introduce `package-lock.json` or `pnpm-lock.yaml` changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,40 @@ Use the repo-local command files under `.claude/commands/` for commit, PR, test,
 - React component creation or editing (UI Primitives in `libs/web-ui/` or Feature Components in `libs/web/pages/<route>/`) must use the ComponentBuilder → ComponentReviewer workflow — see **UI Component Workflows** below.
 - After any `yarn add`, `yarn remove`, or package upgrade, run `/dep-sync` to keep `TECH_STACK.md` current — see **Dependency Sync** below.
 
+## ⚠️ Mandatory Delegation Rules (NO EXCEPTIONS)
+
+**ALWAYS delegate tasks for these file types.** Do NOT skip delegation even if the change seems small or obvious.
+
+| File Pattern                    | Skill                                                   | Agent Flow                           | Rule                   |
+| ------------------------------- | ------------------------------------------------------- | ------------------------------------ | ---------------------- |
+| `*.spec.ts` (Playwright E2E)    | `.github/skills/playwright-e2e-workflow/SKILL.md`       | E2EPlanner → TestScaffold            | ✅ **Always delegate** |
+| `*.test.ts` (Jest tests)        | `.github/skills/unit-test-delegation-workflow/SKILL.md` | TestScaffold                         | ✅ **Always delegate** |
+| `*.stories.tsx` (Storybook)     | `.github/skills/storybook-delegation-workflow/SKILL.md` | StorybookCurator                     | ✅ **Always delegate** |
+| Components in `libs/web-ui/`    | Component workflow (below)                              | ComponentBuilder → ComponentReviewer | ✅ **Always delegate** |
+| Components in `libs/web/pages/` | Component workflow (below)                              | ComponentBuilder → ComponentReviewer | ✅ **Always delegate** |
+
+### Key Anti-Pattern to Avoid
+
+❌ **DO NOT do this:**
+
+```
+"I see a bug in an E2E test. Let me read the similar test, find the pattern, and fix it directly."
+```
+
+✅ **DO THIS INSTEAD:**
+
+```
+"I see a bug in an E2E test. This is an E2E test UPDATE.
+1. Read .github/skills/playwright-e2e-workflow/SKILL.md
+2. Use E2EPlanner to outline the fix
+3. Delegate to TestScaffold with a precise brief
+4. Apply changes from TestScaffold output"
+```
+
+### Before You Edit Any File
+
+Use the decision tree in **`.claude/checklist.md`** to verify you're not skipping delegation.
+
 ## UI Component Workflows
 
 When creating or editing any React component in `libs/web-ui/` (UI Primitives) or `libs/web/pages/<route>/` (Feature Components), follow this chain exactly:

--- a/apps/myorganizer-e2e/src/e2e/helpers/GroceriesPage.ts
+++ b/apps/myorganizer-e2e/src/e2e/helpers/GroceriesPage.ts
@@ -1,0 +1,434 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Page Object Model for Groceries page.
+ * Provides a higher-level API for interacting with the groceries feature
+ * across multiple test scenarios, reducing code duplication.
+ */
+export class GroceriesPage {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Navigate to /dashboard/groceries and unlock the vault if needed.
+   */
+  async gotoAndUnlock(passphrase: string): Promise<void> {
+    await this.page.goto('/dashboard/groceries');
+    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForTimeout(500);
+
+    const unlockButton = this.page.getByRole('button', {
+      name: 'Use passphrase',
+    });
+    const isLocked = await unlockButton
+      .isVisible({ timeout: 10000 })
+      .catch(() => false);
+
+    if (isLocked) {
+      await this.unlockWithPassphrase(passphrase);
+    }
+
+    // Wait for the groceries page content to render after unlock
+    await this.page.waitForFunction(
+      () => {
+        const pageContent = document.body.innerText;
+        const hasNewListBtn = !!document
+          .querySelector('button')
+          ?.textContent?.includes('New List');
+        const hasPageTitle =
+          pageContent.includes('Groceries') || pageContent.includes('grocery');
+        return hasNewListBtn || hasPageTitle;
+      },
+      { timeout: 30000 },
+    );
+
+    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForTimeout(1000);
+  }
+
+  /**
+   * Unlock the vault using passphrase.
+   */
+  async unlockWithPassphrase(passphrase: string): Promise<void> {
+    const unlockUI = this.page.getByRole('button', { name: 'Use passphrase' });
+    const isUnlockScreenVisible = await unlockUI
+      .isVisible({ timeout: 10000 })
+      .catch(() => false);
+
+    if (!isUnlockScreenVisible) {
+      return;
+    }
+
+    if (await unlockUI.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await unlockUI.click();
+      await this.page.waitForTimeout(1000);
+    }
+
+    let input = this.page.locator('#unlock-passphrase');
+    let inputExists = await input
+      .isVisible({ timeout: 5000 })
+      .catch(() => false);
+
+    if (!inputExists) {
+      input = this.page
+        .locator(
+          'input[placeholder*="Security"], input[placeholder*="passphrase"]',
+        )
+        .first();
+      inputExists = await input.isVisible({ timeout: 5000 }).catch(() => false);
+    }
+
+    if (!inputExists) {
+      throw new Error(
+        'Passphrase input not found after clicking "Use passphrase"',
+      );
+    }
+
+    await input.scrollIntoViewIfNeeded();
+    await input.click();
+    await this.page.waitForTimeout(500);
+    await input.fill(passphrase);
+    await this.page.waitForTimeout(300);
+
+    const unlockButton = this.page.getByRole('button', { name: /^Unlock$/i });
+    const buttonExists = await unlockButton
+      .isVisible({ timeout: 5000 })
+      .catch(() => false);
+
+    if (!buttonExists) {
+      throw new Error('Unlock button not found after filling passphrase');
+    }
+
+    await unlockButton.click();
+    await this.page.waitForTimeout(500);
+
+    try {
+      await this.page
+        .locator(
+          '#unlock-passphrase, input[placeholder*="Security"], input[placeholder*="passphrase"]',
+        )
+        .first()
+        .isHidden({ timeout: 30000 });
+    } catch {
+      try {
+        await this.page.waitForLoadState('networkidle', { timeout: 10000 });
+      } catch {
+        // Continue anyway
+      }
+    }
+
+    await this.page.waitForTimeout(1000);
+  }
+
+  /**
+   * Create a new grocery list via the UI.
+   */
+  async createList(name: string): Promise<void> {
+    await this.page.getByRole('button', { name: 'New List' }).click();
+
+    const dialog = this.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    const input = this.page.getByPlaceholder('e.g., Weekly Shopping');
+    await expect(input).toBeVisible();
+    await input.fill(name);
+
+    // Character counter visible
+    await expect(this.page.getByText(/\d+ \/ 100/)).toBeVisible();
+
+    // Click the create button
+    await this.page.getByRole('button', { name: 'Create List' }).click();
+
+    // Dialog should close
+    await expect(this.page.getByRole('dialog')).toHaveCount(0, {
+      timeout: 60000,
+    });
+
+    // Ensure list is created
+    await expect(this.page.getByText(name)).toBeVisible({ timeout: 60000 });
+  }
+
+  /**
+   * Open a grocery list by name and navigate to its items page.
+   */
+  async openList(listName: string, passphraseParam?: string): Promise<void> {
+    const link = this.page
+      .locator(`a[href*="/dashboard/groceries/"]`)
+      .filter({
+        hasText: listName,
+      })
+      .first();
+
+    const href = await link.getAttribute('href');
+    if (!href) {
+      throw new Error(`Could not find link for list "${listName}"`);
+    }
+
+    await this.page.goto(href);
+    await this.page.waitForLoadState('networkidle');
+
+    // Check if vault unlock is required
+    const passphraseInput = this.page
+      .locator('#unlock-passphrase, [data-testid="unlock-passphrase"]')
+      .first();
+    if (await passphraseInput.isVisible({ timeout: 5000 }).catch(() => false)) {
+      if (!passphraseParam) {
+        throw new Error(
+          `Vault unlock required but passphrase not provided to openList`,
+        );
+      }
+      await passphraseInput.fill(passphraseParam);
+      const unlockBtn = this.page
+        .getByRole('button', { name: /Unlock|Confirm/ })
+        .first();
+      await unlockBtn.click();
+      await this.page.waitForLoadState('networkidle');
+    }
+
+    await this.page.waitForFunction(
+      (name) => {
+        const heading = document.querySelector('h1, h2');
+        return heading && heading.textContent?.includes(name);
+      },
+      listName,
+      { timeout: 30000 },
+    );
+  }
+
+  /**
+   * Rename a grocery list.
+   */
+  async renameList(oldName: string, newName: string): Promise<void> {
+    await this.openListContextMenu(oldName);
+    await this.page.getByRole('menuitem', { name: 'Rename' }).click();
+
+    const dialog = this.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    const input = this.page.getByPlaceholder('e.g., Weekly Shopping');
+    await expect(input).toHaveValue(oldName);
+
+    await input.fill(newName);
+    await this.page.getByRole('button', { name: 'Rename List' }).click();
+    await expect(this.page.getByRole('dialog')).toHaveCount(0);
+    await expect(this.page.getByText(newName)).toBeVisible({ timeout: 60000 });
+  }
+
+  /**
+   * Delete a grocery list with confirmation.
+   */
+  async deleteList(listName: string): Promise<void> {
+    await this.openListContextMenu(listName);
+    await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+
+    const dialog = this.page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await this.page.getByRole('button', { name: 'Delete List' }).click();
+
+    await expect(this.page.getByRole('dialog')).toHaveCount(0);
+    await expect(this.page.getByText(listName)).toHaveCount(0);
+  }
+
+  /**
+   * Open the context menu (three-dot dropdown) for a list card.
+   */
+  private async openListContextMenu(listName: string): Promise<void> {
+    const cardButton = this.page
+      .locator('xpath=//div[@role="article"][contains(., "' + listName + '")]')
+      .first();
+    await cardButton.hover();
+
+    const menuButton = cardButton.locator('button').first();
+    await expect(menuButton).toBeVisible();
+    await menuButton.click();
+  }
+
+  /**
+   * Add an item to the current list via the Add Item dialog.
+   */
+  async addItem(name: string): Promise<void> {
+    await this.page.getByRole('button', { name: 'Add Item' }).click();
+
+    const dialog = this.page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 30000 });
+
+    const nameInput = this.page.locator('#add-item-name');
+    await expect(nameInput).toBeVisible({ timeout: 10000 });
+    await nameInput.fill(name);
+
+    const addBtn = dialog.getByRole('button', { name: 'Add to List' });
+    await expect(addBtn).toBeEnabled({ timeout: 10000 });
+    await addBtn.click();
+
+    await expect(dialog).toHaveCount(0, { timeout: 30000 });
+    await expect(this.page.getByText(name, { exact: true })).toBeVisible({
+      timeout: 30000,
+    });
+  }
+
+  /**
+   * Edit an item with the specified fields.
+   */
+  async editItem(
+    originalName: string,
+    updates: {
+      name?: string;
+      category?: string;
+      price?: string;
+      amount?: string;
+      notes?: string;
+    },
+  ): Promise<void> {
+    await this.page
+      .getByRole('button', { name: new RegExp(`Edit ${originalName}`) })
+      .click();
+    const dialog = this.page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 30000 });
+
+    if (updates.name) {
+      const nameInput = this.page.locator('#item-name');
+      await expect(nameInput).toBeVisible({ timeout: 30000 });
+      await nameInput.fill(updates.name);
+    }
+
+    if (updates.category) {
+      await dialog.getByRole('button', { name: updates.category }).click();
+    }
+
+    if (updates.amount) {
+      await this.page.fill('#item-amount', updates.amount);
+    }
+
+    if (updates.price) {
+      await this.page.fill('#item-price', updates.price);
+    }
+
+    if (updates.notes) {
+      await this.page.fill('#item-notes', updates.notes);
+    }
+
+    const saveBtn = dialog
+      .getByRole('button', { name: /Save/ })
+      .filter({ hasText: /Save/ })
+      .first();
+    await expect(saveBtn).toBeVisible({ timeout: 10000 });
+    await saveBtn.click();
+
+    await expect(dialog).toHaveCount(0, { timeout: 30000 });
+  }
+
+  /**
+   * Toggle the checked state of an item.
+   */
+  async toggleItemChecked(itemName: string): Promise<void> {
+    const checkbox = this.page.getByRole('checkbox', {
+      name: new RegExp(`Toggle ${itemName}`),
+    });
+    await expect(checkbox).toBeVisible({ timeout: 30000 });
+    await checkbox.click();
+  }
+
+  /**
+   * Check if an item is checked.
+   */
+  async isItemChecked(itemName: string): Promise<boolean> {
+    const checkbox = this.page.getByRole('checkbox', {
+      name: new RegExp(`Toggle ${itemName}`),
+    });
+    return await checkbox.isChecked();
+  }
+
+  /**
+   * Delete an item with confirmation.
+   */
+  async deleteItem(itemName: string): Promise<void> {
+    const delBtn = this.page.getByRole('button', {
+      name: new RegExp(`Delete ${itemName}`),
+    });
+    await expect(delBtn).toBeVisible({ timeout: 30000 });
+    await delBtn.click();
+
+    const confirmBtn = this.page.getByRole('button', {
+      name: new RegExp(`Confirm delete ${itemName}`),
+    });
+    await expect(confirmBtn).toBeVisible({ timeout: 10000 });
+    await confirmBtn.click();
+
+    await expect(this.page.getByText(itemName)).toHaveCount(0, {
+      timeout: 30000,
+    });
+  }
+
+  /**
+   * Filter items by category using the category tabs.
+   */
+  async filterByCategory(category: string): Promise<void> {
+    await this.page
+      .getByRole('tab', { name: new RegExp(`Filter by ${category}`) })
+      .click();
+  }
+
+  /**
+   * Reset category filter to show all items.
+   */
+  async showAllItems(): Promise<void> {
+    await this.page.getByRole('tab', { name: 'Show all items' }).click();
+  }
+
+  /**
+   * Verify that an item is visible on the current list.
+   */
+  async assertItemVisible(itemName: string): Promise<void> {
+    await expect(
+      this.page.locator(`[data-testid="item-row-${itemName}"]`).or(
+        this.page
+          .locator('div')
+          .filter({
+            has: this.page.locator(`button[aria-label*="Edit ${itemName}"]`),
+          })
+          .first(),
+      ),
+    ).toBeVisible({ timeout: 30000 });
+  }
+
+  /**
+   * Verify that an item is NOT visible on the current list.
+   */
+  async assertItemNotVisible(itemName: string): Promise<void> {
+    await expect(this.page.getByText(itemName)).toHaveCount(0, {
+      timeout: 10000,
+    });
+  }
+
+  /**
+   * Verify that a specific price value is displayed.
+   */
+  async assertPriceVisible(price: string): Promise<void> {
+    await expect(this.page.getByText(`$${price}`)).toBeVisible({
+      timeout: 30000,
+    });
+  }
+
+  /**
+   * Close any open dialog by pressing Escape.
+   */
+  async closeDialogWithEscape(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+    await expect(this.page.getByRole('dialog')).toHaveCount(0);
+  }
+
+  /**
+   * Verify the page is still usable after closing a dialog.
+   */
+  async assertPageUsable(): Promise<void> {
+    await expect(
+      this.page.getByRole('button', { name: 'New List' }),
+    ).toBeVisible();
+  }
+
+  /**
+   * Navigate back to the main groceries page.
+   */
+  async goBack(): Promise<void> {
+    await this.page.goBack();
+    await this.page.waitForLoadState('networkidle');
+  }
+}

--- a/apps/myorganizer-e2e/src/e2e/helpers/index.ts
+++ b/apps/myorganizer-e2e/src/e2e/helpers/index.ts
@@ -1,0 +1,1 @@
+export { GroceriesPage } from './GroceriesPage';

--- a/apps/myorganizer-e2e/src/e2e/vault-export-import.spec.ts
+++ b/apps/myorganizer-e2e/src/e2e/vault-export-import.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
+import os from 'node:os';
+import path from 'node:path';
 
 /**
  * Section 9 — End-to-end tests for hardened vault export/import.
@@ -116,18 +118,21 @@ function setupBackend(page: Page) {
     mobileNumbers: null,
     subscriptions: null,
     todos: null,
+    groceries: null,
   };
   const serverBlobEtags: Record<string, string> = {
     addresses: 'W/"0"',
     mobileNumbers: 'W/"0"',
     subscriptions: 'W/"0"',
     todos: 'W/"0"',
+    groceries: 'W/"0"',
   };
   const serverBlobUpdatedAt: Record<string, string> = {
     addresses: new Date(0).toISOString(),
     mobileNumbers: new Date(0).toISOString(),
     subscriptions: new Date(0).toISOString(),
     todos: new Date(0).toISOString(),
+    groceries: new Date(0).toISOString(),
   };
 
   const backupRecords: BackupRecord[] = [];
@@ -135,7 +140,7 @@ function setupBackend(page: Page) {
   const loginUrl = /\/auth\/login\/?(\?.*)?$/;
   const vaultMetaUrl = /\/vault\/?(\?.*)?$/;
   const vaultBlobUrl =
-    /\/vault\/blob\/(addresses|mobileNumbers|subscriptions|todos)\/?(\?.*)?$/;
+    /\/vault\/blob\/(addresses|mobileNumbers|subscriptions|todos|groceries)\/?(\?.*)?$/;
   const backupsRecordUrl = /\/vault\/backups\/?(\?.*)?$/;
   const backupsLatestUrl = /\/vault\/backups\/latest\/?(\?.*)?$/;
 
@@ -301,7 +306,9 @@ function setupBackend(page: Page) {
 
     const match = request
       .url()
-      .match(/\/vault\/blob\/(addresses|mobileNumbers|subscriptions|todos)/);
+      .match(
+        /\/vault\/blob\/(addresses|mobileNumbers|subscriptions|todos|groceries)/,
+      );
     const type = match?.[1];
     if (!type) {
       await route.fulfill({ status: 400, headers });
@@ -393,6 +400,71 @@ async function setupVaultWithSampleData(page: Page) {
   await expect(addAddress).toBeEnabled({ timeout: 60000 });
   await addAddress.click();
   await expect(page.getByText('221B Baker Street').first()).toBeVisible({
+    timeout: 60000,
+  });
+
+  return passphrase;
+}
+
+async function setupVaultWithGroceryData(page: Page) {
+  const passphrase = 'correct horse battery staple';
+
+  await gotoStable(page, '/dashboard/addresses');
+  await page.fill('#setup-passphrase', passphrase);
+  await page.fill('#setup-confirm', passphrase);
+  await page.getByRole('button', { name: 'Create encrypted vault' }).click();
+
+  await page.waitForFunction(
+    () => Boolean(window.localStorage.getItem('myorganizer_vault_v1')),
+    undefined,
+    { timeout: 60000 },
+  );
+
+  await unlockWithPassphrase(page, passphrase);
+
+  // Navigate to groceries page and ensure vault is unlocked
+  await gotoStable(page, '/dashboard/groceries');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
+
+  // Check if unlock screen is shown and unlock if needed
+  const unlockButton = page.getByRole('button', { name: 'Use passphrase' });
+  const isLocked = await unlockButton
+    .isVisible({ timeout: 10000 })
+    .catch(() => false);
+
+  if (isLocked) {
+    await unlockWithPassphrase(page, passphrase);
+  }
+
+  // Wait for the groceries page content to render after unlock
+  await page.waitForFunction(
+    () => {
+      const pageContent = document.body.innerText;
+      const hasNewListBtn = !!document
+        .querySelector('button')
+        ?.textContent?.includes('New List');
+      const hasPageTitle =
+        pageContent.includes('Groceries') || pageContent.includes('grocery');
+      return hasNewListBtn || hasPageTitle;
+    },
+    { timeout: 30000 },
+  );
+
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1000);
+
+  // Create a grocery list
+  await page.getByRole('button', { name: 'New List' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.getByPlaceholder('e.g., Weekly Shopping').fill('Backup Test List');
+
+  // Click the create button
+  await page.getByRole('button', { name: 'Create List' }).click();
+
+  // Wait for dialog to close and list to appear
+  await expect(page.getByRole('dialog')).toHaveCount(0, { timeout: 60000 });
+  await expect(page.getByText('Backup Test List')).toBeVisible({
     timeout: 60000,
   });
 
@@ -536,6 +608,146 @@ test.describe('Vault export/import (E2E)', () => {
       window.localStorage.getItem('myorganizer_vault_v1'),
     );
     expect(afterVault).toBe(beforeVault);
+
+    await ctx.close();
+  });
+
+  test('groceries are included in vault export', async ({
+    browser,
+  }, testInfo) => {
+    test.setTimeout(120000);
+
+    const ctx = await browser.newContext({
+      acceptDownloads: true,
+    });
+    const page = await ctx.newPage();
+    setupBackend(page);
+
+    await login(page, {
+      webkitDelayMs: testInfo.project.name === 'webkit' ? 1500 : 0,
+    });
+
+    await setupVaultWithGroceryData(page);
+
+    // Trigger export and capture the downloaded JSON
+    await gotoStable(page, '/dashboard/vault-export');
+    if (
+      await page
+        .locator('#unlock-passphrase')
+        .isVisible({ timeout: 1000 })
+        .catch(() => false)
+    ) {
+      await unlockWithPassphrase(page, 'correct horse battery staple');
+    }
+
+    const exportButton = page.getByTestId('export-vault-button');
+    await expect(exportButton).toBeVisible({ timeout: 60000 });
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      exportButton.click(),
+    ]);
+    const downloadPath = path.join(
+      os.tmpdir(),
+      `vault-export-${Date.now()}.json`,
+    );
+    await download.saveAs(downloadPath);
+    const fs = await import('node:fs/promises');
+    const exportedText = await fs.readFile(downloadPath, 'utf8');
+    const parsed = JSON.parse(exportedText) as {
+      schemaVersion: number;
+      blobs?: Record<string, unknown>;
+      exportId: string;
+      exportedAt: string;
+    };
+
+    // Verify groceries blob is included in export
+    expect(parsed.blobs?.groceries).toBeDefined();
+    expect(parsed.schemaVersion).toBe(1);
+
+    await ctx.close();
+  });
+
+  test('groceries are restored from vault import', async ({
+    browser,
+  }, testInfo) => {
+    test.setTimeout(180000);
+
+    const ctx = await browser.newContext({
+      acceptDownloads: true,
+    });
+    const page = await ctx.newPage();
+    setupBackend(page);
+
+    await login(page, {
+      webkitDelayMs: testInfo.project.name === 'webkit' ? 1500 : 0,
+    });
+
+    await setupVaultWithGroceryData(page);
+
+    // Export vault with groceries
+    await gotoStable(page, '/dashboard/vault-export');
+    if (
+      await page
+        .locator('#unlock-passphrase')
+        .isVisible({ timeout: 1000 })
+        .catch(() => false)
+    ) {
+      await unlockWithPassphrase(page, 'correct horse battery staple');
+    }
+
+    const exportButton = page.getByTestId('export-vault-button');
+    await expect(exportButton).toBeVisible({ timeout: 60000 });
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      exportButton.click(),
+    ]);
+    const downloadPath = path.join(
+      os.tmpdir(),
+      `vault-export-${Date.now()}.json`,
+    );
+    await download.saveAs(downloadPath);
+    const fs = await import('node:fs/promises');
+    const exportedText = await fs.readFile(downloadPath, 'utf8');
+
+    // Reset local vault to simulate a fresh device
+    await page.evaluate(() => {
+      window.localStorage.removeItem('myorganizer_vault_v1');
+    });
+
+    // Reload and perform import
+    await gotoStable(page, '/dashboard/vault-export');
+
+    const importInput = page.getByTestId('import-vault-file');
+    await expect(importInput).toBeVisible({ timeout: 60000 });
+
+    await importInput.setInputFiles({
+      name: 'vault-export.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(exportedText, 'utf8'),
+    });
+
+    const importButton = page.getByTestId('import-vault-button');
+    await expect(importButton).toBeEnabled({ timeout: 60000 });
+    page.once('dialog', (d) => d.accept());
+    await importButton.click();
+
+    // Wait for import to complete and vault to be restored
+    await page.waitForFunction(
+      () => Boolean(window.localStorage.getItem('myorganizer_vault_v1')),
+      undefined,
+      { timeout: 60000 },
+    );
+
+    // Navigate to groceries and verify the list was restored
+    await gotoStable(page, '/dashboard/groceries');
+    await unlockWithPassphrase(page, 'correct horse battery staple');
+
+    // Verify the grocery list is still present
+    await expect(page.getByText('Backup Test List')).toBeVisible({
+      timeout: 60000,
+    });
 
     await ctx.close();
   });


### PR DESCRIPTION
## Why
Add groceries export/import E2E tests and helpers. A follow-up commit refine the branch before merging `feat/issue-99-groceries-e2e-tests` into `main`.

## Changes
- Add groceries support to vault export/import tests (vault-export-import.spec.ts)
- Create GroceriesPage Page Object Model helper for test utilities
- Fix download path handling to use saveAs() instead of download.path()
- Add setupVaultWithGroceryData() fixture helper
- Add two groceries export/import round-trip test cases
- Refs #99
- Create .claude/checklist.md — pre-action decision tree and delegation checklist
- Update CLAUDE.md and AGENTS.md — add mandatory delegation rules table and anti-pattern guidance
- Enforces delegation for E2E (*.spec.ts), Jest (*.test.ts), Storybook (*.stories.tsx), and React component workflows to improve code quality processes

## Validation
- Generated from 2 commit(s) on `feat/issue-99-groceries-e2e-tests`.
- Compared against base branch `main`.
