### PR TITLE
[Slice] Mobile App: mobile/feat/auth — keychain + 401 refresh interceptor + session

### DIFF
--- a/libs/mobile/feat/auth/src/api/client.ts
+++ b/libs/mobile/feat/auth/src/api/client.ts
@@ -1,0 +1,159 @@
+import axios, {
+  AxiosInstance,
+  AxiosError,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import { AuthenticationApi, Configuration } from '@myorganizer/app-api-client';
+import {
+  getRefreshToken,
+  saveRefreshToken,
+  clearRefreshToken,
+} from '../storage/keychain';
+import type { AuthTokens, Login200Response } from './types';
+
+const BASE_PATH = 'http://localhost:3000/api/v1';
+
+type TokenRefreshCallback = (tokens: AuthTokens | null) => void;
+
+let accessToken: string | null = null;
+let isRefreshing = false;
+let refreshSubscribers: Array<(token: string | null) => void> = [];
+let tokenRefreshCallback: TokenRefreshCallback | null = null;
+
+function subscribeToTokenRefresh(
+  callback: (token: string | null) => void,
+): void {
+  refreshSubscribers.push(callback);
+}
+
+function notifyRefreshSubscribers(token: string | null): void {
+  refreshSubscribers.forEach((callback) => callback(token));
+  refreshSubscribers = [];
+}
+
+export function setTokenRefreshCallback(callback: TokenRefreshCallback): void {
+  tokenRefreshCallback = callback;
+}
+
+export function setAccessToken(token: string | null): void {
+  accessToken = token;
+}
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+export const apiClient: AxiosInstance = axios.create({
+  baseURL: BASE_PATH,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+apiClient.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    if (accessToken && config.headers) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & {
+      _retry?: boolean;
+    };
+
+    if (error.response?.status !== 401 || originalRequest._retry) {
+      return Promise.reject(error);
+    }
+
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        subscribeToTokenRefresh((newToken) => {
+          if (newToken && originalRequest.headers) {
+            originalRequest.headers.Authorization = `Bearer ${newToken}`;
+            resolve(apiClient(originalRequest));
+          } else {
+            reject(error);
+          }
+        });
+      });
+    }
+
+    originalRequest._retry = true;
+    isRefreshing = true;
+
+    try {
+      const storedRefreshToken = await getRefreshToken();
+      if (!storedRefreshToken) {
+        throw new Error('No refresh token available');
+      }
+
+      const refreshApi = new AuthenticationApi(
+        new Configuration({ basePath: BASE_PATH }),
+        BASE_PATH,
+        axios,
+      );
+
+      const response = await refreshApi.refreshToken({
+        refreshTokenRequest: { refresh_token: storedRefreshToken },
+      });
+
+      const data: Login200Response = response.data;
+      const newAccessToken = data.token;
+      const newRefreshToken = data.refresh_token;
+
+      if (!newAccessToken) {
+        throw new Error('No access token in refresh response');
+      }
+
+      accessToken = newAccessToken;
+
+      if (newRefreshToken) {
+        await saveRefreshToken(newRefreshToken);
+      }
+
+      const tokens: AuthTokens = {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken || storedRefreshToken,
+        expiresIn: data.expires_in,
+      };
+
+      if (tokenRefreshCallback) {
+        tokenRefreshCallback(tokens);
+      }
+
+      notifyRefreshSubscribers(newAccessToken);
+
+      if (originalRequest.headers) {
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+      }
+
+      return apiClient(originalRequest);
+    } catch (refreshError) {
+      await clearRefreshToken();
+      accessToken = null;
+
+      if (tokenRefreshCallback) {
+        tokenRefreshCallback(null);
+      }
+
+      notifyRefreshSubscribers(null);
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+    }
+  },
+);
+
+export function createAuthApi(): AuthenticationApi {
+  const config = new Configuration({
+    basePath: BASE_PATH,
+    accessToken: () => accessToken || '',
+  });
+  return new AuthenticationApi(config, BASE_PATH, apiClient);
+}

--- a/libs/mobile/feat/auth/src/api/types.ts
+++ b/libs/mobile/feat/auth/src/api/types.ts
@@ -1,0 +1,17 @@
+import type {
+  Login200Response,
+  FilteredUserInterface,
+} from '@myorganizer/app-api-client';
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+export interface AuthSession {
+  user: FilteredUserInterface;
+  tokens: AuthTokens;
+}
+
+export type { Login200Response, FilteredUserInterface };

