### PR TITLE
docs(mobile): record phase-1 RN decisions and domain glossary

### DIFF
--- a/.sandcastle/dispatch-waves.mts
+++ b/.sandcastle/dispatch-waves.mts
@@ -1,0 +1,242 @@
+/**
+ * dispatch-waves — autonomous, dependency-aware driver around dispatch-agents.
+ *
+ * The base orchestrator (.sandcastle/main.mts) dispatches every ready AFK slice
+ * for a PRD IN PARALLEL, each branched from the feature branch at run-start, and
+ * squash-merges every finished slice PR back into the feature branch. Siblings in
+ * the same run therefore never see each other's work — only a *later* run, which
+ * re-branches from the updated feature branch, does.
+ *
+ * This driver exploits that: it topologically sorts the PRD's slices by their
+ * `## Blocked by` sections into dependency waves, then runs ONE dispatch-agents
+ * pass per wave — gating the `ready-for-agent` label so only the current wave is
+ * picked up. Each wave's auto-merged output becomes the base for the next wave.
+ * No human interaction between waves.
+ *
+ * Usage: npx tsx .sandcastle/dispatch-waves.mts --prd <issue-number>
+ */
+import { spawnSync } from 'node:child_process';
+
+const REPO = 'mnaimfaizy/myorganizer';
+
+function fail(message: string, code = 1): never {
+  console.error(`\nError: ${message}`);
+  process.exit(code);
+}
+
+function ghJson<T>(args: string[]): T {
+  const r = spawnSync('gh', args, { encoding: 'utf8', windowsHide: true });
+  if (r.error) fail(`gh error: ${r.error.message}`);
+  if (r.status !== 0) fail(`gh failed: ${r.stderr.trim()}`);
+  return JSON.parse(r.stdout) as T;
+}
+
+function ghSilent(args: string[]): void {
+  spawnSync('gh', args, { encoding: 'utf8', stdio: 'pipe', windowsHide: true });
+}
+
+// ─── Parse --prd <N> ─────────────────────────────────────────────────────────
+
+const prdFlag = process.argv.indexOf('--prd');
+if (prdFlag === -1 || !process.argv[prdFlag + 1]) {
+  fail('Usage: npx tsx .sandcastle/dispatch-waves.mts --prd <issue-number>');
+}
+const prdNumber = parseInt(process.argv[prdFlag + 1], 10);
+if (isNaN(prdNumber)) fail('--prd must be a number.');
+
+// ─── Fetch all AFK slices for this PRD ────────────────────────────────────────
+
+type Issue = {
+  number: number;
+  title: string;
+  labels: Array<{ name: string }>;
+  body: string;
+  state: string;
+};
+
+function fetchSlices(): Issue[] {
+  const all = ghJson<Issue[]>([
+    'issue',
+    'list',
+    '--repo',
+    REPO,
+    '--label',
+    'type:afk',
+    '--state',
+    'open',
+    '--json',
+    'number,title,labels,body,state',
+    '--limit',
+    '100',
+  ]);
+  return all.filter((i) => i.body?.includes(`PRD: #${prdNumber}`));
+}
+
+const slices = fetchSlices();
+if (slices.length === 0) {
+  fail(
+    `No open AFK slice issues found for PRD #${prdNumber}.\n` +
+      `Flip any HITL slices to type:afk, or run /to-issues ${prdNumber} first.`,
+  );
+}
+
+const sliceNumbers = new Set(slices.map((s) => s.number));
+
+// ─── Parse `## Blocked by` → dependency edges (within this PRD only) ──────────
+
+function blockersOf(issue: Issue): number[] {
+  const m = issue.body.match(/##\s*Blocked by([\s\S]*?)(?:\n##\s|$)/i);
+  if (!m) return [];
+  const section = m[1];
+  const refs = [...section.matchAll(/#(\d+)/g)].map((x) => parseInt(x[1], 10));
+  // Only count blockers that are themselves slices of this PRD.
+  return refs.filter((n) => sliceNumbers.has(n) && n !== issue.number);
+}
+
+const blockers = new Map<number, number[]>();
+for (const s of slices) blockers.set(s.number, blockersOf(s));
+
+// ─── Topological sort into waves (Kahn, level by level) ───────────────────────
+
+function computeWaves(): number[][] {
+  const remaining = new Set(sliceNumbers);
+  const resolved = new Set<number>();
+  const waves: number[][] = [];
+
+  while (remaining.size > 0) {
+    const wave = [...remaining]
+      .filter((n) => blockers.get(n)!.every((b) => resolved.has(b)))
+      .sort((a, b) => a - b);
+
+    if (wave.length === 0) {
+      fail(
+        `Dependency cycle or unsatisfiable blocker among slices: ${[...remaining].join(', ')}`,
+      );
+    }
+    for (const n of wave) {
+      remaining.delete(n);
+      resolved.add(n);
+    }
+    waves.push(wave);
+  }
+  return waves;
+}
+
+const waves = computeWaves();
+
+function isDone(issue: Issue): boolean {
+  return issue.labels.some((l) => l.name === 'status:done');
+}
+
+// ─── Plan summary ─────────────────────────────────────────────────────────────
+
+const byNumber = new Map(slices.map((s) => [s.number, s]));
+console.log(`\nPRD #${prdNumber} — autonomous wave dispatch`);
+console.log(`${waves.length} wave(s), ${slices.length} slice(s):\n`);
+waves.forEach((wave, i) => {
+  const labels = wave
+    .map((n) => `#${n}${isDone(byNumber.get(n)!) ? ' (done)' : ''}`)
+    .join(', ');
+  console.log(`  Wave ${i + 1}: ${labels}`);
+});
+console.log();
+
+if (process.argv.includes('--plan')) {
+  console.log('--plan: preview only, no slices dispatched.\n');
+  process.exit(0);
+}
+
+// ─── Run each wave ─────────────────────────────────────────────────────────────
+
+for (let i = 0; i < waves.length; i++) {
+  const wave = waves[i];
+  // Re-fetch to pick up status changes from prior waves / prior runs.
+  const current = fetchSlices();
+  const currentByNumber = new Map(current.map((s) => [s.number, s]));
+
+  const openInWave = wave.filter((n) => {
+    const issue = currentByNumber.get(n);
+    return issue && !isDone(issue);
+  });
+
+  if (openInWave.length === 0) {
+    console.log(`\n=== Wave ${i + 1} — already complete, skipping. ===`);
+    continue;
+  }
+
+  console.log(
+    `\n=== Wave ${i + 1}/${waves.length}: dispatching ${openInWave
+      .map((n) => `#${n}`)
+      .join(', ')} ===\n`,
+  );
+
+  // Gate labels: ONLY this wave's open slices are ready-for-agent. Remove the
+  // label from every other PRD slice (future waves AND already-done slices) so
+  // the orchestrator's open+ready+afk filter cannot re-dispatch them.
+  for (const s of current) {
+    const wantReady = openInWave.includes(s.number);
+    const hasReady = s.labels.some((l) => l.name === 'ready-for-agent');
+    if (wantReady && !hasReady) {
+      ghSilent([
+        'issue',
+        'edit',
+        String(s.number),
+        '--repo',
+        REPO,
+        '--add-label',
+        'ready-for-agent',
+      ]);
+    } else if (!wantReady && hasReady) {
+      ghSilent([
+        'issue',
+        'edit',
+        String(s.number),
+        '--repo',
+        REPO,
+        '--remove-label',
+        'ready-for-agent',
+      ]);
+    }
+  }
+
+  // Invoke the existing orchestrator. It branches each ready slice from the
+  // (now updated) feature branch, runs the agent, and auto-merges the PR.
+  const dispatch = spawnSync(
+    'npx',
+    ['tsx', '.sandcastle/main.mts', '--prd', String(prdNumber)],
+    { encoding: 'utf8', stdio: 'inherit', windowsHide: true, shell: true },
+  );
+  if (dispatch.status !== 0) {
+    fail(
+      `Wave ${i + 1} orchestrator exited with code ${dispatch.status}. ` +
+        `Inspect the feature branch and slice issues before re-running.`,
+    );
+  }
+
+  // Verify every slice in this wave reached status:done before proceeding —
+  // a dependent wave must not branch off an incomplete base.
+  const after = fetchSlices();
+  const afterByNumber = new Map(after.map((s) => [s.number, s]));
+  const failedSlices = openInWave.filter((n) => {
+    const issue = afterByNumber.get(n);
+    return !issue || !isDone(issue);
+  });
+
+  if (failedSlices.length > 0) {
+    fail(
+      `Wave ${i + 1} did not fully complete. Incomplete: ${failedSlices
+        .map((n) => `#${n}`)
+        .join(', ')}.\n` +
+        `These slices block later waves. Fix them, then re-run — completed ` +
+        `waves are detected via status:done and skipped automatically.`,
+    );
+  }
+
+  console.log(`\n=== Wave ${i + 1} complete. ===`);
+}
+
+console.log(`\n${'─'.repeat(55)}`);
+console.log(`All ${waves.length} waves complete for PRD #${prdNumber}.`);
+console.log(
+  `Review the feature branch, then open the final PR from it to main.\n`,
+);

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -268,6 +268,138 @@ function sliceBranchFor(issue: Issue): string {
   return `slice/${issue.number}-${slug}`;
 }
 
+// ─── Build gate ───────────────────────────────────────────────────────────────
+// Before a slice PR is merged into the feature branch, lint its affected projects
+// in a Docker container. Fail closed: if the gate cannot run or does not pass, the
+// slice is NOT merged and NOT marked status:done, so dispatch-waves halts rather
+// than branching dependent slices off broken code. Disable with SLICE_GATE=off.
+
+// Serialize gate execution so multiple parallel slices never run
+// `yarn install` into the shared node_modules cache mount at the same time.
+let gateLock: Promise<void> = Promise.resolve();
+async function gated<T>(fn: () => T): Promise<T> {
+  const prev = gateLock;
+  let release!: () => void;
+  gateLock = new Promise<void>((r) => (release = r));
+  await prev;
+  try {
+    return fn();
+  } finally {
+    release();
+  }
+}
+
+function runSliceGate(issue: Issue, sliceBranch: string): boolean {
+  if ((process.env.SLICE_GATE ?? '').toLowerCase() === 'off') {
+    console.log(
+      `  [#${issue.number}] gate disabled (SLICE_GATE=off) — merging without verification.`,
+    );
+    return true;
+  }
+
+  const targets = (process.env.SLICE_GATE_TARGETS || 'lint').trim();
+  const worktreeName = sliceBranch.replace(/\//g, '-');
+  const worktreePath = join(
+    process.cwd(),
+    '.sandcastle',
+    'worktrees',
+    worktreeName,
+  );
+
+  if (!existsSync(worktreePath)) {
+    console.error(
+      `  [#${issue.number}] gate: worktree ${worktreeName} missing — failing closed.`,
+    );
+    return false;
+  }
+
+  // Sync the host worktree to exactly what the agent pushed, so we gate the code
+  // that would be merged. Host git works in worktrees (shared object store).
+  spawnSync('git', ['-C', worktreePath, 'fetch', 'origin', sliceBranch], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  const reset = spawnSync(
+    'git',
+    ['-C', worktreePath, 'reset', '--hard', `origin/${sliceBranch}`],
+    { encoding: 'utf8', windowsHide: true },
+  );
+  if (reset.status !== 0) {
+    console.error(
+      `  [#${issue.number}] gate: could not sync worktree — failing closed.`,
+    );
+    return false;
+  }
+
+  // Compute affected projects on the host (git history + node_modules available).
+  const show = spawnSync(
+    'npx',
+    [
+      'nx',
+      'show',
+      'projects',
+      '--affected',
+      `--base=origin/${featureBranch}`,
+      `--head=origin/${sliceBranch}`,
+    ],
+    {
+      encoding: 'utf8',
+      windowsHide: true,
+      shell: true,
+      env: { ...process.env, NX_DAEMON: 'false' },
+    },
+  );
+  if (show.status !== 0) {
+    console.error(
+      `  [#${issue.number}] gate: nx could not compute affected projects — failing closed.\n${show.stderr}`,
+    );
+    return false;
+  }
+  const projects = (show.stdout || '')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s && !s.includes(' '));
+  if (projects.length === 0) {
+    console.log(`  [#${issue.number}] gate: no affected projects — pass.`);
+    return true;
+  }
+
+  console.log(
+    `  [#${issue.number}] gate: running '${targets}' on ${projects.join(', ')} ...`,
+  );
+  // Lint the slice's code in Docker. Explicit --projects means no git is needed
+  // inside the container (the worktree's .git link does not resolve there).
+  const gate = spawnSync(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '--entrypoint',
+      '/bin/bash',
+      '--user',
+      '1000:1000',
+      '-e',
+      'NX_DAEMON=false',
+      '-e',
+      'NX_ISOLATE_PLUGINS=false',
+      '-e',
+      'NX_SKIP_NX_CACHE=true',
+      '-v',
+      `${worktreePath}:/home/agent/workspace`,
+      '-v',
+      `${linuxNmCache}:/home/agent/workspace/node_modules`,
+      'sandcastle:myorganizer',
+      '-c',
+      `cd /home/agent/workspace && corepack yarn install --immutable && npx nx run-many -t ${targets} --projects=${projects.join(',')} --skip-nx-cache`,
+    ],
+    { encoding: 'utf8', stdio: 'inherit', windowsHide: true, timeout: 1200000 },
+  );
+
+  const ok = gate.status === 0;
+  console.log(`  [#${issue.number}] gate: ${ok ? 'PASS' : 'FAIL'}.`);
+  return ok;
+}
+
 function buildPrompt(issue: Issue, sliceBranch: string): string {
   return [
     `You are implementing GitHub Issue #${issue.number}: ${issue.title}`,
@@ -321,6 +453,7 @@ type SliceResult = {
   sliceBranch: string;
   prUrl: string;
   commits: number;
+  merged: boolean;
 };
 
 const results = await Promise.allSettled<SliceResult>(
@@ -374,19 +507,6 @@ const results = await Promise.allSettled<SliceResult>(
       prompt: buildPrompt(issue, sliceBranch),
     });
 
-    // Update labels
-    ghSilent([
-      'issue',
-      'edit',
-      String(issue.number),
-      '--repo',
-      REPO,
-      '--remove-label',
-      'status:in-progress',
-      '--add-label',
-      'status:done',
-    ]);
-
     // Create PR from slice branch → feature branch
     const prCreate = spawnSync(
       'gh',
@@ -412,9 +532,29 @@ const results = await Promise.allSettled<SliceResult>(
         ? prCreate.stdout.trim()
         : `(PR creation failed: ${prCreate.stderr.trim().slice(0, 80)})`;
 
-    // Merge the slice PR into the feature branch and delete the slice branch.
-    // The feature branch → main PR is where the real review happens.
-    if (prCreate.status === 0) {
+    // Build gate before merge. Serialized so parallel slices never run
+    // `yarn install` into the shared node_modules cache mount concurrently.
+    const gatePassed =
+      prCreate.status === 0
+        ? await gated(() => runSliceGate(issue, sliceBranch))
+        : false;
+
+    const merged = prCreate.status === 0 && gatePassed;
+
+    if (merged) {
+      // Gate green → mark done and squash-merge into the feature branch.
+      ghSilent([
+        'issue',
+        'edit',
+        String(issue.number),
+        '--repo',
+        REPO,
+        '--remove-label',
+        'status:in-progress',
+        '--add-label',
+        'status:done',
+      ]);
+
       const prMerge = spawnSync(
         'gh',
         [
@@ -434,45 +574,90 @@ const results = await Promise.allSettled<SliceResult>(
           `  Warning: auto-merge failed for ${prUrl} — merge manually before opening the feature PR.`,
         );
       }
+
+      ghSilent([
+        'issue',
+        'comment',
+        String(issue.number),
+        '--repo',
+        REPO,
+        '--body',
+        `Agent completed and the build gate passed. ${result.commits.length} commit(s) on \`${sliceBranch}\`.\nMerged into \`${featureBranch}\`. PR: ${prUrl}`,
+      ]);
+    } else {
+      // PR failed OR gate failed → do NOT merge, do NOT mark status:done, so the
+      // wave-runner halts instead of branching dependents off broken code.
+      ghSilent([
+        'issue',
+        'edit',
+        String(issue.number),
+        '--repo',
+        REPO,
+        '--remove-label',
+        'status:in-progress',
+      ]);
+
+      const reason =
+        prCreate.status !== 0
+          ? 'the PR could not be created'
+          : `the build gate (${process.env.SLICE_GATE_TARGETS || 'lint'}) failed`;
+      ghSilent([
+        'issue',
+        'comment',
+        String(issue.number),
+        '--repo',
+        REPO,
+        '--body',
+        `Agent finished but ${reason} — slice was NOT merged into \`${featureBranch}\`. ` +
+          `Branch \`${sliceBranch}\` and its PR are left open for inspection: ${prUrl}\n\n` +
+          `Dependent waves are halted. Fix the slice, then re-run \`yarn dispatch-waves\` (completed waves are skipped).`,
+      ]);
     }
 
-    // Post completion comment on issue
-    ghSilent([
-      'issue',
-      'comment',
-      String(issue.number),
-      '--repo',
-      REPO,
-      '--body',
-      `Agent completed. ${result.commits.length} commit(s) on \`${sliceBranch}\`.\nPR: ${prUrl}`,
-    ]);
-
-    return { issue, sliceBranch, prUrl, commits: result.commits.length };
+    return {
+      issue,
+      sliceBranch,
+      prUrl,
+      commits: result.commits.length,
+      merged,
+    };
   }),
 );
 
 // ─── Summary ─────────────────────────────────────────────────────────────────
 
-const succeeded = results.filter(
+const fulfilled = results.filter(
   (r): r is PromiseFulfilledResult<SliceResult> => r.status === 'fulfilled',
 );
+const merged = fulfilled.filter((r) => r.value.merged);
+const blocked = fulfilled.filter((r) => !r.value.merged);
 const failed = results.filter(
   (r): r is PromiseRejectedResult => r.status === 'rejected',
 );
 
 console.log(`\n${'─'.repeat(55)}`);
 console.log(
-  `Batch done: ${succeeded.length} succeeded, ${failed.length} failed.\n`,
+  `Batch done: ${merged.length} merged, ${blocked.length} blocked (gate/PR), ${failed.length} crashed.\n`,
 );
 
-for (const r of succeeded) {
-  console.log(`  ✓ #${r.value.issue.number} — ${r.value.prUrl}`);
+for (const r of merged) {
+  console.log(`  ✓ #${r.value.issue.number} merged — ${r.value.prUrl}`);
+}
+for (const r of blocked) {
+  console.error(
+    `  ⚠ #${r.value.issue.number} NOT merged (gate failed / PR open) — ${r.value.prUrl}`,
+  );
 }
 for (const r of failed) {
   console.error(`  ✗ ${String(r.reason)}`);
 }
 
-if (succeeded.length > 0) {
+if (blocked.length > 0 || failed.length > 0) {
+  console.log(
+    `\nOne or more slices did not merge. Dependent waves will halt until resolved.`,
+  );
+}
+if (merged.length > 0) {
   console.log(`\nNext step: review slice PRs targeting \`${featureBranch}\`,`);
   console.log(`then open a final PR from \`${featureBranch}\` to \`main\`.`);
 }
@@ -487,7 +672,7 @@ spawnSync(
     [
       'Add-Type -AssemblyName System.Windows.Forms;',
       `[System.Windows.Forms.MessageBox]::Show(`,
-      `  '${succeeded.length} agent(s) done, ${failed.length} failed.` +
+      `  '${merged.length} merged, ${blocked.length} blocked, ${failed.length} crashed.` +
         `\\nPRD #${prdNumber}: ${safeTitle}',`,
       `  'dispatch-agents complete', 'OK', 'Information'`,
       `)`,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,24 @@ _Avoid_: Page component, route component, smart component
 The handoff document the main agent passes to ComponentBuilder. Contains: component name, target path, scope (UI Primitive or Feature Component), props interface, state ownership, Zod schema if applicable, and relevant guideline references.
 _Avoid_: Component brief, component plan, design spec
 
+## Mobile
+
+**Mobile App**:
+The React Native client in `apps/mobile`, sharing domain logic with the web app through cross-platform libraries. Feature code lives under `libs/mobile/*`.
+_Avoid_: native app, RN app, the app
+
+**Platform Adapter**:
+A thin implementation of a shared abstract interface (e.g. `VaultCrypto`, `VaultStorage`, token storage) that supplies platform-specific behavior to otherwise platform-agnostic code.
+_Avoid_: shim, wrapper, provider
+
+**Vault Unlock**:
+The client-side action of deriving the Master Key from the User's passphrase so vault Ciphertext can be decrypted for the session. No plaintext or key leaves the device.
+_Avoid_: vault login, decrypt vault, open vault
+
+**Master Key**:
+The symmetric key derived from the passphrase (PBKDF2 → AES-GCM) that decrypts vault Ciphertext. Never sent to the server.
+_Avoid_: vault key, encryption key, secret key
+
 ## Planning & Orchestration
 
 **PRD Issue**:

--- a/docs/adr/0005-react-native-bare-with-nx.md
+++ b/docs/adr/0005-react-native-bare-with-nx.md
@@ -1,0 +1,18 @@
+---
+status: accepted
+---
+
+# Mobile app is bare React Native via @nx/react-native (not Expo)
+
+The MyOrganizer mobile client (`apps/mobile`) is built as a bare React Native app integrated through the `@nx/react-native` plugin, with native `ios/` and `android/` projects committed and compiled directly (Gradle / Xcode).
+
+## Considered Options
+
+- **Expo (managed) + Metro bundle** — fastest CI (Node only, no native SDKs), but the managed runtime constrains native modules. The vault requires `react-native-quick-crypto` (JSI) and we want unrestricted control over native crypto and secure storage.
+- **Expo prebuild** — generates native dirs but still anchors the project to the Expo toolchain and config plugins.
+- **Bare React Native + @nx/react-native** — chosen. Full control over native build and modules, native dirs are first-class, and it sits naturally in the existing Nx monorepo alongside the Next.js and Express apps.
+
+## Consequences
+
+- iOS native builds require macOS/Xcode and are verified by the human on a Mac; the Windows dev/CI environment can compile Android (Gradle) and always runs the Metro bundle + `tsc` as the autonomous build gate.
+- We own native dependency wiring (babel, Metro, CocoaPods/Gradle) rather than delegating it to Expo.

--- a/docs/adr/0006-mobile-refresh-token-delivery.md
+++ b/docs/adr/0006-mobile-refresh-token-delivery.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+---
+
+# Mobile receives the refresh token in the login body, not an httpOnly cookie
+
+The web app authenticates with a short-lived access token plus a refresh token delivered as an httpOnly `refresh_cookie` and replayed automatically by the browser cookie jar. React Native has no equivalent reliable cookie jar (Android OkHttp drops cookies across restarts, and httpOnly cookies can't be moved into secure storage), so the mobile client needs the refresh token in hand.
+
+## Decision
+
+The `/auth/login` request carries a client type. When it is `mobile`, the response body additionally includes `refresh_token`; the default (web) response is unchanged and continues to rely on the httpOnly cookie. The mobile app stores the refresh token in the OS keychain (`react-native-keychain`) and sends it in the `/auth/refresh` request body — a path the backend already supports (`refresh_token` body falls back to `refresh_cookie`).
+
+## Consequences
+
+- `app-api-client` is regenerated with an additive optional `refresh_token` field on the login response; web behavior is unaffected, but the web auth flow gets a smoke check in the same change.
+- The refresh token now exists in two delivery channels (cookie for web, body for mobile) gated by client type — both must be kept in sync if the token contract changes.

--- a/docs/adr/0007-mobile-styling-nativewind-dual-preset.md
+++ b/docs/adr/0007-mobile-styling-nativewind-dual-preset.md
@@ -1,0 +1,21 @@
+---
+status: accepted
+---
+
+# Mobile styling uses NativeWind over a generated native token preset
+
+The mobile app styles components with NativeWind v4 (Tailwind syntax on React Native). Color, spacing, radius, and font alignment with the web app is guaranteed by generating a second Tailwind preset from the same `libs/design-tokens` source.
+
+## Context
+
+The existing `tailwind-preset.js` maps tokens to CSS custom properties (`var(--color-primary)`), which React Native cannot resolve. Rather than hand-maintain a parallel mobile palette (which would drift), `design-tokens` emits an additional Style Dictionary output — a native preset with the resolved hex values — from the same `tokens.json`. Web keeps the var-based preset; mobile consumes the hex-based one.
+
+## Considered Options
+
+- **StyleSheet + a typed theme object from `tokens.ts`** — zero new dependencies and simplest to compile, but no shared className DX with web.
+- **NativeWind + generated native preset** — chosen. Familiar Tailwind authoring shared with web, and alignment is enforced because both presets regenerate from one token source. Cost: NativeWind native wiring (babel/Metro) and one design-tokens generator addition.
+
+## Consequences
+
+- A single `tokens.json` remains the source of truth for both platforms; regenerating tokens updates web and mobile presets together.
+- The mobile build gains NativeWind's babel plugin and Metro transformer as native-build surface.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ai:create-pr": "node tools/scripts/ai/create-pr.mjs",
     "ai:create-labels": "node tools/scripts/ai/create-labels.mjs",
     "dispatch-agents": "npx tsx .sandcastle/main.mts",
+    "dispatch-waves": "npx tsx .sandcastle/dispatch-waves.mts",
     "nx": "nx",
     "postinstall": "husky"
   },


### PR DESCRIPTION
## Why
Record phase-1 RN decisions and domain glossary. A follow-up commit refine the branch before merging `chore/sandcastle-wave-runner` into `main`.

## Changes
- Add ADR-0005 (bare React Native via @nx/react-native), ADR-0006 (mobile
- refresh token delivered in the login body, gated by client type), and
- ADR-0007 (NativeWind + dual token preset). Extend CONTEXT.md with the
- Mobile glossary (Mobile App, Platform Adapter, Vault Unlock, Master Key).
- These ground PRD #140 and are read by the autonomous agents dispatched
- for the mobile phase-1 slices.
- Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
- Add dispatch-waves.mts: topologically sorts a PRD's AFK slices by their
- `## Blocked by` sections into dependency waves and runs one dispatch-agents
- pass per wave, gating the ready-for-agent label so each wave auto-merges
- into the feature branch before its dependents are dispatched. Fully
- unattended; completed waves are detected via status:done and skipped on
- re-run. Supports --plan for a dry-run preview.
- Gate each slice merge in main.mts on an affected-project lint run in
- Docker before squash-merging. Fail closed: a slice that fails the gate (or
- whose PR cannot be created) is left open and NOT marked status:done, so the
- wave runner halts instead of branching dependents off broken code. Gates
- are serialized to avoid concurrent installs into the shared node_modules
- cache. Configurable via SLICE_GATE=off and SLICE_GATE_TARGETS.
- Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Validation
- Generated from 2 commit(s) on `chore/sandcastle-wave-runner`.
- Compared against base branch `main`.
