### PR TITLE
[Slice] Task Management: Tasks page — edit, delete, archive, context filter

### DIFF
--- a/libs/web-vault/src/lib/vault/taskNormalization.test.ts
+++ b/libs/web-vault/src/lib/vault/taskNormalization.test.ts
@@ -1,74 +1,747 @@
 import { normalizeTasks } from './taskNormalization';
 
+jest.mock('@myorganizer/core', () => ({
+  ...jest.requireActual('@myorganizer/core'),
+  randomId: jest.fn().mockReturnValue('generated-id'),
+}));
+
 describe('taskNormalization', () => {
   describe('normalizeTasks', () => {
-    it('returns empty array for non-array input', () => {
+    // --- Input validation and array coercion ---
+
+    it('returns empty array and changed=false for null input', () => {
       const result = normalizeTasks(null);
+      expect(result.value).toEqual([]);
+      expect(result.changed).toBe(false);
+    });
+
+    it('returns empty array and changed=true for non-null non-array input', () => {
+      const result = normalizeTasks({});
       expect(result.value).toEqual([]);
       expect(result.changed).toBe(true);
     });
 
-    it('normalizes valid tasks with all fields', () => {
-      const input = [
-        { id: '1', title: 'Task 1', status: 'pending', archived: false },
-        { id: '2', title: 'Task 2', status: 'in_progress', archived: false },
-      ];
-      const result = normalizeTasks(input);
-      expect(result.value).toEqual(input);
-      expect(result.changed).toBe(false);
-    });
-
-    it('generates id for tasks without id', () => {
-      const input = [{ title: 'Task 1', status: 'pending', archived: false }];
-      const result = normalizeTasks(input);
-      expect(result.value).toHaveLength(1);
-      expect(result.value[0].id).toBeTruthy();
+    it('returns empty array and changed=true for undefined input', () => {
+      const result = normalizeTasks(undefined);
+      expect(result.value).toEqual([]);
       expect(result.changed).toBe(true);
     });
 
-    it('defaults status to pending if invalid', () => {
+    // --- Core field normalization with changed flag ---
+
+    it('preserves fully valid task without changes', () => {
+      const createdAtISO = '2024-01-01T00:00:00.000Z';
       const input = [
-        { id: '1', title: 'Task 1', status: 'invalid', archived: false },
+        {
+          id: '1',
+          title: 'Task 1',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: createdAtISO,
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).toEqual({
+        id: '1',
+        title: 'Task 1',
+        status: 'pending',
+        archived: false,
+        priority: 'medium',
+        createdAt: createdAtISO,
+      });
+      expect(result.changed).toBe(false);
+    });
+
+    it('generates id when missing and marks changed=true', () => {
+      const input = [
+        {
+          title: 'No ID Task',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].id).toBe('generated-id');
+      expect(result.changed).toBe(true);
+    });
+
+    it('defaults missing priority to medium and marks changed=true', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'No Priority',
+          status: 'pending',
+          archived: false,
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].priority).toBe('medium');
+      expect(result.changed).toBe(true);
+    });
+
+    it('defaults invalid priority to medium and marks changed=true', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Invalid Priority',
+          status: 'pending',
+          archived: false,
+          priority: 'urgent',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].priority).toBe('medium');
+      expect(result.changed).toBe(true);
+    });
+
+    it('preserves valid priority value without marking changed', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'High Priority',
+          status: 'pending',
+          archived: false,
+          priority: 'high',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].priority).toBe('high');
+      expect(result.changed).toBe(false);
+    });
+
+    it('preserves low priority without marking changed', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Low Priority',
+          status: 'pending',
+          archived: false,
+          priority: 'low',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].priority).toBe('low');
+      expect(result.changed).toBe(false);
+    });
+
+    it('generates createdAt when missing and marks changed=true', () => {
+      const beforeTime = new Date();
+      const input = [
+        {
+          id: '1',
+          title: 'No CreatedAt',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+        },
+      ];
+      const result = normalizeTasks(input);
+      const afterTime = new Date();
+
+      expect(result.value[0].createdAt).toBeTruthy();
+      expect(typeof result.value[0].createdAt).toBe('string');
+      const createdAtDate = new Date(result.value[0].createdAt);
+      expect(createdAtDate.getTime()).toBeGreaterThanOrEqual(
+        beforeTime.getTime() - 1000,
+      );
+      expect(createdAtDate.getTime()).toBeLessThanOrEqual(
+        afterTime.getTime() + 1000,
+      );
+      expect(result.changed).toBe(true);
+    });
+
+    it('preserves provided createdAt without marking changed', () => {
+      const createdAtISO = '2024-06-01T12:00:00.000Z';
+      const input = [
+        {
+          id: '1',
+          title: 'With CreatedAt',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: createdAtISO,
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].createdAt).toBe(createdAtISO);
+      expect(result.changed).toBe(false);
+    });
+
+    it('defaults invalid status to pending and marks changed=true', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Invalid Status',
+          status: 'invalid',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
       ];
       const result = normalizeTasks(input);
       expect(result.value[0].status).toBe('pending');
       expect(result.changed).toBe(true);
     });
 