--- a/libs/mobile/feat/auth/src/context/AuthContext.tsx
+++ b/libs/mobile/feat/auth/src/context/AuthContext.tsx
@@ -1,0 +1,186 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+} from 'react';
+import type { ReactNode } from 'react';
+import type { FilteredUserInterface } from '@myorganizer/app-api-client';
+import {
+  saveRefreshToken,
+  getRefreshToken,
+  clearRefreshToken,
+} from '../storage/keychain';
+import {
+  apiClient,
+  createAuthApi,
+  setAccessToken,
+  setTokenRefreshCallback,
+} from '../api/client';
+import type { AuthSession, AuthTokens } from '../api/types';
+
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+
+interface AuthContextValue {
+  status: AuthStatus;
+  user: FilteredUserInterface | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({
+  children,
+}: AuthProviderProps): React.JSX.Element {
+  const [status, setStatus] = useState<AuthStatus>('loading');
+  const [session, setSession] = useState<AuthSession | null>(null);
+
+  const clearSession = useCallback(async () => {
+    await clearRefreshToken();
+    setAccessToken(null);
+    setSession(null);
+    setStatus('unauthenticated');
+  }, []);
+
+  const handleTokenRefresh = useCallback((tokens: AuthTokens | null) => {
+    if (!tokens) {
+      setSession(null);
+      setStatus('unauthenticated');
+      return;
+    }
+
+    setSession((prev) => {
+      if (!prev) return null;
+      return {
+        ...prev,
+        tokens,
+      };
+    });
+  }, []);
+
+  useEffect(() => {
+    setTokenRefreshCallback(handleTokenRefresh);
+  }, [handleTokenRefresh]);
+
+  useEffect(() => {
+    async function restoreSession(): Promise<void> {
+      try {
+        const storedRefreshToken = await getRefreshToken();
+        if (!storedRefreshToken) {
+          setStatus('unauthenticated');
+          return;
+        }
+
+        const authApi = createAuthApi();
+        const response = await authApi.refreshToken({
+          refreshTokenRequest: { refresh_token: storedRefreshToken },
+        });
+
+        const data = response.data;
+        const newAccessToken = data.token;
+        const newRefreshToken = data.refresh_token;
+
+        if (!newAccessToken) {
+          await clearSession();
+          return;
+        }
+
+        setAccessToken(newAccessToken);
+
+        if (newRefreshToken) {
+          await saveRefreshToken(newRefreshToken);
+        }
+
+        setSession({
+          user: data.user,
+          tokens: {
+            accessToken: newAccessToken,
+            refreshToken: newRefreshToken || storedRefreshToken,
+            expiresIn: data.expires_in,
+          },
+        });
+        setStatus('authenticated');
+      } catch {
+        await clearSession();
+      }
+    }
+
+    restoreSession();
+  }, [clearSession]);
+
+  const login = useCallback(
+    async (email: string, password: string): Promise<void> => {
+      const authApi = createAuthApi();
+      const response = await authApi.login({
+        userLoginBody: {
+          email,
+          password,
+          client_type: 'mobile',
+        },
+      });
+
+      const data = response.data;
+      const newAccessToken = data.token;
+      const refreshToken = data.refresh_token;
+
+      if (!refreshToken) {
+        throw new Error('Server did not return refresh token');
+      }
+
+      setAccessToken(newAccessToken);
+      await saveRefreshToken(refreshToken);
+
+      setSession({
+        user: data.user,
+        tokens: {
+          accessToken: newAccessToken,
+          refreshToken,
+          expiresIn: data.expires_in,
+        },
+      });
+      setStatus('authenticated');
+    },
+    [],
+  );
+
+  const logout = useCallback(async (): Promise<void> => {
+    try {
+      if (session?.user.id) {
+        const authApi = createAuthApi();
+        await authApi.logout({ userId: session.user.id });
+      }
+    } catch {
+      // Continue with local logout even if server logout fails
+    }
+    await clearSession();
+  }, [session, clearSession]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      status,
+      user: session?.user ?? null,
+      login,
+      logout,
+    }),
+    [status, session, login, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}
+
+export { apiClient };

--- a/libs/mobile/feat/auth/src/index.ts
+++ b/libs/mobile/feat/auth/src/index.ts
@@ -1,2 +1,12 @@
-// @myorganizer/mobile/feat-auth — scaffolded by #143. Feature slices populate this module.
-export {};
+export { AuthProvider, useAuth, apiClient } from './context/AuthContext';
+export type { AuthStatus } from './context/AuthContext';
+
+export {
+  saveRefreshToken,
+  getRefreshToken,
+  clearRefreshToken,
+} from './storage/keychain';
+
+export { setAccessToken, getAccessToken, createAuthApi } from './api/client';
+
+export type { AuthTokens, AuthSession } from './api/types';

--- a/libs/mobile/feat/auth/src/storage/keychain.ts
+++ b/libs/mobile/feat/auth/src/storage/keychain.ts
@@ -1,0 +1,28 @@
+import * as Keychain from 'react-native-keychain';
+
+const SERVICE_NAME = 'com.myorganizer.auth';
+
+export interface StoredCredentials {
+  refreshToken: string;
+}
+
+export async function saveRefreshToken(refreshToken: string): Promise<void> {
+  await Keychain.setGenericPassword('refresh_token', refreshToken, {
+    service: SERVICE_NAME,
+    accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  });
+}
+
+export async function getRefreshToken(): Promise<string | null> {
+  const credentials = await Keychain.getGenericPassword({
+    service: SERVICE_NAME,
+  });
+  if (credentials && credentials.password) {
+    return credentials.password;
+  }
+  return null;
+}
+
+export async function clearRefreshToken(): Promise<void> {
+  await Keychain.resetGenericPassword({ service: SERVICE_NAME });
+}


### PR DESCRIPTION
Closes #145

Part of `feat/react-native-mobile-app-phase-1-foundation-auth-read-only-vault` — see PRD #140.