-    it('defaults archived to false if missing', () => {
-      const input = [{ id: '1', title: 'Task 1', status: 'pending' }];
+    it('preserves all valid task statuses without marking changed', () => {
+      const statuses = [
+        'pending',
+        'in_progress',
+        'done',
+        'cancelled',
+        'blocked',
+      ];
+      const input = statuses.map((status, idx) => ({
+        id: String(idx),
+        title: `Task ${idx}`,
+        status,
+        archived: false,
+        priority: 'medium',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      })) as Parameters<typeof normalizeTasks>[0];
+
+      const result = normalizeTasks(input);
+      expect(result.value).toHaveLength(5);
+      statuses.forEach((status, idx) => {
+        expect(result.value[idx].status).toBe(status);
+      });
+      expect(result.changed).toBe(false);
+    });
+
+    it('defaults missing archived to false and marks changed=true', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'No Archived',
+          status: 'pending',
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
       const result = normalizeTasks(input);
       expect(result.value[0].archived).toBe(false);
       expect(result.changed).toBe(true);
     });
 
-    it('skips tasks with empty or missing title', () => {
+    it('defaults non-boolean archived to false and marks changed=true', () => {
       const input = [
-        { id: '1', title: 'Task 1', status: 'pending', archived: false },
-        { id: '2', title: '   ', status: 'pending', archived: false },
-        { id: '3', status: 'pending', archived: false },
+        {
+          id: '1',
+          title: 'Non-Boolean Archived',
+          status: 'pending',
+          archived: 'yes',
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
       ];
       const result = normalizeTasks(input);
-      expect(result.value).toHaveLength(1);
+      expect(result.value[0].archived).toBe(false);
       expect(result.changed).toBe(true);
     });
 
-    it('normalizes all valid task statuses', () => {
+    it('preserves boolean archived=true without marking changed', () => {
       const input = [
-        { id: '1', title: 'Pending', status: 'pending', archived: false },
         {
-          id: '2',
-          title: 'In Progress',
-          status: 'in_progress',
-          archived: false,
+          id: '1',
+          title: 'Archived Task',
+          status: 'pending',
+          archived: true,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
         },
-        { id: '3', title: 'Done', status: 'done', archived: false },
-        { id: '4', title: 'Cancelled', status: 'cancelled', archived: false },
-        { id: '5', title: 'Blocked', status: 'blocked', archived: false },
       ];
       const result = normalizeTasks(input);
-      expect(result.value).toHaveLength(5);
+      expect(result.value[0].archived).toBe(true);
       expect(result.changed).toBe(false);
+    });
+
+    it('trims title and marks changed=true when whitespace present', () => {
+      const input = [
+        {
+          id: '1',
+          title: '  Task with Whitespace  ',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].title).toBe('Task with Whitespace');
+      expect(result.changed).toBe(true);
+    });
+
+    // --- Optional fields: description, context, dueDate, estimatedMinutes, updatedAt ---
+
+    it('includes description when provided and non-empty', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'With Description',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          description: 'This is a description',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].description).toBe('This is a description');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits description when not provided', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'No Description',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('description');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits description when empty string', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Empty Description',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          description: '',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('description');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits description when whitespace-only', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Whitespace Description',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          description: '   ',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('description');
+      expect(result.changed).toBe(false);
+    });
+
+    it('trims description when provided', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Trim Description',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          description: '  trimmed desc  ',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].description).toBe('trimmed desc');
+      expect(result.changed).toBe(false);
+    });
+
+    it('includes context when valid (personal)', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Personal Context',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          context: 'personal',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].context).toBe('personal');
+      expect(result.changed).toBe(false);
+    });
+
+    it('includes context when valid (work)', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Work Context',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          context: 'work',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].context).toBe('work');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits context when not provided', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'No Context',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('context');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits context when invalid', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Invalid Context',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          context: 'home',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('context');
+      expect(result.changed).toBe(false);
+    });
+
+    it('includes dueDate when provided', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'With Due Date',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          dueDate: '2024-12-31',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].dueDate).toBe('2024-12-31');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits dueDate when not provided', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'No Due Date',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('dueDate');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits dueDate when empty string', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Empty Due Date',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          dueDate: '',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('dueDate');
+      expect(result.changed).toBe(false);
+    });
+
+    it('includes estimatedMinutes when provided and > 0', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'With Estimate',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          estimatedMinutes: 30,
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].estimatedMinutes).toBe(30);
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits estimatedMinutes when not provided', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'No Estimate',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('estimatedMinutes');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits estimatedMinutes when 0', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Zero Estimate',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          estimatedMinutes: 0,
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('estimatedMinutes');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits estimatedMinutes when negative', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Negative Estimate',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          estimatedMinutes: -5,
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('estimatedMinutes');
+      expect(result.changed).toBe(false);
+    });
+
+    it('includes updatedAt when provided', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'With Updated At',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T12:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0].updatedAt).toBe('2024-06-01T12:00:00.000Z');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits updatedAt when not provided', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'No Updated At',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('updatedAt');
+      expect(result.changed).toBe(false);
+    });
+
+    it('omits updatedAt when empty string', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Empty Updated At',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value[0]).not.toHaveProperty('updatedAt');
+      expect(result.changed).toBe(false);
+    });
+
+    // --- Task filtering and multiple-task scenarios ---
+
+    it('skips tasks with null/falsy item in array', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Task 1',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+        null,
+        {
+          id: '2',
+          title: 'Task 2',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value).toHaveLength(2);
+      expect(result.value[0].id).toBe('1');
+      expect(result.value[1].id).toBe('2');
+      expect(result.changed).toBe(true);
+    });
+
+    it('skips tasks with non-object item in array', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Task 1',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+        'string',
+        {
+          id: '2',
+          title: 'Task 2',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value).toHaveLength(2);
+      expect(result.changed).toBe(true);
+    });
+
+    it('skips tasks with empty string title', () => {
+      const input = [
+        {
+          id: '1',
+          title: '',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value).toHaveLength(0);
+      expect(result.changed).toBe(true);
+    });
+
+    it('skips tasks with whitespace-only title', () => {
+      const input = [
+        {
+          id: '1',
+          title: '   ',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value).toHaveLength(0);
+      expect(result.changed).toBe(true);
+    });
+
+    it('skips tasks with non-string title', () => {
+      const input = [
+        {
+          id: '1',
+          title: 123,
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value).toHaveLength(0);
+      expect(result.changed).toBe(true);
+    });
+
+    it('normalizes mixed valid and invalid tasks correctly', () => {
+      const input = [
+        {
+          id: '1',
+          title: 'Valid Task',
+          status: 'pending',
+          archived: false,
+          priority: 'medium',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+        { id: '2', title: '   ' },
+        {
+          id: '3',
+          title: 'Another Valid',
+          status: 'done',
+          archived: true,
+          priority: 'high',
+          createdAt: '2024-02-01T00:00:00.000Z',
+        },
+        null,
+      ];
+      const result = normalizeTasks(input);
+      expect(result.value).toHaveLength(2);
+      expect(result.value[0].id).toBe('1');
+      expect(result.value[1].id).toBe('3');
+      expect(result.changed).toBe(true);
+    });
+
+    it('combines multiple changed flags when any core field is modified', () => {
+      const input = [
+        {
+          title: '  Title with spaces  ',
+          status: 'invalid',
+          priority: 'urgent',
+          archived: 'yes',
+          priority: 'urgent',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+      const result = normalizeTasks(input);
+      // changed=true because: id generated, title trimmed, status defaulted, priority defaulted, archived defaulted
+      expect(result.changed).toBe(true);
     });
   });
 });

--- a/libs/web-vault/src/lib/vault/taskNormalization.ts
+++ b/libs/web-vault/src/lib/vault/taskNormalization.ts
@@ -19,6 +19,14 @@ function isValidTaskStatus(value: unknown): value is Task['status'] {
   );
 }
 
+function isValidPriority(value: unknown): value is Task['priority'] {
+  return value === 'high' || value === 'medium' || value === 'low';
+}
+
+function isValidContext(value: unknown): value is Task['context'] {
+  return value === 'personal' || value === 'work';
+}
+
 export function normalizeTasks(value: unknown): NormalizeResult<Task[]> {
   if (!Array.isArray(value)) return { value: [], changed: value != null };
 
@@ -31,24 +39,54 @@ export function normalizeTasks(value: unknown): NormalizeResult<Task[]> {
       continue;
     }
 
-    const raw = item as any;
+    const raw = item as Record<string, unknown>;
 
-    const title = toTrimmedString(raw.title);
+    const title = toTrimmedString(raw['title']);
     if (!title) {
       changed = true;
       continue;
     }
 
-    const id = toTrimmedString(raw.id) ?? randomId();
-    const status = isValidTaskStatus(raw.status) ? raw.status : 'pending';
-    const archived = typeof raw.archived === 'boolean' ? raw.archived : false;
+    const rawId = toTrimmedString(raw['id']);
+    const id = rawId ?? randomId();
+    const status = isValidTaskStatus(raw['status']) ? raw['status'] : 'pending';
+    const archived =
+      typeof raw['archived'] === 'boolean' ? raw['archived'] : false;
+    const priority = isValidPriority(raw['priority'])
+      ? raw['priority']
+      : 'medium';
+    const createdAt =
+      typeof raw['createdAt'] === 'string' && raw['createdAt']
+        ? raw['createdAt']
+        : new Date().toISOString();
 
-    const next: Task = { id, title, status, archived };
+    const next: Task = { id, title, status, archived, priority, createdAt };
 
-    if (next.id !== raw.id) changed = true;
-    if (next.title !== raw.title) changed = true;
-    if (next.status !== raw.status) changed = true;
-    if (next.archived !== raw.archived) changed = true;
+    if (typeof raw['description'] === 'string' && raw['description'].trim()) {
+      next.description = raw['description'].trim();
+    }
+    if (isValidContext(raw['context'])) {
+      next.context = raw['context'];
+    }
+    if (typeof raw['dueDate'] === 'string' && raw['dueDate']) {
+      next.dueDate = raw['dueDate'];
+    }
+    if (
+      typeof raw['estimatedMinutes'] === 'number' &&
+      raw['estimatedMinutes'] > 0
+    ) {
+      next.estimatedMinutes = raw['estimatedMinutes'];
+    }
+    if (typeof raw['updatedAt'] === 'string' && raw['updatedAt']) {
+      next.updatedAt = raw['updatedAt'];
+    }
+
+    if (rawId !== id) changed = true;
+    if (raw['title'] !== title) changed = true;
+    if (raw['status'] !== status) changed = true;
+    if (raw['archived'] !== archived) changed = true;
+    if (raw['priority'] !== priority) changed = true;
+    if (!raw['createdAt']) changed = true;
 
     normalized.push(next);
   }

--- a/libs/web/pages/tasks/src/components/TasksPageClient.test.tsx
+++ b/libs/web/pages/tasks/src/components/TasksPageClient.test.tsx
@@ -31,20 +31,27 @@ jest.mock('@myorganizer/web-ui', () => ({
 }));
 
 jest.mock('./task-form', () => ({
-  __esModule: true,
-  default: ({
-    onAddTask,
+  TaskForm: ({
+    onSubmit,
   }: {
-    onAddTask: (v: {
+    onSubmit: (v: {
       title: string;
       priority: 'high' | 'medium' | 'low';
+      status: 'pending' | 'in_progress' | 'done' | 'cancelled' | 'blocked';
+      description?: string;
+      context?: 'personal' | 'work';
       dueDate?: string;
     }) => void;
   }) => (
     <button
       data-testid="add-task-btn"
       onClick={() =>
-        onAddTask({ title: 'New Task', priority: 'high', dueDate: undefined })
+        onSubmit({
+          title: 'New Task',
+          priority: 'high',
+          status: 'pending',
+          dueDate: undefined,
+        })
       }
     >
       Add Task
@@ -57,9 +64,13 @@ jest.mock('./task-item', () => ({
   default: ({
     task,
     onDeleteTask,
+    onEditTask,
+    onArchiveTask,
   }: {
     task: { id: string; title: string; priority: string };
     onDeleteTask: (id: string) => void;
+    onEditTask: (id: string) => void;
+    onArchiveTask: (id: string) => void;
   }) => (
     <div data-testid={`task-${task.id}`}>
       <h3>{task.title}</h3>
@@ -70,8 +81,79 @@ jest.mock('./task-item', () => ({
       >
         Delete
       </button>
+      <button
+        data-testid={`edit-${task.id}`}
+        onClick={() => onEditTask(task.id)}
+      >
+        Edit
+      </button>
+      <button
+        data-testid={`archive-${task.id}`}
+        onClick={() => onArchiveTask(task.id)}
+      >
+        Archive
+      </button>
     </div>
   ),
+}));
+
+jest.mock('./task-edit-dialog', () => ({
+  TaskEditDialog: ({
+    task,
+    isOpen,
+    onSave,
+    onClose,
+  }: {
+    task: { id: string; title: string } | null;
+    isOpen: boolean;
+    onSave: (id: string, values: object) => void;
+    onClose: () => void;
+  }) =>
+    isOpen && task ? (
+      <div data-testid="edit-dialog">
+        <span data-testid="editing-task-title">{task.title}</span>
+        <button
+          data-testid="save-edit-btn"
+          onClick={() =>
+            onSave(task.id, {
+              title: 'Updated Title',
+              priority: 'low',
+              status: 'done',
+            })
+          }
+        >
+          Save
+        </button>
+        <button data-testid="close-edit-btn" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+jest.mock('./task-delete-dialog', () => ({
+  TaskDeleteDialog: ({
+    task,
+    isOpen,
+    onConfirm,
+    onClose,
+  }: {
+    task: { id: string; title: string } | null;
+    isOpen: boolean;
+    onConfirm: () => void;
+    onClose: () => void;
+  }) =>
+    isOpen && task ? (
+      <div data-testid="delete-dialog">
+        <span data-testid="deleting-task-title">{task.title}</span>
+        <button data-testid="confirm-delete-btn" onClick={onConfirm}>
+          Confirm
+        </button>
+        <button data-testid="cancel-delete-btn" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    ) : null,
 }));
 
 const mockLoadDecryptedData = loadDecryptedData as jest.Mock;
@@ -91,6 +173,8 @@ describe('TasksPageClient', () => {
         id: 't1',
         title: 'Task 1',
         priority: 'medium',
+        status: 'pending',
+        archived: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       } as Task,
     ]);
@@ -109,6 +193,8 @@ describe('TasksPageClient', () => {
             id: t.id,
             title: t.todo,
             priority: 'medium' as const,
+            status: 'pending' as const,
+            archived: false,
             createdAt: '2024-01-01T00:00:00.000Z',
           }))
         : [],
@@ -121,6 +207,8 @@ describe('TasksPageClient', () => {
         id: 't1',
         title: 'Task One',
         priority: 'medium',
+        status: 'pending',
+        archived: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
@@ -152,6 +240,8 @@ describe('TasksPageClient', () => {
         id: 'todo1',
         title: 'Migrate me',
         priority: 'medium',
+        status: 'pending',
+        archived: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
@@ -217,7 +307,14 @@ describe('TasksPageClient', () => {
       { id: 't1', title: 'Task One', priority: 'high', createdAt: '...' },
     ];
     const normalizedTasks: Task[] = [
-      { id: 't1', title: 'Task One', priority: 'high', createdAt: '...' },
+      {
+        id: 't1',
+        title: 'Task One',
+        priority: 'high',
+        status: 'pending',
+        archived: false,
+        createdAt: '...',
+      },
     ];
     mockLoadDecryptedData.mockResolvedValue(rawTasks);
     mockNormalizeTasks.mockReturnValue({
@@ -240,18 +337,24 @@ describe('TasksPageClient', () => {
         id: 'low',
         title: 'Low Priority',
         priority: 'low',
+        status: 'pending',
+        archived: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       },
       {
         id: 'high',
         title: 'High Priority',
         priority: 'high',
+        status: 'pending',
+        archived: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       },
       {
         id: 'medium',
         title: 'Medium Priority',
         priority: 'medium',
+        status: 'pending',
+        archived: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
@@ -303,6 +406,8 @@ describe('TasksPageClient', () => {
       id: 't1',
       title: 'Task to delete',
       priority: 'medium',
+      status: 'pending',
+      archived: false,
       createdAt: '2024-01-01T00:00:00.000Z',
     };
     mockLoadDecryptedData.mockResolvedValue([task]);
@@ -317,8 +422,377 @@ describe('TasksPageClient', () => {
     fireEvent.click(screen.getByTestId('delete-t1'));
 
     await waitFor(() => {
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('confirm-delete-btn'));
+
+    await waitFor(() => {
       expect(mockSaveEncryptedData).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'tasks', value: [] }),
+      );
+    });
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Task deleted' }),
+      );
+    });
+  });
+
+  it('should open edit dialog and save edit with updatedAt', async () => {
+    const task: Task = {
+      id: 't1',
+      title: 'Task to edit',
+      priority: 'high',
+      status: 'pending',
+      archived: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    mockLoadDecryptedData.mockResolvedValue([task]);
+    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('edit-t1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('editing-task-title')).toHaveTextContent(
+        'Task to edit',
+      );
+    });
+
+    fireEvent.click(screen.getByTestId('save-edit-btn'));
+
+    await waitFor(() => {
+      expect(mockSaveEncryptedData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tasks',
+          value: expect.arrayContaining([
+            expect.objectContaining({
+              id: 't1',
+              title: 'Updated Title',
+              priority: 'low',
+              status: 'done',
+              updatedAt: expect.any(String),
+            }),
+          ]),
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Task updated' }),
+      );
+    });
+  });
+
+  it('should close edit dialog when close button clicked', async () => {
+    const task: Task = {
+      id: 't1',
+      title: 'Task to edit',
+      priority: 'high',
+      status: 'pending',
+      archived: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    mockLoadDecryptedData.mockResolvedValue([task]);
+    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('edit-t1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-dialog')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('close-edit-btn'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('edit-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should archive task with archived:true and updatedAt', async () => {
+    const task: Task = {
+      id: 't1',
+      title: 'Task to archive',
+      priority: 'medium',
+      status: 'pending',
+      archived: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    mockLoadDecryptedData.mockResolvedValue([task]);
+    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('archive-t1'));
+
+    await waitFor(() => {
+      expect(mockSaveEncryptedData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tasks',
+          value: expect.arrayContaining([
+            expect.objectContaining({
+              id: 't1',
+              archived: true,
+              updatedAt: expect.any(String),
+            }),
+          ]),
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Task archived' }),
+      );
+    });
+  });
+
+  it('should hide archived tasks by default', async () => {
+    const tasks: Task[] = [
+      {
+        id: 't1',
+        title: 'Active task',
+        priority: 'medium',
+        status: 'pending',
+        archived: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 't2',
+        title: 'Archived task',
+        priority: 'medium',
+        status: 'done',
+        archived: true,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+    mockLoadDecryptedData.mockResolvedValue(tasks);
+    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Active task')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Archived task')).not.toBeInTheDocument();
+  });
+
+  it('should show archived tasks when "Show Archived" button clicked', async () => {
+    const tasks: Task[] = [
+      {
+        id: 't1',
+        title: 'Active task',
+        priority: 'medium',
+        status: 'pending',
+        archived: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 't2',
+        title: 'Archived task',
+        priority: 'medium',
+        status: 'done',
+        archived: true,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+    mockLoadDecryptedData.mockResolvedValue(tasks);
+    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Active task')).toBeInTheDocument();
+    });
+
+    const showArchivedBtn = screen.getByRole('button', {
+      name: 'Show Archived',
+    });
+    fireEvent.click(showArchivedBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Archived task')).toBeInTheDocument();
+    });
+  });
+
+  it('should filter tasks by context: "Personal" button shows only personal tasks', async () => {
+    const tasks: Task[] = [
+      {
+        id: 't1',
+        title: 'Personal task',
+        priority: 'medium',
+        status: 'pending',
+        context: 'personal',
+        archived: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 't2',
+        title: 'Work task',
+        priority: 'medium',
+        status: 'pending',
+        context: 'work',
+        archived: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+    mockLoadDecryptedData.mockResolvedValue(tasks);
+    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Personal task')).toBeInTheDocument();
+      expect(screen.getByText('Work task')).toBeInTheDocument();
+    });
+
+    const personalBtn = screen.getByRole('button', { name: 'Personal' });
+    fireEvent.click(personalBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Personal task')).toBeInTheDocument();
+      expect(screen.queryByText('Work task')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should filter tasks by context: "Work" button shows only work tasks', async () => {
+    const tasks: Task[] = [
+      {
+        id: 't1',
+        title: 'Personal task',
+        priority: 'medium',
+        status: 'pending',
+        context: 'personal',
+        archived: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 't2',
+        title: 'Work task',
+        priority: 'medium',
+        status: 'pending',
+        context: 'work',
+        archived: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+    mockLoadDecryptedData.mockResolvedValue(tasks);
+    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Personal task')).toBeInTheDocument();
+      expect(screen.getByText('Work task')).toBeInTheDocument();
+    });
+
+    const workBtn = screen.getByRole('button', { name: 'Work' });
+    fireEvent.click(workBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Personal task')).not.toBeInTheDocument();
+      expect(screen.getByText('Work task')).toBeInTheDocument();
+    });
+  });
+
+  it('should show all non-archived tasks when "All" filter button clicked', async () => {
+    const tasks: Task[] = [
+      {
+        id: 't1',
+        title: 'Personal task',
+        priority: 'medium',
+        status: 'pending',
+        context: 'personal',
+        archived: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 't2',
+        title: 'Work task',
+        priority: 'medium',
+        status: 'pending',
+        context: 'work',
+        archived: false,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+    mockLoadDecryptedData.mockResolvedValue(tasks);
+    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Personal task')).toBeInTheDocument();
+      expect(screen.getByText('Work task')).toBeInTheDocument();
+    });
+
+    const personalBtn = screen.getByRole('button', { name: 'Personal' });
+    fireEvent.click(personalBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Work task')).not.toBeInTheDocument();
+    });
+
+    const allBtn = screen.getByRole('button', { name: 'All' });
+    fireEvent.click(allBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Personal task')).toBeInTheDocument();
+      expect(screen.getByText('Work task')).toBeInTheDocument();
+    });
+  });
+
+  it('should show destructive toast on save failure', async () => {
+    const task: Task = {
+      id: 't1',
+      title: 'Task to edit',
+      priority: 'high',
+      status: 'pending',
+      archived: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    mockLoadDecryptedData.mockResolvedValue([task]);
+    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
+    mockSaveEncryptedData.mockRejectedValueOnce(new Error('Save failed'));
+
+    render(<TasksPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('edit-t1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-dialog')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('save-edit-btn'));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to save',
+          description: 'Save failed',
+          variant: 'destructive',
+        }),
       );
     });
   });

--- a/libs/web/pages/tasks/src/components/TasksPageClient.tsx
+++ b/libs/web/pages/tasks/src/components/TasksPageClient.tsx
@@ -13,7 +13,9 @@ import {
 import { VaultGate } from '@myorganizer/web-vault-ui';
 import { useCallback, useEffect, useState } from 'react';
 
-import TaskForm from './task-form';
+import { TaskDeleteDialog } from './task-delete-dialog';
+import { TaskEditDialog } from './task-edit-dialog';
+import { TaskForm } from './task-form';
 import TaskItem from './task-item';
 
 const PRIORITY_ORDER: Record<TaskPriority, number> = {
@@ -36,6 +38,12 @@ function sortTasks(tasks: Task[]): Task[] {
 function TasksInner(props: { masterKeyBytes: Uint8Array }) {
   const { toast } = useToast();
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [deletingTask, setDeletingTask] = useState<Task | null>(null);
+  const [showArchived, setShowArchived] = useState(false);
+  const [contextFilter, setContextFilter] = useState<
+    'all' | 'personal' | 'work'
+  >('all');
 
   useEffect(() => {
     loadDecryptedData<unknown>({
@@ -109,14 +117,21 @@ function TasksInner(props: { masterKeyBytes: Uint8Array }) {
   const handleAddTask = useCallback(
     async (formData: {
       title: string;
+      description?: string;
       priority: TaskPriority;
+      status: Task['status'];
+      context?: Task['context'];
       dueDate?: string;
     }) => {
       const newTask: Task = {
         id: randomId(),
         title: formData.title,
+        description: formData.description,
         priority: formData.priority,
-        dueDate: formData.dueDate || undefined,
+        status: formData.status,
+        context: formData.context,
+        dueDate: formData.dueDate,
+        archived: false,
         createdAt: new Date().toISOString(),
       };
       await persist([newTask, ...tasks]);
@@ -128,39 +143,151 @@ function TasksInner(props: { masterKeyBytes: Uint8Array }) {
     [persist, tasks, toast],
   );
 
-  const handleDeleteTask = useCallback(
-    async (id: string) => {
-      const next = tasks.filter((t) => t.id !== id);
+  const handleRequestDelete = useCallback(
+    (id: string) => {
+      const task = tasks.find((t) => t.id === id);
+      if (task) setDeletingTask(task);
+    },
+    [tasks],
+  );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deletingTask) return;
+    const next = tasks.filter((t) => t.id !== deletingTask.id);
+    await persist(next);
+    toast({
+      title: 'Task deleted',
+      description: 'Your task has been deleted.',
+    });
+    setDeletingTask(null);
+  }, [deletingTask, tasks, persist, toast]);
+
+  const handleRequestEdit = useCallback(
+    (id: string) => {
+      const task = tasks.find((t) => t.id === id);
+      if (task) setEditingTask(task);
+    },
+    [tasks],
+  );
+
+  const handleSaveEdit = useCallback(
+    async (
+      taskId: string,
+      values: {
+        title: string;
+        description?: string;
+        priority: Task['priority'];
+        status: Task['status'];
+        context?: Task['context'];
+        dueDate?: string;
+      },
+    ) => {
+      const next = tasks.map((t) =>
+        t.id === taskId
+          ? {
+              ...t,
+              ...values,
+              updatedAt: new Date().toISOString(),
+            }
+          : t,
+      );
       await persist(next);
       toast({
-        title: 'Task deleted',
-        description: 'Your task has been deleted.',
+        title: 'Task updated',
+        description: 'Changes saved (encrypted).',
+      });
+      setEditingTask(null);
+    },
+    [tasks, persist, toast],
+  );
+
+  const handleArchiveTask = useCallback(
+    async (id: string) => {
+      const next = tasks.map((t) =>
+        t.id === id
+          ? { ...t, archived: true, updatedAt: new Date().toISOString() }
+          : t,
+      );
+      await persist(next);
+      toast({
+        title: 'Task archived',
+        description: 'Task moved to archive.',
       });
     },
     [tasks, persist, toast],
   );
+
+  const displayedTasks = tasks.filter((t) => {
+    if (!showArchived && t.archived) return false;
+    if (contextFilter !== 'all' && t.context !== contextFilter) return false;
+    return true;
+  });
 
   return (
     <div className="flex sm:flex-row flex-col sm:justify-between gap-2 flex-1 p-2 pt-0">
       <div className="sm:w-1/2 w-full p-3 bg-slate-100 rounded-lg">
         <h2 className="text-center text-lg pt-3 font-semibold">Create task</h2>
         <div className="mt-8">
-          <TaskForm onAddTask={handleAddTask} />
+          <TaskForm onSubmit={handleAddTask} />
         </div>
       </div>
 
       <div className="sm:w-1/2 w-full rounded-lg border bg-white">
-        <h2 className="text-center text-lg pt-3 font-semibold">Task List</h2>
+        <div className="flex items-center justify-between px-3 pt-3">
+          <h2 className="text-lg font-semibold">Task List</h2>
+          <div className="flex items-center gap-2">
+            {(['all', 'personal', 'work'] as const).map((ctx) => (
+              <button
+                key={ctx}
+                onClick={() => setContextFilter(ctx)}
+                className={`text-xs px-2 py-1 rounded border ${
+                  contextFilter === ctx
+                    ? 'bg-slate-800 text-white border-slate-800'
+                    : 'bg-white text-slate-700 border-slate-300'
+                }`}
+              >
+                {ctx === 'all'
+                  ? 'All'
+                  : ctx.charAt(0).toUpperCase() + ctx.slice(1)}
+              </button>
+            ))}
+            <button
+              onClick={() => setShowArchived((v) => !v)}
+              className={`text-xs px-2 py-1 rounded border ${
+                showArchived
+                  ? 'bg-slate-800 text-white border-slate-800'
+                  : 'bg-white text-slate-700 border-slate-300'
+              }`}
+            >
+              {showArchived ? 'Hide Archived' : 'Show Archived'}
+            </button>
+          </div>
+        </div>
         <div className="py-3 space-y-2 px-3">
-          {tasks.map((task) => (
+          {displayedTasks.map((task) => (
             <TaskItem
               key={task.id}
               task={task}
-              onDeleteTask={handleDeleteTask}
+              onDeleteTask={handleRequestDelete}
+              onEditTask={handleRequestEdit}
+              onArchiveTask={handleArchiveTask}
             />
           ))}
         </div>
       </div>
+
+      <TaskEditDialog
+        task={editingTask}
+        isOpen={editingTask !== null}
+        onClose={() => setEditingTask(null)}
+        onSave={handleSaveEdit}
+      />
+      <TaskDeleteDialog
+        task={deletingTask}
+        isOpen={deletingTask !== null}
+        onClose={() => setDeletingTask(null)}
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   );
 }

--- a/libs/web/pages/tasks/src/components/task-delete-dialog.tsx
+++ b/libs/web/pages/tasks/src/components/task-delete-dialog.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import type { Task } from '@myorganizer/core';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@myorganizer/web-ui';
+import { AlertTriangle } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+interface TaskDeleteDialogProps {
+  task: Task | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}
+
+export function TaskDeleteDialog({
+  task,
+  isOpen,
+  onClose,
+  onConfirm,
+}: TaskDeleteDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleConfirm = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await onConfirm();
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [onConfirm]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!task) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={!isDeleting}>
+        <div className="mb-4 flex items-center justify-center">
+          <div className="rounded-full bg-red-100 p-3">
+            <AlertTriangle className="h-6 w-6 text-red-600" />
+          </div>
+        </div>
+        <DialogHeader>
+          <DialogTitle>Delete "{task.title}"?</DialogTitle>
+          <DialogDescription>
+            This action cannot be undone. The task will be permanently deleted.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isDeleting}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isDeleting}
+          >
+            {isDeleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/libs/web/pages/tasks/src/components/task-edit-dialog.tsx
+++ b/libs/web/pages/tasks/src/components/task-edit-dialog.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import type { Task } from '@myorganizer/core';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@myorganizer/web-ui';
+import { useCallback, useState } from 'react';
+import { TaskForm } from './task-form';
+
+interface TaskEditDialogProps {
+  task: Task | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (
+    taskId: string,
+    values: {
+      title: string;
+      description?: string;
+      priority: Task['priority'];
+      status: Task['status'];
+      context?: Task['context'];
+      dueDate?: string;
+    },
+  ) => Promise<void>;
+}
+
+export function TaskEditDialog({
+  task,
+  isOpen,
+  onClose,
+  onSave,
+}: TaskEditDialogProps) {
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = useCallback(
+    async (values: {
+      title: string;
+      description?: string;
+      priority: Task['priority'];
+      status: Task['status'];
+      context?: Task['context'];
+      dueDate?: string;
+    }) => {
+      if (!task) return;
+      setIsSaving(true);
+      try {
+        await onSave(task.id, values);
+        onClose();
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [task, onSave, onClose],
+  );
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!task) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={!isSaving}>
+        <DialogHeader>
+          <DialogTitle>Edit Task</DialogTitle>
+          <DialogDescription>Update the task details below</DialogDescription>
+        </DialogHeader>
+        <TaskForm
+          initialValues={{
+            title: task.title,
+            description: task.description,
+            priority: task.priority,
+            status: task.status,
+            context: task.context,
+            dueDate: task.dueDate,
+          }}
+          onSubmit={handleSave}
+          submitLabel="Save Changes"
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/libs/web/pages/tasks/src/components/task-form.tsx
+++ b/libs/web/pages/tasks/src/components/task-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -19,44 +19,83 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@myorganizer/web-ui';
-import { TaskPriority } from '@myorganizer/core';
+import { TaskPriority, TaskStatus, TaskContext } from '@myorganizer/core';
 
 interface TaskFormProps {
-  onAddTask: (values: {
+  onSubmit: (values: {
     title: string;
+    description?: string;
     priority: TaskPriority;
+    status: TaskStatus;
+    context?: TaskContext;
     dueDate?: string;
   }) => void;
+  initialValues?: {
+    title?: string;
+    description?: string;
+    priority?: TaskPriority;
+    status?: TaskStatus;
+    context?: TaskContext;
+    dueDate?: string;
+  };
+  submitLabel?: string;
 }
 
 const taskFormSchema = z.object({
   title: z.string().min(1, 'Title is required'),
+  description: z.string().optional(),
   priority: z.enum(['high', 'medium', 'low']),
+  status: z.enum(['pending', 'in_progress', 'done', 'cancelled', 'blocked']),
+  context: z.string().optional(),
   dueDate: z.string().optional(),
 });
 
 type TaskFormValues = z.infer<typeof taskFormSchema>;
 
-export default function TaskForm({ onAddTask }: TaskFormProps) {
+export function TaskForm({
+  onSubmit,
+  initialValues,
+  submitLabel = 'Add Task',
+}: TaskFormProps) {
   const form = useForm<TaskFormValues>({
     resolver: zodResolver(taskFormSchema),
     defaultValues: {
-      title: '',
-      priority: 'medium',
-      dueDate: '',
+      title: initialValues?.title ?? '',
+      description: initialValues?.description ?? '',
+      priority: initialValues?.priority ?? 'medium',
+      status: initialValues?.status ?? 'pending',
+      context: initialValues?.context ?? '',
+      dueDate: initialValues?.dueDate ?? '',
     },
   });
 
+  useEffect(() => {
+    form.reset({
+      title: initialValues?.title ?? '',
+      description: initialValues?.description ?? '',
+      priority: initialValues?.priority ?? 'medium',
+      status: initialValues?.status ?? 'pending',
+      context: initialValues?.context ?? '',
+      dueDate: initialValues?.dueDate ?? '',
+    });
+  }, [initialValues, form]);
+
   const handleSubmit = useCallback(
     (values: TaskFormValues) => {
-      onAddTask({
+      const payload = {
         title: values.title,
+        description: values.description || undefined,
         priority: values.priority,
+        status: values.status as TaskStatus,
+        context: (values.context || undefined) as TaskContext | undefined,
         dueDate: values.dueDate || undefined,
-      });
-      form.reset();
+      };
+      onSubmit(payload);
+      if (!initialValues) {
+        form.reset();
+      }
     },
-    [onAddTask, form],
+    [onSubmit, form, initialValues],
   );
 
   return (
@@ -70,6 +109,20 @@ export default function TaskForm({ onAddTask }: TaskFormProps) {
               <FormLabel>Title</FormLabel>
               <FormControl>
                 <Input placeholder="Enter task title" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Input placeholder="Enter task description" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -101,6 +154,54 @@ export default function TaskForm({ onAddTask }: TaskFormProps) {
 
         <FormField
           control={form.control}
+          name="status"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Status</FormLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="pending">Pending</SelectItem>
+                  <SelectItem value="in_progress">In Progress</SelectItem>
+                  <SelectItem value="done">Done</SelectItem>
+                  <SelectItem value="cancelled">Cancelled</SelectItem>
+                  <SelectItem value="blocked">Blocked</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="context"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Context</FormLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="">None</SelectItem>
+                  <SelectItem value="personal">Personal</SelectItem>
+                  <SelectItem value="work">Work</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
           name="dueDate"
           render={({ field }) => (
             <FormItem>
@@ -113,7 +214,7 @@ export default function TaskForm({ onAddTask }: TaskFormProps) {
           )}
         />
 
-        <Button type="submit">Add Task</Button>
+        <Button type="submit">{submitLabel}</Button>
       </form>
     </Form>
   );

--- a/libs/web/pages/tasks/src/components/task-item.tsx
+++ b/libs/web/pages/tasks/src/components/task-item.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { Task } from '@myorganizer/core';
-import { TrashIcon } from 'lucide-react';
+import { Task, TaskStatus } from '@myorganizer/core';
+import { ArchiveIcon, PencilIcon, TrashIcon } from 'lucide-react';
 import { useCallback } from 'react';
 
 interface TaskItemProps {
   task: Task;
   onDeleteTask: (id: string) => void;
+  onEditTask: (id: string) => void;
+  onArchiveTask: (id: string) => void;
 }
 
 const priorityStyles: Record<Task['priority'], string> = {
@@ -15,27 +17,92 @@ const priorityStyles: Record<Task['priority'], string> = {
   low: 'bg-green-100 text-green-700',
 };
 
-const TaskItem = ({ task, onDeleteTask }: TaskItemProps) => {
+const contextStyles: Record<string, string> = {
+  personal: 'bg-blue-100 text-blue-700',
+  work: 'bg-purple-100 text-purple-700',
+};
+
+const statusLabels: Record<TaskStatus, string> = {
+  pending: 'Pending',
+  in_progress: 'In Progress',
+  done: 'Done',
+  cancelled: 'Cancelled',
+  blocked: 'Blocked',
+};
+
+const TaskItem = ({
+  task,
+  onDeleteTask,
+  onEditTask,
+  onArchiveTask,
+}: TaskItemProps) => {
+  const handleEditTask = useCallback(() => {
+    onEditTask(task.id);
+  }, [task.id, onEditTask]);
+
+  const handleArchiveTask = useCallback(() => {
+    onArchiveTask(task.id);
+  }, [task.id, onArchiveTask]);
+
   const handleDeleteTask = useCallback(() => {
     onDeleteTask(task.id);
   }, [task.id, onDeleteTask]);
 
+  const containerClasses = task.archived
+    ? 'opacity-70 flex items-center justify-between gap-2 border border-gray-200 rounded-lg p-3 hover:bg-gray-200'
+    : 'flex items-center justify-between gap-2 border border-gray-200 rounded-lg p-3 hover:bg-gray-200';
+
   return (
-    <div className="flex items-center justify-between gap-2 border border-gray-200 rounded-lg p-3 hover:bg-gray-200">
+    <div className={containerClasses}>
       <div className="flex-1">
-        <h3 className="text-lg">{task.title}</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg">{task.title}</h3>
+          {task.archived && (
+            <span className="text-xs px-2 py-1 rounded bg-gray-200 text-gray-600">
+              Archived
+            </span>
+          )}
+        </div>
         <div className="flex items-center gap-2 mt-2">
           <span
             className={`text-xs px-2 py-1 rounded ${priorityStyles[task.priority]}`}
           >
             {task.priority}
           </span>
+          {task.context && (
+            <span
+              className={`text-xs px-2 py-1 rounded ${contextStyles[task.context] || 'bg-gray-100 text-gray-700'}`}
+            >
+              {task.context}
+            </span>
+          )}
+          {task.status !== 'pending' && (
+            <span className="text-xs text-gray-600">
+              {statusLabels[task.status]}
+            </span>
+          )}
           {task.dueDate && (
             <span className="text-xs text-gray-600">Due: {task.dueDate}</span>
           )}
         </div>
       </div>
       <div className="flex flex-row items-center justify-between gap-2">
+        <button
+          aria-label="Edit task"
+          className="cursor-pointer"
+          onClick={handleEditTask}
+        >
+          <PencilIcon />
+        </button>
+        {!task.archived && (
+          <button
+            aria-label="Archive task"
+            className="cursor-pointer"
+            onClick={handleArchiveTask}
+          >
+            <ArchiveIcon />
+          </button>
+        )}
         <button
           aria-label="Delete task"
           className="cursor-pointer"


### PR DESCRIPTION
Closes #122

Part of `feat/task-management` — see PRD #119.

## Changes
- Add `TaskEditDialog` component (pre-populated RHF form for all Task fields)
- Add `TaskDeleteDialog` component (AlertDialog confirmation before permanent delete)
- Update `TasksPageClient` with edit/archive/delete handlers and context filter (all/personal/work)
- Update `TaskItem` to surface edit, archive, and delete actions
- `updatedAt` set on every edit and archive operation
- Extend component integration tests to cover all new interactions