### PR TITLE
chore(graphify): evaluate knowledge-graph tool and adopt narrow MCP index (#158)

### DIFF
--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -45,34 +45,42 @@ Which sections of the Explore Summary matter most for this request.
 3. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
 4. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
 
-## Optional: Graphify structural index (MCP)
+## Graphify structural index (MCP) — query FIRST for relationship questions
 
 A pre-built code knowledge graph is available via the `graphify` MCP tools, backed by
-`graphify-out/graph.json`. Use it as a **fast first lookup**, then confirm against the
-actual files — it is a supplement to grep, not a replacement.
+`graphify-out/graph.json`. We are measuring whether it earns its keep, so usage is **deliberate
+and logged**, not optional.
 
-**Use it for (its proven strengths):**
+**REQUIRED — when the Goal is a relationship/consumer question** ("what calls / imports /
+consumes / is connected to symbol X?", or "what are the core abstractions here?"), your FIRST
+action after orienting MUST be a Graphify query, before any grep:
 
-- "What directly calls / imports / consumes symbol X?" → `get_neighbors` (instant, accurate
-  for in-package call/import edges). Example win: `saveEncryptedData` returns all 20 consumers.
-- "What are the core abstractions / most-connected nodes?" → `god_nodes` (good orientation).
-- Broad "what relates to X" context → `query_graph`.
+- "What calls / imports / consumes symbol X?" → `get_neighbors` (then confirm with grep/read).
+- "Core abstractions / most-connected nodes?" → `god_nodes`.
+- Broad "what relates to X" → `query_graph`.
 
-**Do NOT rely on it for (proven blind spots):**
+Then verify against the actual files. Graphify is a fast first lookup, not the source of truth.
+
+**Do NOT use it for (proven blind spots) — go straight to the better tool:**
 
 - Cross-package / cross-HTTP-boundary impact (e.g. "what breaks if `VaultController` changes"):
   the graph is AST-only and has **no edge across the OpenAPI/codegen seam** — it returns empty
   or partial. Use `nx affected --files=<path>` for authoritative cross-project impact instead.
 - TypeScript **type**-reference blast radius (type usages are not edges; nodes show degree ~1).
-- Any symbol whose name appears in more than one file (the graph cannot disambiguate it).
+- Any symbol whose name appears in more than one file (`get_node` picks an arbitrary match and
+  silently returns the wrong one — prefer `query_graph`, then disambiguate by reading files).
 
 **Trust rules:**
 
-- The graph can be **stale** (it is rebuilt manually, not on every commit). Treat any graph
-  result as `[inferred]` until you confirm the exact location with `Read`/`Grep`, then upgrade
-  to `[found]` with the file:line citation.
-- If the MCP tools are unavailable (graph not built), fall back to Glob/Grep silently — do not
-  error. Build/refresh instructions live in `docs/graphify.md`.
+- The graph can be **stale** (rebuilt manually, not on every commit — see `docs/graphify.md`).
+  Treat any graph result as `[inferred]` until you confirm the exact location with `Read`/`Grep`,
+  then upgrade to `[found]` with the file:line citation.
+- If the MCP tools are unavailable (graph not built), fall back to Glob/Grep — do not error, but
+  record it in the Graphify Usage block below so the gap is visible.
+
+**Measurement (REQUIRED every run):** record what Graphify did in the `Graphify Usage` section of
+your output (see Output Format). This is how we judge whether to keep it — be honest: if it added
+nothing over grep, say so; if grep found something Graphify missed, say that too.
 
 ## Evidence Tagging
 
@@ -108,6 +116,17 @@ File paths and line numbers the main agent should read next, ranked by relevance
 ### Gaps / Unknowns
 
 What could NOT be determined and why.
+
+### Graphify Usage
+
+Honest, factual log of whether the structural index helped (omit only if the Goal was not a
+relationship question AND Graphify was not applicable — otherwise always include it):
+
+- **Queried**: tool(s) + argument(s) run, or "not applicable — <reason>" / "unavailable — graph not built".
+- **Result**: what it returned (counts, key nodes), or empty/wrong.
+- **Verdict**: `helped` (found something faster/that grep would have missed),
+  `redundant` (grep/read would have been just as fast), or `wrong/missed` (returned a wrong or
+  incomplete answer — name what it got wrong vs the verified file evidence).
 
 ### Recommendation
 

--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -5,7 +5,7 @@ description: >
   the main agent would issue 3 or more consecutive Glob/Grep/Read calls to
   locate something in the codebase. Returns a structured Explore Summary
   with [found]/[inferred] tagged findings and ranked file paths.
-tools: [Read, Glob, Grep]
+tools: [Read, Glob, Grep, mcp__graphify__query_graph, mcp__graphify__get_neighbors, mcp__graphify__get_node, mcp__graphify__god_nodes, mcp__graphify__graph_stats]
 model: haiku
 ---
 
@@ -44,6 +44,35 @@ Which sections of the Explore Summary matter most for this request.
 2. Start with Known Locations if provided — do not start from scratch when hints exist.
 3. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
 4. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+
+## Optional: Graphify structural index (MCP)
+
+A pre-built code knowledge graph is available via the `graphify` MCP tools, backed by
+`graphify-out/graph.json`. Use it as a **fast first lookup**, then confirm against the
+actual files — it is a supplement to grep, not a replacement.
+
+**Use it for (its proven strengths):**
+
+- "What directly calls / imports / consumes symbol X?" → `get_neighbors` (instant, accurate
+  for in-package call/import edges). Example win: `saveEncryptedData` returns all 20 consumers.
+- "What are the core abstractions / most-connected nodes?" → `god_nodes` (good orientation).
+- Broad "what relates to X" context → `query_graph`.
+
+**Do NOT rely on it for (proven blind spots):**
+
+- Cross-package / cross-HTTP-boundary impact (e.g. "what breaks if `VaultController` changes"):
+  the graph is AST-only and has **no edge across the OpenAPI/codegen seam** — it returns empty
+  or partial. Use `nx affected --files=<path>` for authoritative cross-project impact instead.
+- TypeScript **type**-reference blast radius (type usages are not edges; nodes show degree ~1).
+- Any symbol whose name appears in more than one file (the graph cannot disambiguate it).
+
+**Trust rules:**
+
+- The graph can be **stale** (it is rebuilt manually, not on every commit). Treat any graph
+  result as `[inferred]` until you confirm the exact location with `Read`/`Grep`, then upgrade
+  to `[found]` with the file:line citation.
+- If the MCP tools are unavailable (graph not built), fall back to Glob/Grep silently — do not
+  error. Build/refresh instructions live in `docs/graphify.md`.
 
 ## Evidence Tagging
 

--- a/.github/skills/to-issues/config.md
+++ b/.github/skills/to-issues/config.md
@@ -19,7 +19,7 @@ GitHub Issues
 | `type:afk`           | Agent can implement and merge without human interaction |
 | `type:hitl`          | Human decision required before agent can proceed        |
 | `status:in-progress` | Agent has picked up the issue                           |
-| `status:done`        | Agent finished; PR opened                               |
+| `status:done`        | Agent finished; integrated into local feature branch    |
 | `prd`                | Parent PRD Issue for a planned feature                  |
 
 ## Model Routing
@@ -46,11 +46,11 @@ GitHub Issues
 - **Body**: Must include `PRD: #<parent-issue-number>` on the first line. Then acceptance criteria, affected libs, test seams.
 - **Created by**: `to-issues` skill via IssueCreator agent.
 
-## PR Strategy (Hybrid)
+## Integration Strategy (local-only)
 
-1. `dispatch-agents` creates a feature branch (`feat/<slugified-prd-title>`) from `main` at run-start.
-2. Each AFK Slice agent opens a PR targeting the feature branch (not `main`).
-3. After all slice PRs are reviewed and merged into the feature branch, a final PR from the feature branch to `main` is created manually.
+1. `dispatch-agents` creates the feature branch (`feat/<slugified-prd-title>`) from `origin/main` **locally — it is never pushed**.
+2. AFK slices run one at a time; each agent commits on its slice branch and the orchestrator **fast-forwards it into the local feature branch** after a lint gate. No per-slice push, no per-slice PR.
+3. After QA, the feature branch is pushed and **one** PR from it to `main` is created manually; CI runs there. See `docs/adr/0010`.
 
 ## Trigger Command
 

--- a/.github/skills/to-prd/config.md
+++ b/.github/skills/to-prd/config.md
@@ -19,7 +19,7 @@ GitHub Issues
 | `type:afk`           | Agent can implement and merge without human interaction |
 | `type:hitl`          | Human decision required before agent can proceed        |
 | `status:in-progress` | Agent has picked up the issue                           |
-| `status:done`        | Agent finished; PR opened                               |
+| `status:done`        | Agent finished; integrated into local feature branch    |
 | `prd`                | Parent PRD Issue for a planned feature                  |
 
 ## Model Routing
@@ -46,11 +46,11 @@ GitHub Issues
 - **Body**: Must include `PRD: #<parent-issue-number>` on the first line. Then acceptance criteria, affected libs, test seams.
 - **Created by**: `to-issues` skill via IssueCreator agent.
 
-## PR Strategy (Hybrid)
+## Integration Strategy (local-only)
 
-1. `dispatch-agents` creates a feature branch (`feat/<slugified-prd-title>`) from `main` at run-start.
-2. Each AFK Slice agent opens a PR targeting the feature branch (not `main`).
-3. After all slice PRs are reviewed and merged into the feature branch, a final PR from the feature branch to `main` is created manually.
+1. `dispatch-agents` creates the feature branch (`feat/<slugified-prd-title>`) from `origin/main` **locally — it is never pushed**.
+2. AFK slices run one at a time; each agent commits on its slice branch and the orchestrator **fast-forwards it into the local feature branch** after a lint gate. No per-slice push, no per-slice PR.
+3. After QA, the feature branch is pushed and **one** PR from it to `main` is created manually; CI runs there. See `docs/adr/0010`.
 
 ## Trigger Command
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ testem.log
 .sandcastle/logs/
 .sandcastle/worktrees/
 .sandcastle/patches/
+.sandcastle/gate/
+.sandcastle/.yarn-cache/
+.sandcastle/node_modules_linux_cache/
 
 # System Files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,8 @@ yarn-error.log
 
 
 vite.config.*.timestamp*
+
+# Graphify knowledge-graph artifacts (generated; rebuild via docs/graphify.md).
+# .mcp.json and .graphifyignore are committed; the generated graph is not.
+graphify-out/
+**/graphify-out/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,60 @@
+# Graphify ignore — pilot rerun (issue #158), corrected config.
+# Goal: graph all AUTHORED + GENERATED source the agent must reason about.
+# NOTE: we intentionally NO LONGER exclude libs/app-api-client — the generated
+# API client is part of the real impact chain (VaultController → VaultApi) and
+# excluding it last time made R5 fail by our own hand.
+
+# Dependencies / package manager
+node_modules/
+.yarn/
+.pnp.*
+
+# Build & framework output (not source)
+dist/
+build/
+.next/
+out/
+tmp/
+.nx/
+**/.cache/
+
+# Test / coverage artifacts
+coverage/
+playwright-report/
+test-results/
+.playwright/
+
+# Raw OpenAPI spec blobs (data, not code — would skew the graph)
+**/openapi.json
+**/openapi.yaml
+
+# Build/tool config — NOT domain knowledge. Excluding these removes the 57%
+# "TypeScript Config"/"Nx Project Config" community noise so the labeled graph
+# surfaces real feature domains. Project structure lives in `nx graph`, not here.
+**/tsconfig*.json
+**/project.json
+**/package.json
+**/jest.config.*
+**/jest.preset.*
+**/.eslintrc*
+**/eslint.config.*
+**/*.config.js
+**/*.config.ts
+**/*.config.mjs
+**/*.config.cjs
+**/babel.config.*
+**/.babelrc*
+**/metro.config.*
+**/webpack.config.*
+# Native mobile build trees (not the TS/JS knowledge graph)
+apps/mobile/android/
+apps/mobile/ios/
+
+# Graphify's own output
+graphify-out/
+
+# Lockfiles & misc noise
+yarn.lock
+package-lock.json
+pnpm-lock.yaml
+*.log

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "graphify": {
+      "command": "graphify-mcp",
+      "args": ["graphify-out/graph.json"],
+      "env": {}
+    }
+  }
+}

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -44,16 +44,20 @@ WORKDIR /home/agent
 
 # Prevent Nx from connecting to a background daemon or spawning a plugin-isolation
 # worker process. Both code paths try to load nx/src/native (WASM via @napi-rs/wasm-runtime),
-# which hangs on worker-thread creation inside Docker when the Linux-native Nx binding
-# (@nx/nx-linux-x64-gnu) is absent. These vars are belt-and-suspenders alongside the
-# fix in main.mts that skips the Windows node_modules mirror so yarn install fetches
-# the correct Linux binary instead.
+# which hangs on worker-thread creation inside Docker. These vars are belt-and-suspenders;
+# the Linux-native Nx binding (@nx/nx-linux-x64-gnu) is resolved by the in-container
+# `yarn install` (below), which runs on this image's linux/x64 platform.
 ENV NX_DAEMON=false
 ENV NX_ISOLATE_PLUGINS=false
 ENV NX_SKIP_NX_CACHE=true
 
 # Sandcastle bind-mounts the git worktree at /home/agent/workspace at container start.
-# The agent must run `corepack yarn install` (without --immutable) as its first step so
-# Yarn resolves the Linux-native optional packages (e.g. @nx/nx-linux-x64-gnu) rather
-# than falling back to the WASM path that hangs in this environment.
+# Dependencies are installed IN THIS CONTAINER by the orchestrator's
+# `hooks.sandbox.onSandboxReady` hook (`corepack yarn install --immutable`) BEFORE the
+# agent runs — so native binaries (bcrypt, prisma, @swc/core) are built for this Linux
+# platform regardless of the host OS (WSL2/Linux/macOS). The agent does NOT run
+# `yarn install`. Yarn's global cache is bind-mounted at /home/agent/.yarn-cache (set
+# via YARN_GLOBAL_FOLDER) so installs are incremental across slices. The worktree must
+# live on a native host fs (ext4/APFS) — see docs/adr/0009 and
+# docs/sandcastle/RUNBOOK.md.
 ENTRYPOINT ["sleep", "infinity"]

--- a/.sandcastle/dispatch-waves.mts
+++ b/.sandcastle/dispatch-waves.mts
@@ -57,6 +57,9 @@ type Issue = {
 };
 
 function fetchSlices(): Issue[] {
+  // --state all: the orchestrator CLOSES a slice on successful integration, so a
+  // completed slice must still be visible here (for blocker resolution and wave
+  // verification). isDone() below treats a closed slice as complete.
   const all = ghJson<Issue[]>([
     'issue',
     'list',
@@ -65,7 +68,7 @@ function fetchSlices(): Issue[] {
     '--label',
     'type:afk',
     '--state',
-    'open',
+    'all',
     '--json',
     'number,title,labels,body,state',
     '--limit',
@@ -127,7 +130,12 @@ function computeWaves(): number[][] {
 const waves = computeWaves();
 
 function isDone(issue: Issue): boolean {
-  return issue.labels.some((l) => l.name === 'status:done');
+  // A slice is complete if it carries status:done OR has been closed (the
+  // orchestrator closes slices on successful local integration).
+  return (
+    issue.state === 'CLOSED' ||
+    issue.labels.some((l) => l.name === 'status:done')
+  );
 }
 
 // ─── Plan summary ─────────────────────────────────────────────────────────────

--- a/.sandcastle/dispatch-waves.mts
+++ b/.sandcastle/dispatch-waves.mts
@@ -1,17 +1,19 @@
 /**
  * dispatch-waves — autonomous, dependency-aware driver around dispatch-agents.
  *
- * The base orchestrator (.sandcastle/main.mts) dispatches every ready AFK slice
- * for a PRD IN PARALLEL, each branched from the feature branch at run-start, and
- * squash-merges every finished slice PR back into the feature branch. Siblings in
- * the same run therefore never see each other's work — only a *later* run, which
- * re-branches from the updated feature branch, does.
+ * The base orchestrator (.sandcastle/main.mts) dispatches a PRD's ready AFK slices
+ * ONE BY ONE, each branched from the CURRENT local feature head, and fast-forwards
+ * every finished slice into the LOCAL feature branch (no push, no PR). Within a
+ * single run, a slice already sees the work of every earlier slice in that run.
  *
- * This driver exploits that: it topologically sorts the PRD's slices by their
- * `## Blocked by` sections into dependency waves, then runs ONE dispatch-agents
- * pass per wave — gating the `ready-for-agent` label so only the current wave is
- * picked up. Each wave's auto-merged output becomes the base for the next wave.
- * No human interaction between waves.
+ * This driver adds explicit dependency ORDERING across runs: it topologically sorts
+ * the PRD's slices by their `## Blocked by` sections into dependency waves, then runs
+ * ONE dispatch-agents pass per wave — gating the `ready-for-agent` label so only the
+ * current wave is picked up. Each wave's integrated output (on the local feature
+ * branch) becomes the base for the next wave. No human interaction between waves.
+ *
+ * Nothing is pushed and no PRs are opened — after all waves complete you QA the
+ * local feature branch, then push it and open ONE PR to `main` by hand.
  *
  * Usage: npx tsx .sandcastle/dispatch-waves.mts --prd <issue-number>
  */
@@ -200,7 +202,8 @@ for (let i = 0; i < waves.length; i++) {
   }
 
   // Invoke the existing orchestrator. It branches each ready slice from the
-  // (now updated) feature branch, runs the agent, and auto-merges the PR.
+  // (now updated) local feature branch, runs the agent, and fast-forwards the
+  // slice into the local feature branch.
   const dispatch = spawnSync(
     'npx',
     ['tsx', '.sandcastle/main.mts', '--prd', String(prdNumber)],
@@ -238,5 +241,6 @@ for (let i = 0; i < waves.length; i++) {
 console.log(`\n${'─'.repeat(55)}`);
 console.log(`All ${waves.length} waves complete for PRD #${prdNumber}.`);
 console.log(
-  `Review the feature branch, then open the final PR from it to main.\n`,
+  `The local feature branch now contains every slice. QA it, then push it and\n` +
+    `open ONE PR to main by hand:  git push -u origin <feature-branch> && gh pr create --base main\n`,
 );

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,11 +1,25 @@
 import { run, claudeCode } from '@ai-hero/sandcastle';
 import { docker } from '@ai-hero/sandcastle/sandboxes/docker';
-import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REPO = 'mnaimfaizy/myorganizer';
+
+// ─── Integration model (local-only) ───────────────────────────────────────────
+// GitHub coupling is deliberately minimal: we READ the PRD + slice issues and
+// WRITE status labels + a completion comment back to each slice. That is all.
+//
+// Everything else is LOCAL:
+//   • The feature branch `feat/<slug>` is created from origin/main and is NEVER
+//     pushed. It lives only in this clone until you push it by hand.
+//   • Slices run ONE BY ONE. Each branches off the CURRENT local feature head, so
+//     a slice sees every previously-merged slice's work. The agent commits inside
+//     its sandbox; the host fast-forwards the local feature branch onto the slice.
+//   • No per-slice push, no per-slice PR, no `gh pr merge`.
+//
+// After the run you QA the local feature branch, then push it and open ONE PR to
+// `main` yourself — CI runs there. See docs/adr/0010 and docs/sandcastle/RUNBOOK.md.
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -26,14 +40,11 @@ function fail(message: string, code = 1): never {
 function changedProjects(base: string, head: string): string[] {
   // Three-dot range: diff the slice head against the MERGE-BASE, i.e. only the
   // files the slice itself introduced — not files where the slice is merely
-  // behind an advanced base (e.g. another wave-mate already merged into the
-  // feature branch). A two-dot diff would over-report those, dragging unrelated
-  // projects into the gate.
-  const diff = spawnSync(
-    'git',
-    ['diff', '--name-only', `${base}...${head}`],
-    { encoding: 'utf8', windowsHide: true },
-  );
+  // behind an advanced base.
+  const diff = spawnSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
   const files = (diff.stdout || '')
     .split('\n')
     .map((s) => s.trim())
@@ -80,6 +91,16 @@ function gitCmd(args: string[]): string {
   return r.stdout.trim();
 }
 
+/** True if the git ref resolves locally (branch, remote-tracking ref, or sha). */
+function gitRefExists(ref: string): boolean {
+  return (
+    spawnSync('git', ['rev-parse', '--verify', '--quiet', ref], {
+      encoding: 'utf8',
+      windowsHide: true,
+    }).status === 0
+  );
+}
+
 // ─── Parse --prd <N> ─────────────────────────────────────────────────────────
 
 const prdFlag = process.argv.indexOf('--prd');
@@ -116,50 +137,24 @@ const featureSlug = featureName
 const featureBranch = `feat/${featureSlug}`;
 
 console.log(`\nPRD #${prdNumber}: ${featureName}`);
-console.log(`Feature branch:  ${featureBranch}\n`);
+console.log(`Feature branch:  ${featureBranch} (local only — never pushed)\n`);
 
-// ─── Create feature branch on origin if missing ───────────────────────────────
+// ─── Ensure the feature branch exists LOCALLY (never pushed) ───────────────────
+// The PRD branch is created once, locally, from the freshest main. It is the
+// integration target for every slice in this PRD. We do NOT create it on origin
+// and we do NOT push it — you push it by hand after QA to open the PRD PR.
 
-gitCmd(['fetch', 'origin']);
+gitCmd(['fetch', 'origin', 'main']);
 
-const remoteBranchExists =
-  spawnSync('git', ['ls-remote', '--exit-code', 'origin', featureBranch], {
-    encoding: 'utf8',
-    windowsHide: true,
-  }).status === 0;
-
-if (!remoteBranchExists) {
-  console.log(`Creating ${featureBranch} from origin/main...`);
-  const mainSha = gitCmd(['rev-parse', 'origin/main']);
-  const create = spawnSync(
-    'gh',
-    [
-      'api',
-      `repos/${REPO}/git/refs`,
-      '--method',
-      'POST',
-      '-f',
-      `ref=refs/heads/${featureBranch}`,
-      '-f',
-      `sha=${mainSha}`,
-    ],
-    { encoding: 'utf8', windowsHide: true },
+if (gitRefExists(featureBranch)) {
+  console.log(`Reusing existing local branch ${featureBranch}.`);
+} else {
+  const base = gitRefExists('origin/main') ? 'origin/main' : 'main';
+  gitCmd(['branch', featureBranch, base]);
+  console.log(
+    `Created local branch ${featureBranch} from ${base} (not pushed).`,
   );
-  if (create.status !== 0 && !create.stdout.includes('already_exists')) {
-    fail(`Failed to create ${featureBranch}: ${create.stderr.trim()}`);
-  }
-  console.log(`Branch ${featureBranch} created.`);
 }
-
-// Fetch the feature branch from origin.
-gitCmd(['fetch', 'origin', featureBranch]);
-console.log(`Fetched ${featureBranch} from origin.`);
-
-// Pre-create all slice branches locally from origin/<featureBranch> before
-// dispatching. This lets sandcastle's first `git worktree add <path> <slice>`
-// succeed directly — avoiding the fallback that tries to checkout featureBranch
-// itself, which would only work for one worktree at a time (race condition).
-// Branch creation is best-effort: ignore if already exists.
 
 // ─── Fetch AFK slice issues for this PRD ─────────────────────────────────────
 
@@ -195,113 +190,48 @@ if (slices.length === 0) {
   );
 }
 
-// ─── Linux node_modules cache ─────────────────────────────────────────────────
-// We maintain a Linux-native node_modules at .sandcastle/node_modules_linux_cache/.
-// It is seeded once via a short-lived Docker container and then BIND-MOUNTED into
-// every agent container at /home/agent/workspace/node_modules. Agents call
-// `yarn install --immutable` which exits in <5s (node_modules already present and
-// correct for Linux). The cache is invalidated when yarn.lock changes.
+// ─── Dependency install model ─────────────────────────────────────────────────
+// Each slice's node_modules is installed INSIDE the Linux container by a
+// `hooks.sandbox.onSandboxReady` hook that runs `corepack yarn install --immutable`
+// before the agent starts (see the run() call below). Installing in-container means
+// the native binaries (bcrypt, prisma, @swc/core) are always built for the
+// container's platform — so dispatch works correctly on WSL2, native Linux, AND
+// macOS hosts (a host-side install would bake in the host's wrong-arch binaries).
+//
+// Yarn's global cache is bind-mounted from .sandcastle/.yarn-cache (host) into every
+// container, so it survives across runs and is shared between slices. It is
+// content-addressable, so it NEVER needs full invalidation. Repeat installs are
+// incremental.
+//
+// The ONLY environment requirement: the worktree must live on a NATIVE filesystem
+// (ext4 on Linux/WSL2, APFS on macOS) — NOT a Windows-mounted path (/mnt/d, drvfs),
+// where the same install takes ~29 min instead of ~2 min. On Windows that means
+// running dispatch from inside WSL2 with the repo on ext4. See docs/adr/0009 and
+// docs/sandcastle/RUNBOOK.md.
 
-const linuxNmCache = join(
-  process.cwd(),
-  '.sandcastle',
-  'node_modules_linux_cache',
-);
-const cacheHashFile = join(linuxNmCache, '.cache-lockfile-hash');
-const lockfilePath = join(process.cwd(), 'yarn.lock');
+// Shared, content-addressable Yarn global cache, bind-mounted into every agent and
+// gate container at /home/agent/.yarn-cache (see YARN_GLOBAL_FOLDER below). Created
+// here so sandcastle's mount validation (which requires the host path to exist)
+// passes on a fresh checkout.
+const yarnCacheDir = join(process.cwd(), '.sandcastle', '.yarn-cache');
+mkdirSync(yarnCacheDir, { recursive: true });
 
-function lockfileHash(): string {
-  return createHash('sha256')
-    .update(readFileSync(lockfilePath))
-    .digest('hex')
-    .slice(0, 16);
-}
+// Env that makes every container use the bind-mounted global cache.
+const YARN_CACHE_ENV = {
+  YARN_ENABLE_GLOBAL_CACHE: 'true',
+  YARN_GLOBAL_FOLDER: '/home/agent/.yarn-cache',
+} as const;
 
-function cacheIsValid(): boolean {
-  if (!existsSync(join(linuxNmCache, '.yarn-state.yml'))) return false;
-  if (!existsSync(cacheHashFile)) return false;
-  return readFileSync(cacheHashFile, 'utf8').trim() === lockfileHash();
-}
+// Run the gate container as the host user so bind-mounted files (worktree, cache)
+// stay owned by the dispatcher. Matches the AGENT_UID/GID baked into the image by
+// sandcastle (host UID/GID at build). undefined on Windows, but dispatch runs on
+// Linux/WSL2/macOS where these are defined.
+const HOST_UID = process.getuid?.() ?? 1000;
+const HOST_GID = process.getgid?.() ?? 1000;
 
-if (!cacheIsValid()) {
-  console.log(
-    'Linux node_modules cache missing or stale — seeding via Docker (one-time, ~10-15 min)...',
-  );
-  mkdirSync(linuxNmCache, { recursive: true });
-  const hash = lockfileHash();
-  const seed = spawnSync(
-    'docker',
-    [
-      'run',
-      '--rm',
-      '--entrypoint',
-      '/bin/bash',
-      '--user',
-      '1000:1000',
-      '-v',
-      `${process.cwd()}:/home/agent/workspace`,
-      '-v',
-      `${linuxNmCache}:/home/agent/workspace/node_modules`,
-      'sandcastle:myorganizer',
-      '-c',
-      `cd /home/agent/workspace && corepack yarn install 2>&1 && echo ${hash} > /home/agent/workspace/node_modules/.cache-lockfile-hash`,
-    ],
-    { encoding: 'utf8', stdio: 'inherit', windowsHide: true, timeout: 1800000 },
-  );
-  if (seed.status !== 0) {
-    console.error(
-      'Warning: cache seed failed — agents will run yarn install themselves (slow).',
-    );
-  } else {
-    writeFileSync(cacheHashFile, hash);
-    console.log('Linux node_modules cache ready.\n');
-  }
-} else {
-  console.log(
-    'Linux node_modules cache valid — agents start with node_modules pre-populated.\n',
-  );
-}
-
-// Pre-create slice branches and worktrees so sandcastle reuses them on first try.
 const worktreesDir = join(process.cwd(), '.sandcastle', 'worktrees');
 
-for (const issue of slices) {
-  const sb = sliceBranchFor(issue);
-
-  // 1. Ensure local branch exists.
-  const branchExists =
-    spawnSync('git', ['rev-parse', '--verify', sb], {
-      encoding: 'utf8',
-      windowsHide: true,
-    }).status === 0;
-  if (!branchExists) {
-    spawnSync('git', ['branch', sb, `origin/${featureBranch}`], {
-      encoding: 'utf8',
-      windowsHide: true,
-    });
-    console.log(`  Pre-created branch ${sb}`);
-  }
-
-  // 2. Ensure the worktree directory exists so sandcastle reuses it.
-  const worktreeName = sb.replace(/\//g, '-');
-  const worktreePath = join(worktreesDir, worktreeName);
-  if (!existsSync(worktreePath)) {
-    const wt = spawnSync('git', ['worktree', 'add', worktreePath, sb], {
-      encoding: 'utf8',
-      windowsHide: true,
-    });
-    if (wt.status !== 0) {
-      console.error(
-        `  Warning: could not create worktree for ${sb}: ${wt.stderr.trim()}`,
-      );
-    } else {
-      console.log(`  Pre-created worktree  ${worktreeName}`);
-    }
-  }
-}
-console.log();
-
-console.log(`Dispatching ${slices.length} slice(s) in parallel...\n`);
+console.log(`Dispatching ${slices.length} slice(s) one by one...\n`);
 
 // ─── Model routing ────────────────────────────────────────────────────────────
 
@@ -322,55 +252,22 @@ function sliceBranchFor(issue: Issue): string {
   return `slice/${issue.number}-${slug}`;
 }
 
-// ─── Build gate ───────────────────────────────────────────────────────────────
-// Before a slice PR is merged into the feature branch, lint its affected projects
-// in a Docker container. Fail closed: if the gate cannot run or does not pass, the
-// slice is NOT merged and NOT marked status:done, so dispatch-waves halts rather
-// than branching dependent slices off broken code. Disable with SLICE_GATE=off.
-
-// Serialize gate execution so multiple parallel slices never run
-// `yarn install` into the shared node_modules cache mount at the same time.
-let gateLock: Promise<void> = Promise.resolve();
-async function gated<T>(fn: () => T): Promise<T> {
-  const prev = gateLock;
-  let release!: () => void;
-  gateLock = new Promise<void>((r) => (release = r));
-  await prev;
-  try {
-    return fn();
-  } finally {
-    release();
-  }
-}
-
-// Host-side push. Agents run in a credential-less sandbox and only commit
-// locally; the host (which has working git/gh credentials) finalizes and pushes
-// the slice branch so a PR can be opened. Operates on the local branch ref — which
-// carries the agent's commit even after sandcastle has cleaned up the worktree
-// directory. Returns false if there is nothing to push or the push fails.
-function pushSliceBranch(issue: Issue, sliceBranch: string): boolean {
-  const branchExists =
-    spawnSync('git', ['rev-parse', '--verify', '--quiet', sliceBranch], {
-      encoding: 'utf8',
-      windowsHide: true,
-    }).status === 0;
-  if (!branchExists) {
+// ─── Finalize the agent's local commit ─────────────────────────────────────────
+// Agents run in a credential-less sandbox and only commit locally on their slice
+// branch. Their commit lands on the local slice-branch ref (shared .git), so there
+// is nothing to push. This just captures any stray uncommitted changes the agent
+// left (formatting, generated files) and confirms the slice actually produced work.
+function finalizeSliceBranch(issue: Issue, sliceBranch: string): boolean {
+  if (!gitRefExists(sliceBranch)) {
     console.error(
-      `  [#${issue.number}] push: local branch ${sliceBranch} not found — nothing to push.`,
+      `  [#${issue.number}] local branch ${sliceBranch} not found — nothing to integrate.`,
     );
     return false;
   }
 
-  // If the agent's worktree survived AND has uncommitted changes (formatting,
-  // generated files), capture them. --no-verify skips host husky hooks; the
-  // build gate is the real check. When sandcastle already cleaned up the
-  // worktree the agent's commit is on the branch ref, so this is best-effort.
-  const worktreePath = join(
-    process.cwd(),
-    '.sandcastle',
-    'worktrees',
-    sliceBranch.replace(/\//g, '-'),
-  );
+  // If the agent's worktree survived AND has uncommitted changes, capture them.
+  // --no-verify skips host husky hooks; the gate is the real check.
+  const worktreePath = join(worktreesDir, sliceBranch.replace(/\//g, '-'));
   if (existsSync(worktreePath)) {
     const dirty = (
       spawnSync('git', ['-C', worktreePath, 'status', '--porcelain'], {
@@ -398,91 +295,51 @@ function pushSliceBranch(issue: Issue, sliceBranch: string): boolean {
     }
   }
 
-  // Nothing ahead of the feature branch means the agent produced no mergeable
-  // work — treat as a failure so the wave halts rather than opening an empty PR.
+  // Nothing ahead of the feature branch means the agent produced no work.
   const ahead = spawnSync(
     'git',
-    ['rev-list', '--count', `origin/${featureBranch}..${sliceBranch}`],
+    ['rev-list', '--count', `${featureBranch}..${sliceBranch}`],
     { encoding: 'utf8', windowsHide: true },
   );
   if ((ahead.stdout || '').trim() === '0') {
     console.error(
-      `  [#${issue.number}] push: ${sliceBranch} has no commits beyond ${featureBranch} — nothing to merge.`,
+      `  [#${issue.number}] ${sliceBranch} has no commits beyond ${featureBranch} — nothing to integrate.`,
     );
     return false;
   }
-
-  const push = spawnSync(
-    'git',
-    ['push', '--force-with-lease', 'origin', `${sliceBranch}:${sliceBranch}`],
-    { encoding: 'utf8', stdio: 'pipe', windowsHide: true },
-  );
-  if (push.status !== 0) {
-    console.error(`  [#${issue.number}] push failed:\n${push.stderr}`);
-    return false;
-  }
-  console.log(`  [#${issue.number}] pushed ${sliceBranch} to origin.`);
   return true;
 }
 
+// ─── Build gate ───────────────────────────────────────────────────────────────
+// Before a slice is fast-forwarded into the LOCAL feature branch, lint its changed
+// projects in a Docker container against the LOCAL slice branch. Fail closed: if the
+// gate cannot run or does not pass, the slice is NOT integrated and NOT marked
+// status:done, so we never stack later slices on broken code. Disable with
+// SLICE_GATE=off.
 function runSliceGate(issue: Issue, sliceBranch: string): boolean {
   if ((process.env.SLICE_GATE ?? '').toLowerCase() === 'off') {
     console.log(
-      `  [#${issue.number}] gate disabled (SLICE_GATE=off) — merging without verification.`,
+      `  [#${issue.number}] gate disabled (SLICE_GATE=off) — integrating without verification.`,
     );
     return true;
   }
 
   const targets = (process.env.SLICE_GATE_TARGETS || 'lint').trim();
-
-  // Slices that change yarn.lock add dependencies the shared (already-seeded)
-  // node_modules cache does not contain. Linting them against that stale cache
-  // fails spuriously, and installing into the shared mount would corrupt it for
-  // other slices. Skip the gate for dependency-changing slices — they are verified
-  // another way (the agent's own in-sandbox build, or manual review of the dep PR).
-  spawnSync('git', ['fetch', 'origin', sliceBranch], {
-    encoding: 'utf8',
-    windowsHide: true,
-  });
-  const lockDiff = spawnSync(
-    'git',
-    [
-      'diff',
-      '--name-only',
-      `origin/${featureBranch}`,
-      `origin/${sliceBranch}`,
-      '--',
-      'yarn.lock',
-    ],
-    { encoding: 'utf8', windowsHide: true },
-  );
-  if ((lockDiff.stdout || '').trim() !== '') {
-    console.log(
-      `  [#${issue.number}] gate: yarn.lock changed — skipping lint gate (shared cache cannot validate new deps). NOT gated.`,
-    );
-    return true;
-  }
+  const targetList = targets.split(/[\s,]+/).filter(Boolean);
 
   // Gate only the projects whose OWN files this slice changed — not their
   // transitive dependents. For a per-file lint gate, an upstream change cannot
-  // introduce lint errors downstream, so linting dependents just adds slowness
-  // and couples the slice to unrelated projects' lint state (which produced a
-  // spurious 14-project sweep + blind failure before this change).
-  const projects = changedProjects(
-    `origin/${featureBranch}`,
-    `origin/${sliceBranch}`,
-  );
+  // introduce lint errors downstream.
+  const projects = changedProjects(featureBranch, sliceBranch);
   if (projects.length === 0) {
-    console.log(
-      `  [#${issue.number}] gate: no project files changed — pass.`,
-    );
+    console.log(`  [#${issue.number}] gate: no project files changed — pass.`);
     return true;
   }
 
-  // Gate in a DEDICATED detached worktree at the pushed commit. Detached + a
-  // separate path means it never holds the slice branch checked out (so the
-  // post-merge --delete-branch works) and it is independent of sandcastle's own
-  // worktree lifecycle, which may already have removed the agent's worktree.
+  // Gate in a DEDICATED detached worktree at the local slice commit. Detached + a
+  // separate path means it never holds the slice branch checked out and it is
+  // independent of sandcastle's own worktree lifecycle (which may already have
+  // removed the agent's worktree).
   const gateName = sliceBranch.replace(/\//g, '-');
   const gateRoot = join(process.cwd(), '.sandcastle', 'gate');
   const gatePath = join(gateRoot, gateName);
@@ -497,13 +354,9 @@ function runSliceGate(issue: Issue, sliceBranch: string): boolean {
       windowsHide: true,
     });
   }
-  spawnSync('git', ['fetch', 'origin', sliceBranch], {
-    encoding: 'utf8',
-    windowsHide: true,
-  });
   const add = spawnSync(
     'git',
-    ['worktree', 'add', '--detach', gatePath, `origin/${sliceBranch}`],
+    ['worktree', 'add', '--detach', gatePath, sliceBranch],
     { encoding: 'utf8', windowsHide: true },
   );
   if (add.status !== 0) {
@@ -514,41 +367,48 @@ function runSliceGate(issue: Issue, sliceBranch: string): boolean {
   }
 
   try {
+    // Validate this slice INSIDE the Linux container (cross-platform: WSL2, native
+    // Linux, and macOS hosts all work). Install the slice's EXACT tree in-container
+    // — so the gate validates lock-changing slices correctly, with binaries matching
+    // the container — then run nx. Shares the bind-mounted Yarn global cache, so the
+    // install is incremental. Fail closed on any failure.
     console.log(
-      `  [#${issue.number}] gate: running '${targets}' on ${projects.join(', ')} ...`,
+      `  [#${issue.number}] gate: installing + running '${targets}' on ${projects.join(', ')} ...`,
     );
-    // Explicit --projects means no git is needed inside the container.
     const gate = spawnSync(
       'docker',
       [
         'run',
         '--rm',
-        '--entrypoint',
-        '/bin/bash',
         '--user',
-        '1000:1000',
+        `${HOST_UID}:${HOST_GID}`,
+        '-e',
+        'HOME=/home/agent',
         '-e',
         'NX_DAEMON=false',
         '-e',
         'NX_ISOLATE_PLUGINS=false',
         '-e',
         'NX_SKIP_NX_CACHE=true',
+        '-e',
+        `YARN_ENABLE_GLOBAL_CACHE=${YARN_CACHE_ENV.YARN_ENABLE_GLOBAL_CACHE}`,
+        '-e',
+        `YARN_GLOBAL_FOLDER=${YARN_CACHE_ENV.YARN_GLOBAL_FOLDER}`,
         '-v',
         `${gatePath}:/home/agent/workspace`,
         '-v',
-        `${linuxNmCache}:/home/agent/workspace/node_modules`,
+        `${yarnCacheDir}:/home/agent/.yarn-cache`,
+        '--entrypoint',
+        '/bin/bash',
         'sandcastle:myorganizer',
         '-c',
-        // Invoke nx directly from the mounted, already-seeded node_modules — no
-        // yarn/corepack/npx (which can fall back to Yarn 1 in a worktree) and no
-        // install (which would write into and corrupt the shared cache mount).
-        `cd /home/agent/workspace && node node_modules/.bin/nx run-many -t ${targets} --projects=${projects.join(',')} --skip-nx-cache`,
+        `cd /home/agent/workspace && corepack yarn install --immutable && node node_modules/.bin/nx run-many -t ${targetList.join(' ')} --projects=${projects.join(',')} --skip-nx-cache`,
       ],
       {
         encoding: 'utf8',
         stdio: 'inherit',
         windowsHide: true,
-        timeout: 1200000,
+        timeout: 1800000,
       },
     );
 
@@ -563,6 +423,40 @@ function runSliceGate(issue: Issue, sliceBranch: string): boolean {
   }
 }
 
+// ─── Integrate a slice into the local feature branch (fast-forward) ────────────
+// Slices run serially, each branched off the current feature head, so the slice is
+// always a pure descendant of the feature branch — a fast-forward, no merge commit,
+// no conflicts. We advance the (un-checked-out) feature ref with `git branch -f`.
+// Nothing is pushed. Fails closed if the slice is somehow not a descendant.
+function integrateSlice(issue: Issue, sliceBranch: string): boolean {
+  const isDescendant =
+    spawnSync(
+      'git',
+      ['merge-base', '--is-ancestor', featureBranch, sliceBranch],
+      { encoding: 'utf8', windowsHide: true },
+    ).status === 0;
+  if (!isDescendant) {
+    console.error(
+      `  [#${issue.number}] integrate: ${sliceBranch} is not a fast-forward of ${featureBranch} — failing closed (resolve by hand).`,
+    );
+    return false;
+  }
+  const ff = spawnSync('git', ['branch', '-f', featureBranch, sliceBranch], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (ff.status !== 0) {
+    console.error(
+      `  [#${issue.number}] integrate: failed to advance ${featureBranch}.\n${ff.stderr}`,
+    );
+    return false;
+  }
+  console.log(
+    `  [#${issue.number}] integrated into local ${featureBranch} (fast-forward).`,
+  );
+  return true;
+}
+
 function buildPrompt(issue: Issue, sliceBranch: string): string {
   return [
     `You are implementing GitHub Issue #${issue.number}: ${issue.title}`,
@@ -573,13 +467,13 @@ function buildPrompt(issue: Issue, sliceBranch: string): string {
     ``,
     `## Instructions`,
     ``,
-    `- Run \`corepack yarn install --immutable\` as your first step (expect ~3 min — node_modules is pre-seeded with Linux-native binaries so no compilation occurs, but yarn still fetches and links). Do not skip or interrupt this step.`,
+    `- Dependencies are ALREADY installed in this sandbox before you start (a setup hook runs \`corepack yarn install --immutable\`). Do NOT run \`yarn install\` yourself.`,
     `- Read CLAUDE.md, CONTEXT.md, and TECH_STACK.md before making any changes.`,
     `- Implement this vertical slice end-to-end (schema → API → UI → tests where applicable).`,
     `- Your working branch is \`${sliceBranch}\` (based on \`${featureBranch}\`). Do not switch branches.`,
     `- Follow all mandatory delegation rules in CLAUDE.md (tests → TestScaffold, components → ComponentBuilder, etc.).`,
     `- Commit your changes using Conventional Commit messages (\`corepack yarn ai:commit\`).`,
-    `- Do NOT push — this sandbox has no push credentials. The orchestrator pushes your branch from the host after you finish. Just commit locally; leave nothing uncommitted.`,
+    `- Do NOT push and do NOT open a PR — this sandbox has no credentials. Just commit locally on your branch; leave nothing uncommitted. The orchestrator integrates your branch into the feature branch on the host.`,
     `- When implementation is complete, output <promise>COMPLETE</promise>.`,
     ``,
     `## Running tests in this sandbox`,
@@ -609,32 +503,69 @@ function buildPrompt(issue: Issue, sliceBranch: string): string {
   ].join('\n');
 }
 
-// ─── Dispatch all slices in parallel ─────────────────────────────────────────
+// ─── Dispatch slices one by one ───────────────────────────────────────────────
 
 type SliceResult = {
   issue: Issue;
   sliceBranch: string;
-  prUrl: string;
   commits: number;
   merged: boolean;
+  reason: string;
 };
 
-const results = await Promise.allSettled<SliceResult>(
-  slices.map(async (issue): Promise<SliceResult> => {
-    const model = modelFor(issue);
-    const sliceBranch = sliceBranchFor(issue);
+const results: SliceResult[] = [];
+const crashed: Array<{ issue: Issue; error: string }> = [];
 
-    console.log(`  → #${issue.number} on ${sliceBranch} (${model})`);
+for (const issue of slices) {
+  const model = modelFor(issue);
+  const sliceBranch = sliceBranchFor(issue);
 
-    ghSilent([
-      'issue',
-      'edit',
-      String(issue.number),
-      '--repo',
-      REPO,
-      '--add-label',
-      'status:in-progress',
-    ]);
+  ghSilent([
+    'issue',
+    'edit',
+    String(issue.number),
+    '--repo',
+    REPO,
+    '--add-label',
+    'status:in-progress',
+  ]);
+
+  try {
+    console.log(`\n  → #${issue.number} on ${sliceBranch} (${model})`);
+
+    // Fresh slice branch + worktree off the CURRENT local feature head, so this
+    // slice (processed one by one) builds on every previously-integrated slice.
+    // Clear any stale branch/worktree from an earlier run first.
+    const worktreeName = sliceBranch.replace(/\//g, '-');
+    const worktreePath = join(worktreesDir, worktreeName);
+    if (existsSync(worktreePath)) {
+      spawnSync('git', ['worktree', 'remove', '--force', worktreePath], {
+        encoding: 'utf8',
+        windowsHide: true,
+      });
+    }
+    spawnSync('git', ['worktree', 'prune'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    spawnSync('git', ['branch', '-D', sliceBranch], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    gitCmd(['branch', sliceBranch, featureBranch]);
+    const wt = spawnSync(
+      'git',
+      ['worktree', 'add', worktreePath, sliceBranch],
+      {
+        encoding: 'utf8',
+        windowsHide: true,
+      },
+    );
+    if (wt.status !== 0) {
+      throw new Error(
+        `could not create worktree for ${sliceBranch}: ${wt.stderr.trim()}`,
+      );
+    }
 
     const result = await run({
       agent: claudeCode(model),
@@ -643,21 +574,13 @@ const results = await Promise.allSettled<SliceResult>(
           NX_DAEMON: 'false',
           NX_ISOLATE_PLUGINS: 'false',
           NX_SKIP_NX_CACHE: 'true',
+          ...YARN_CACHE_ENV,
         },
-        // Mount the pre-seeded Linux node_modules cache over the worktree's
-        // node_modules directory. This gives agents a working Linux-native
-        // node_modules instantly — `yarn install --immutable` exits in <5s.
+        // Bind-mount the shared, content-addressable Yarn global cache so the
+        // in-container install (below) is incremental and never re-downloads
+        // across slices.
         mounts: [
-          {
-            // Absolute host path — relative paths lose the drive letter on Windows.
-            // Absolute Linux container path — relative paths get a D: prefix on Windows.
-            hostPath: join(
-              process.cwd(),
-              '.sandcastle',
-              'node_modules_linux_cache',
-            ),
-            sandboxPath: '/home/agent/workspace/node_modules',
-          },
+          { hostPath: yarnCacheDir, sandboxPath: '/home/agent/.yarn-cache' },
         ],
       }),
       name: `#${issue.number}`,
@@ -666,75 +589,33 @@ const results = await Promise.allSettled<SliceResult>(
         branch: sliceBranch,
         baseBranch: featureBranch,
       },
+      // Install this slice's deps INSIDE the container before the agent starts, so
+      // native binaries match the container's platform (correct on WSL2, Linux, and
+      // macOS hosts). Writes node_modules to the bind-mounted worktree, which MUST
+      // be on a native fs (ext4/APFS) — ~2 min there vs ~29 min on a Windows mount.
+      hooks: {
+        sandbox: {
+          onSandboxReady: [
+            {
+              command: 'corepack yarn install --immutable',
+              timeoutMs: 1200000,
+            },
+          ],
+        },
+      },
       maxIterations: 25,
-      // Quiet stretches (yarn install, codegen, builds) can exceed the 600s
-      // default and trip the idle watchdog; give long-running slices headroom.
+      // Quiet stretches (codegen, builds) can exceed the 600s default and trip the
+      // idle watchdog; give long-running slices headroom.
       idleTimeoutSeconds: 1800,
       prompt: buildPrompt(issue, sliceBranch),
     });
 
-    // Host-side push: the sandbox has no push credentials, so the host finalizes
-    // and pushes the slice branch before any PR can be opened.
-    const pushOk = pushSliceBranch(issue, sliceBranch);
-
-    // Create PR from slice branch → feature branch (only once it exists on origin).
-    const prCreate = pushOk
-      ? spawnSync(
-          'gh',
-          [
-            'pr',
-            'create',
-            '--repo',
-            REPO,
-            '--head',
-            sliceBranch,
-            '--base',
-            featureBranch,
-            '--title',
-            issue.title,
-            '--body',
-            `Closes #${issue.number}\n\nPart of \`${featureBranch}\` — see PRD #${prdNumber}.`,
-          ],
-          { encoding: 'utf8', windowsHide: true },
-        )
-      : null;
-
-    const prCreated = prCreate !== null && prCreate.status === 0;
-    const prUrl = !pushOk
-      ? '(push to origin failed)'
-      : prCreated
-        ? prCreate!.stdout.trim()
-        : `(PR creation failed: ${prCreate!.stderr.trim().slice(0, 80)})`;
-
-    // Build gate before merge. Serialized so parallel slices never run
-    // `yarn install` into the shared node_modules cache mount concurrently.
-    const gatePassed = prCreated
-      ? await gated(() => runSliceGate(issue, sliceBranch))
-      : false;
-
-    const merged = prCreated && gatePassed;
-
-    let mergeOk = false;
-    if (merged) {
-      // Gate green → squash-merge into the feature branch. `gh pr merge` is
-      // non-interactive when a merge-method flag is given and stdin isn't a TTY;
-      // there is no `--yes` flag (passing it aborts the merge).
-      const prMerge = spawnSync(
-        'gh',
-        ['pr', 'merge', prUrl, '--squash', '--delete-branch', '--repo', REPO],
-        { encoding: 'utf8', stdio: 'inherit', windowsHide: true },
-      );
-      mergeOk = prMerge.status === 0;
-      if (!mergeOk) {
-        console.error(
-          `  Warning: auto-merge failed for ${prUrl} — merge manually before opening the feature PR.`,
-        );
-      }
-    }
+    // Finalize → gate → integrate, all LOCAL. No push, no PR.
+    const hasWork = finalizeSliceBranch(issue, sliceBranch);
+    const gatePassed = hasWork ? runSliceGate(issue, sliceBranch) : false;
+    const mergeOk = gatePassed ? integrateSlice(issue, sliceBranch) : false;
 
     if (mergeOk) {
-      // Only mark done once the slice is actually on the feature branch, so a
-      // failed merge doesn't make the wave-runner skip an unmerged slice.
       ghSilent([
         'issue',
         'edit',
@@ -746,7 +627,6 @@ const results = await Promise.allSettled<SliceResult>(
         '--add-label',
         'status:done',
       ]);
-
       ghSilent([
         'issue',
         'comment',
@@ -754,11 +634,11 @@ const results = await Promise.allSettled<SliceResult>(
         '--repo',
         REPO,
         '--body',
-        `Agent completed and the build gate passed. ${result.commits.length} commit(s) on \`${sliceBranch}\`.\nMerged into \`${featureBranch}\`. PR: ${prUrl}`,
+        `Agent completed and the build gate passed. ${result.commits.length} commit(s) on \`${sliceBranch}\`.\n` +
+          `Integrated into the local \`${featureBranch}\` (fast-forward, not pushed). ` +
+          `It will reach \`main\` via the manual PRD PR.`,
       ]);
     } else {
-      // PR failed OR gate failed → do NOT merge, do NOT mark status:done, so the
-      // wave-runner halts instead of branching dependents off broken code.
       ghSilent([
         'issue',
         'edit',
@@ -768,14 +648,11 @@ const results = await Promise.allSettled<SliceResult>(
         '--remove-label',
         'status:in-progress',
       ]);
-
-      const reason = !pushOk
-        ? 'its branch could not be pushed to origin'
-        : !prCreated
-          ? 'the PR could not be created'
-          : !merged
-            ? `the build gate (${process.env.SLICE_GATE_TARGETS || 'lint'}) failed`
-            : 'the gate passed but the auto-merge command failed';
+      const reason = !hasWork
+        ? 'it produced no commits'
+        : !gatePassed
+          ? `the build gate (${process.env.SLICE_GATE_TARGETS || 'lint'}) failed`
+          : 'the local fast-forward integration failed';
       ghSilent([
         'issue',
         'comment',
@@ -783,61 +660,81 @@ const results = await Promise.allSettled<SliceResult>(
         '--repo',
         REPO,
         '--body',
-        `Agent finished but ${reason} — slice was NOT merged into \`${featureBranch}\`. ` +
-          `Branch \`${sliceBranch}\` and its PR are left open for inspection: ${prUrl}\n\n` +
-          `Dependent waves are halted. Fix the slice, then re-run \`yarn dispatch-waves\` (completed waves are skipped).`,
+        `Agent finished but ${reason} — slice was NOT integrated into \`${featureBranch}\`. ` +
+          `The local branch \`${sliceBranch}\` is left in place for inspection. ` +
+          `Later slices in this PRD will NOT include this one until it is fixed and re-run.`,
       ]);
+      results.push({
+        issue,
+        sliceBranch,
+        commits: result.commits.length,
+        merged: false,
+        reason,
+      });
+      continue;
     }
 
-    return {
+    results.push({
       issue,
       sliceBranch,
-      prUrl,
       commits: result.commits.length,
-      merged: mergeOk,
-    };
-  }),
-);
+      merged: true,
+      reason: 'integrated',
+    });
+  } catch (e) {
+    ghSilent([
+      'issue',
+      'edit',
+      String(issue.number),
+      '--repo',
+      REPO,
+      '--remove-label',
+      'status:in-progress',
+    ]);
+    console.error(`  ✗ #${issue.number} crashed: ${String(e)}`);
+    crashed.push({ issue, error: String(e) });
+  }
+}
 
 // ─── Summary ─────────────────────────────────────────────────────────────────
 
-const fulfilled = results.filter(
-  (r): r is PromiseFulfilledResult<SliceResult> => r.status === 'fulfilled',
-);
-const merged = fulfilled.filter((r) => r.value.merged);
-const blocked = fulfilled.filter((r) => !r.value.merged);
-const failed = results.filter(
-  (r): r is PromiseRejectedResult => r.status === 'rejected',
-);
+const merged = results.filter((r) => r.merged);
+const blocked = results.filter((r) => !r.merged);
 
 console.log(`\n${'─'.repeat(55)}`);
 console.log(
-  `Batch done: ${merged.length} merged, ${blocked.length} blocked (gate/PR), ${failed.length} crashed.\n`,
+  `Batch done: ${merged.length} integrated, ${blocked.length} blocked (gate/no-work), ${crashed.length} crashed.\n`,
 );
 
 for (const r of merged) {
-  console.log(`  ✓ #${r.value.issue.number} merged — ${r.value.prUrl}`);
-}
-for (const r of blocked) {
-  console.error(
-    `  ⚠ #${r.value.issue.number} NOT merged (gate failed / PR open) — ${r.value.prUrl}`,
+  console.log(
+    `  ✓ #${r.issue.number} integrated — ${r.commits} commit(s) on ${featureBranch}`,
   );
 }
-for (const r of failed) {
-  console.error(`  ✗ ${String(r.reason)}`);
+for (const r of blocked) {
+  console.error(`  ⚠ #${r.issue.number} NOT integrated — ${r.reason}`);
+}
+for (const r of crashed) {
+  console.error(`  ✗ #${r.issue.number} crashed — ${r.error}`);
 }
 
-if (blocked.length > 0 || failed.length > 0) {
+if (blocked.length > 0 || crashed.length > 0) {
   console.log(
-    `\nOne or more slices did not merge. Dependent waves will halt until resolved.`,
+    `\nOne or more slices did not integrate. Fix them and re-run — done slices are skipped.`,
   );
 }
 if (merged.length > 0) {
-  console.log(`\nNext step: review slice PRs targeting \`${featureBranch}\`,`);
-  console.log(`then open a final PR from \`${featureBranch}\` to \`main\`.`);
+  console.log(`\nNext step: QA the local \`${featureBranch}\` branch`);
+  console.log(
+    `  git switch ${featureBranch}   # it now contains the merged slices`,
+  );
+  console.log(`Then push it and open ONE PR to \`main\` manually so CI runs:`);
+  console.log(
+    `  git push -u origin ${featureBranch} && gh pr create --base main`,
+  );
 }
 
-// ─── Desktop notification (Windows) ──────────────────────────────────────────
+// ─── Desktop notification (best-effort; Windows / WSL2 only) ───────────────────
 
 const safeTitle = featureName.replace(/'/g, "''");
 spawnSync(
@@ -847,7 +744,7 @@ spawnSync(
     [
       'Add-Type -AssemblyName System.Windows.Forms;',
       `[System.Windows.Forms.MessageBox]::Show(`,
-      `  '${merged.length} merged, ${blocked.length} blocked, ${failed.length} crashed.` +
+      `  '${merged.length} integrated, ${blocked.length} blocked, ${crashed.length} crashed.` +
         `\\nPRD #${prdNumber}: ${safeTitle}',`,
       `  'dispatch-agents complete', 'OK', 'Information'`,
       `)`,

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -627,15 +627,21 @@ for (const issue of slices) {
         '--add-label',
         'status:done',
       ]);
+      // Close the slice on successful local integration. status:done + closed
+      // makes re-runs idempotent — both this orchestrator's open+afk filter and
+      // dispatch-waves treat a closed slice as complete and skip it. The work is
+      // on the local feature branch and reaches `main` via the manual PRD PR.
       ghSilent([
         'issue',
-        'comment',
+        'close',
         String(issue.number),
         '--repo',
         REPO,
-        '--body',
+        '--reason',
+        'completed',
+        '--comment',
         `Agent completed and the build gate passed. ${result.commits.length} commit(s) on \`${sliceBranch}\`.\n` +
-          `Integrated into the local \`${featureBranch}\` (fast-forward, not pushed). ` +
+          `Integrated into the local \`${featureBranch}\` (fast-forward, not pushed) and closed as completed. ` +
           `It will reach \`main\` via the manual PRD PR.`,
       ]);
     } else {

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -11,10 +11,12 @@
 
 You are implementing a vertical slice for MyOrganizer.
 
+- Dependencies are **already installed** in this sandbox before you start (a setup hook runs `corepack yarn install --immutable`). Do NOT run `yarn install` yourself.
 - Read `CLAUDE.md`, `CONTEXT.md`, and `TECH_STACK.md` before making any changes.
 - Follow all mandatory delegation rules in `CLAUDE.md` (tests → TestScaffold, components → ComponentBuilder, etc.).
 - Work only on the branch you were given. Do not switch branches.
 - Commit with Conventional Commit messages (`corepack yarn ai:commit`).
+- Do NOT push and do NOT open a PR — the sandbox has no credentials. Just commit locally; the orchestrator integrates your branch into the feature branch on the host.
 
 # Task
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,17 +167,19 @@ Fetches the PRD, drafts vertical slices (AFK / HITL + complexity), quizzes you o
 yarn dispatch-agents --prd <prd-issue-number>
 ```
 
-The orchestrator:
+The orchestrator (integration is **local-only** — see `docs/adr/0010`):
 
-1. Creates `feat/<feature-slug>` from `origin/main` (if it doesn't exist)
-2. Fans out one sandcastle agent per AFK slice, each on its own `slice/N-slug` branch in Docker isolation
+1. Creates `feat/<feature-slug>` from `origin/main` **locally and never pushes it** (if it doesn't exist)
+2. Runs one sandcastle agent per AFK slice **one at a time** in Docker isolation, each slice branched from the _current_ local feature head (so a slice sees earlier slices' work)
 3. Routes the model from the `complexity:*` label (Haiku → Sonnet → Opus)
-4. On completion: applies `status:done`, creates a PR from slice branch → feature branch, posts a comment on the issue
+4. Per slice: runs a Docker lint gate, then **fast-forwards the slice into the local feature branch** (no per-slice push, no per-slice PR); applies `status:done` and posts a comment on the issue
 5. Sends a desktop notification when the full batch is done
+
+GitHub is touched only to **read** issues and **write** status labels + a completion comment. Nothing is pushed to origin.
 
 ### Step 4 — Review and merge (user returns)
 
-Review each slice PR targeting `feat/<slug>`. After all slice PRs are merged, open a final PR from `feat/<slug>` to `main`.
+QA the local `feat/<slug>` branch — it now contains every integrated slice. When satisfied, push it and open **one** PR from `feat/<slug>` to `main`; CI runs there, then merge it on GitHub. There are no per-slice PRs.
 
 ### Key distinctions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ The orchestrator (integration is **local-only** — see `docs/adr/0010`):
 1. Creates `feat/<feature-slug>` from `origin/main` **locally and never pushes it** (if it doesn't exist)
 2. Runs one sandcastle agent per AFK slice **one at a time** in Docker isolation, each slice branched from the _current_ local feature head (so a slice sees earlier slices' work)
 3. Routes the model from the `complexity:*` label (Haiku → Sonnet → Opus)
-4. Per slice: runs a Docker lint gate, then **fast-forwards the slice into the local feature branch** (no per-slice push, no per-slice PR); applies `status:done` and posts a comment on the issue
+4. Per slice: runs a Docker lint gate, then **fast-forwards the slice into the local feature branch** (no per-slice push, no per-slice PR); applies `status:done`, **closes the slice issue** (reason: completed), and posts a comment on it
 5. Sends a desktop notification when the full batch is done
 
 GitHub is touched only to **read** issues and **write** status labels + a completion comment. Nothing is pushed to origin.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,7 +79,7 @@ A Slice Issue requiring a human decision before an agent can proceed. Skipped by
 _Avoid_: Blocked issue, human task
 
 **dispatch-agents**:
-The `yarn dispatch-agents --prd <issue-number>` command that triggers the sandcastle orchestrator. Reads AFK Slice Issues labelled `ready-for-agent`, creates the feature branch, and fans out one sandcastle agent per slice running in Docker isolation.
+The `yarn dispatch-agents --prd <issue-number>` command that triggers the sandcastle orchestrator. Reads AFK Slice Issues labelled `ready-for-agent`, creates the feature branch **locally (never pushed)**, and runs one sandcastle agent per slice — one at a time, in Docker isolation — fast-forwarding each finished slice into the local feature branch. Integration is local: you push the feature branch and open one PR to `main` by hand.
 _Avoid_: Agent runner, orchestrator command, run-agents
 
 ## Agent Roles

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,7 +79,7 @@ A Slice Issue requiring a human decision before an agent can proceed. Skipped by
 _Avoid_: Blocked issue, human task
 
 **dispatch-agents**:
-The `yarn dispatch-agents --prd <issue-number>` command that triggers the sandcastle orchestrator. Reads AFK Slice Issues labelled `ready-for-agent`, creates the feature branch **locally (never pushed)**, and runs one sandcastle agent per slice — one at a time, in Docker isolation — fast-forwarding each finished slice into the local feature branch. Integration is local: you push the feature branch and open one PR to `main` by hand.
+The `yarn dispatch-agents --prd <issue-number>` command that triggers the sandcastle orchestrator. Reads AFK Slice Issues labelled `ready-for-agent`, creates the feature branch **locally (never pushed)**, and runs one sandcastle agent per slice — one at a time, in Docker isolation — fast-forwarding each finished slice into the local feature branch and closing the slice issue. Integration is local: you push the feature branch and open one PR to `main` by hand.
 _Avoid_: Agent runner, orchestrator command, run-agents
 
 ## Agent Roles

--- a/docs/adr/0002-agent-orchestration-label-vocabulary.md
+++ b/docs/adr/0002-agent-orchestration-label-vocabulary.md
@@ -13,7 +13,7 @@ The full label vocabulary:
 | `type:afk`           | Agent can implement and merge without human interaction               |
 | `type:hitl`          | Human decision required before agent can proceed — orchestrator skips |
 | `status:in-progress` | Agent has picked up the issue                                         |
-| `status:done`        | Agent finished; PR opened                                             |
+| `status:done`        | Agent finished; slice integrated into the local feature branch        |
 
 `to-issues` applies `ready-for-agent` + `type:*` + `complexity:*` at creation time. The orchestrator filters on `ready-for-agent` + `type:afk` and reads `complexity:*` to select the model.
 

--- a/docs/adr/0009-sandcastle-yarn-cache-mount-architecture.md
+++ b/docs/adr/0009-sandcastle-yarn-cache-mount-architecture.md
@@ -1,0 +1,92 @@
+# Sandcastle dependency handling: in-container install + shared Yarn cache (keep Yarn)
+
+Sandbox dependency setup was the slow, fragile part of `dispatch-agents`. The orchestrator
+built a Linux-native `node_modules` tree once inside Docker (`.sandcastle/node_modules_linux_cache/`,
+~10-15 min), bind-mounted that single shared tree into every agent container, and ran
+`yarn install --immutable` (~3 min) over Docker's Windows→Linux 9P layer. The shared mutable
+tree forced `gateLock` serialization and a **gate skip whenever a slice changed `yarn.lock`**,
+and the whole tree was **fully re-seeded** (~15 min again) on any lockfile change.
+
+We will install each slice's dependencies **inside the Linux container** via a
+`hooks.sandbox.onSandboxReady` hook (`corepack yarn install --immutable`) that runs before the
+agent starts, with Yarn's **content-addressable global cache** bind-mounted from
+`.sandcastle/.yarn-cache` (host) into every container. Installing in-container means native
+binaries (`bcrypt`, `prisma`, `@swc/core`) are always built for the container's platform, so
+the same code path is correct on **WSL2, native Linux, and macOS** hosts. **Yarn stays** (no
+migration), and the entire seed + lockfile-hash-invalidation + `gateLock` machinery is deleted.
+
+The one environment invariant: the worktree must live on a **native filesystem** (ext4 on
+Linux/WSL2, APFS on macOS), never a Windows-mounted path (`/mnt/d`, drvfs/9P). On Windows that
+means running dispatch from inside WSL2 with the repo on ext4.
+
+## Status
+
+accepted — validated by benchmark (below).
+
+## Benchmark (this monorepo, warm shared Yarn cache; only the variable named changes)
+
+| Scenario                                    | Wall-clock | Notes                                                                 |
+| ------------------------------------------- | ---------- | --------------------------------------------------------------------- |
+| In-container install → ext4 worktree (WSL2) | **2m 04s** | exit 0; the chosen path. ~25% over host-native                        |
+| Host-native install → ext4 (reference)      | 1m 39s     | not used (host-install bakes in wrong-arch binaries on macOS/Windows) |
+| In-container/host install → drvfs `/mnt/d`  | ~29m 00s   | the filesystem trap, any mode                                         |
+| Old Docker seed (cold, full tree)           | ~10-15m    | replaced                                                              |
+
+In-container on WSL2 (124s) is only ~25% slower than a host-native install (99s) and ~14×
+faster than the Windows-mounted path. Because in-container is both fast enough **and** the only
+option that produces correct binaries on macOS, it becomes the **single portable path** — no
+host-vs-container dual mode, no platform detection.
+
+## Considered Options & Evidence
+
+**Host-side install + bind-mount (rejected — wrong-arch off Linux).** As used in
+`mattpocock/course-video-manager`: install on the host, bind-mount `node_modules` in. Correct
+and fast _only when host OS/arch matches the container_. On macOS/Windows the host produces
+darwin/win32 native binaries the Linux container cannot execute. A WSL2-only variant works but
+does not generalize, so it was dropped in favor of the in-container path that works everywhere.
+
+**Dual-mode (host-install on Linux, in-container on macOS) — rejected as unnecessary.** Once the
+benchmark showed in-container is only ~25% slower on WSL2, the extra ~2× install/gate code to
+save 25s wasn't worth it.
+
+**pnpm migration (deferred).** pnpm's `--store-dir` + `--virtual-store-dir` keeps the heavy tree
+off slow mounts with `node_modules` as symlinks (makes the sibling `mnaimfaizy/langtutor` repo
+fast). Rejected because it migrates a security-hardened, RN-containing monorepo end-to-end
+(`yarn.lock`→`pnpm-lock.yaml`, re-expressing `.yarnrc.yml` gates — `enableHardenedMode`,
+`npmMinimalAgeGate`, `npmPreapprovedPackages`, `checksumBehavior: throw` — as pnpm config,
+rewriting every `yarn` reference, RN/Metro re-validation). Kept as the fallback if a future need
+demands fast installs on a Windows-mounted path.
+
+**Yarn + symlink `node_modules` to native overlay (rejected — disproven).** Plan: `ln -sfn
+/home/agent/nm node_modules` then install. A Docker smoke-test showed **Yarn 4 refuses a
+symlinked `node_modules`** — `YN0031` deletes the symlink and recreates a real directory. Yarn's
+node-modules linker has no `--virtual-store-dir` equivalent, so the heavy tree cannot be
+relocated off the workspace mount from inside the container.
+
+**Native Docker named volume for the cache (rejected — infeasible for agents).** sandcastle's
+`docker()` provider only accepts **host bind-mounts** and validates `existsSync(hostPath)`
+(`resolveUserMounts`), so a named/anonymous volume cannot be passed to the agent containers that
+`run()` launches. Hence the cache is a host **bind-mount** (`.sandcastle/.yarn-cache`).
+
+## Consequences
+
+- **Environment requirement:** the worktree must be on a native fs. macOS and native Linux work
+  out of the box (repo on local disk). On Windows, run dispatch from WSL2 with the repo on ext4.
+  Windows-native (drvfs) is supported but ~29 min/install — strongly discouraged.
+- **The gate is strictly stronger.** Each gate runs in a Docker container that installs the
+  slice's exact tree (sharing the cache mount) then runs `nx` — so the `yarn.lock`-change skip
+  and the `gateLock` serialization are **removed**; every slice is gated, including dep-changing
+  ones.
+- **Cache:** `.sandcastle/.yarn-cache` (host, gitignored) is bind-mounted into every container at
+  `/home/agent/.yarn-cache` (via `YARN_GLOBAL_FOLDER`). Content-addressable → never fully
+  invalidated; first run warms it (cold), subsequent installs are incremental. The first dispatch
+  on a fresh checkout pays a one-time cold download (bounded by `SLICE_CONCURRENCY`).
+- **Code changes** (`.sandcastle/main.mts`): `hooks.sandbox.onSandboxReady: corepack yarn install
+--immutable`; bind-mount `.sandcastle/.yarn-cache` + `YARN_*` env in `docker()`; deleted the
+  Docker seed + `lockfileHash`/`.cache-lockfile-hash` invalidation and `gateLock`; gate rewritten
+  to a single Docker `install && nx` run; added a `SLICE_CONCURRENCY` cap (default 4). `prompt.md`
+  and `Dockerfile` comments updated; `.gitignore` covers `.sandcastle/.yarn-cache/` and `gate/`.
+- **Host needs:** Node + corepack + `gh`/`git` + Docker on the dispatch host. It does NOT need
+  native build tools (compilation happens in-container).
+- **Deferred follow-up:** an explicit one-time cache pre-seed before fan-out (to avoid up to
+  `SLICE_CONCURRENCY` parallel cold downloads on the very first run).

--- a/docs/adr/0010-sandcastle-local-only-integration.md
+++ b/docs/adr/0010-sandcastle-local-only-integration.md
@@ -8,7 +8,8 @@ branch off a frozen base (they never saw each other's work — the whole reason 
 existed).
 
 We are reducing GitHub's role to the minimum: **read** the PRD + slice issues, and **write**
-status labels + a completion comment back to each slice. Integration becomes entirely local.
+status labels + a completion comment back to each slice (and **close** each slice once it
+integrates). Integration becomes entirely local.
 
 ## Decision
 
@@ -21,6 +22,11 @@ status labels + a completion comment back to each slice. Integration becomes ent
   slice (`git branch -f`). Serial execution guarantees the slice is a pure descendant, so the
   fast-forward never conflicts and adds no merge commit.
 - **No per-slice push, no per-slice PR, no `gh pr merge`.**
+- On successful integration the orchestrator **closes the slice issue** (reason: completed) in
+  addition to labelling it `status:done`. `status:done` + closed makes re-runs idempotent — both
+  `main.mts` (open + `type:afk` filter) and `dispatch-waves` (which fetches `--state all` and treats
+  a closed slice as done) skip an already-integrated slice. The PRD issue stays open until the
+  manual PRD PR merges.
 - After the run, the human QAs the local feature branch, then pushes it once and opens **one** PR
   to `main` so CI runs there and the PRD lands as a single review unit.
 

--- a/docs/adr/0010-sandcastle-local-only-integration.md
+++ b/docs/adr/0010-sandcastle-local-only-integration.md
@@ -1,0 +1,79 @@
+# Sandcastle integration: local-only feature branch, slices integrated by fast-forward (no per-slice PRs)
+
+`dispatch-agents` previously coupled tightly to GitHub for _integration_: it created the
+feature branch **on origin**, **pushed** every slice branch, opened a **PR per slice**, ran the
+gate against `origin/<slice>`, then **squash-merged** each PR into the feature branch on GitHub.
+That is a lot of remote round-trips, a lot of throwaway PRs, and it forced parallel slices to
+branch off a frozen base (they never saw each other's work — the whole reason `dispatch-waves`
+existed).
+
+We are reducing GitHub's role to the minimum: **read** the PRD + slice issues, and **write**
+status labels + a completion comment back to each slice. Integration becomes entirely local.
+
+## Decision
+
+- The feature branch `feat/<slug>` is created **locally** from `origin/main` and is **never
+  pushed**. It is the integration target for the whole PRD and lives only in the dispatch clone.
+- Slices run **one by one**. Each slice branch is cut from the **current local feature head**, so
+  a slice sees every previously-integrated slice's work.
+- The agent commits locally in its credential-less sandbox. The host then runs the gate against
+  the **local** slice branch and, on green, **fast-forwards the local feature branch** onto the
+  slice (`git branch -f`). Serial execution guarantees the slice is a pure descendant, so the
+  fast-forward never conflicts and adds no merge commit.
+- **No per-slice push, no per-slice PR, no `gh pr merge`.**
+- After the run, the human QAs the local feature branch, then pushes it once and opens **one** PR
+  to `main` so CI runs there and the PRD lands as a single review unit.
+
+## Status
+
+accepted.
+
+## Why
+
+- **Fewer moving parts / failure modes.** The old flow could fail at push, PR-create, gate, or
+  merge — each a remote call with its own error handling and partial-state recovery. The new flow
+  fails only at the gate or a local fast-forward.
+- **Slices compose.** Serial cut-from-live-head means slice N builds on slice N−1 automatically.
+  This is what `dispatch-waves` previously bought with extra runs; now ordering is the only thing
+  waves add, and the common single-wave PRD needs no special handling.
+- **No PR spam.** One PR per PRD (manual) instead of one per slice. CI runs once, on the unit that
+  actually ships.
+- **Safer by default.** Nothing reaches origin until a human pushes. A bad batch is discarded by
+  deleting a local branch.
+
+## Considered options & evidence
+
+**Keep the per-slice PR + squash-merge flow (rejected).** Correct, but it is exactly the GitHub
+coupling we set out to remove, and it cannot give slices visibility into siblings without the
+re-branch-per-wave dance.
+
+**Parallel slices + serialized local merges (rejected).** Keeps wall-clock down but reintroduces
+the "siblings branch off a frozen base" problem (parallel agents cut from the same head), so
+merges conflict and slices don't compose. Serial cut-from-live-head avoids both. The cost is
+wall-clock — accepted deliberately ("one by one").
+
+**`--no-ff` merge commits per slice in a dedicated feature worktree (rejected — unnecessary).**
+Robust to any history shape, but serial execution already guarantees a clean fast-forward, so a
+persistent feature worktree (extra checkout, extra cleanup) buys nothing. `git branch -f` on the
+un-checked-out feature ref is enough.
+
+## Consequences
+
+- **The feature branch is local and unpushed.** Deleting it loses the integrated work — push
+  before deleting. Documented in `docs/sandcastle/RUNBOOK.md`.
+- **The gate operates on local refs** (`featureBranch`, `sliceBranch`) — no `git fetch origin
+<slice>` before gating. Still fail-closed: no integration without a green gate (or `SLICE_GATE=off`).
+- **`dispatch-waves` still works** unchanged in behavior — it gates the `ready-for-agent` label
+  per wave and calls `main.mts`; each wave's integrated output (local feature branch) is the next
+  wave's base. Its role narrows to _ordering_ by `## Blocked by`.
+- **Serial execution removes `SLICE_CONCURRENCY`.** One slice's `node_modules` worktree exists at
+  a time.
+- **Code** (`.sandcastle/main.mts`): removed origin feature-branch creation, `pushSliceBranch`,
+  `gh pr create`, `gh pr merge`, and the parallel `Promise.allSettled` + semaphore. Added local
+  feature-branch creation, a serial slice loop that cuts each branch from the live feature head,
+  `finalizeSliceBranch` (capture stray changes, confirm work), and `integrateSlice` (local
+  fast-forward). The gate now uses local refs. `dispatch-waves.mts` header + final messages and
+  `docs/sandcastle/RUNBOOK.md` updated to the local model.
+- **Relationship to [0009](0009-sandcastle-yarn-cache-mount-architecture.md):** orthogonal. 0009
+  governs _how dependencies are installed_ (in-container, shared Yarn cache); this ADR governs
+  _how slice output is integrated_ (local fast-forward). Both stay in force.

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -28,6 +28,15 @@ limited because of measured blind spots (below).
 
 Always confirm a graph result against the actual file before trusting it — the graph can be stale.
 
+## On probation — usage is measured
+
+This integration is **on probation**: a real-workflow spike showed an agent never invoked it
+directly and its contribution (buried inside CodeExplorer) was unmeasurable. So CodeExplorer now
+**queries Graphify first** for relationship questions and **logs the outcome** (`helped` /
+`redundant` / `wrong/missed`) in a `Graphify Usage` block on every run. If those logs show it is
+consistently `redundant` or `wrong/missed`, drop the integration — it is not worth the manual
+rebuild + staleness cost. Keep it only if it earns a clear `helped` track record.
+
 ## Build / refresh
 
 The graph is **not committed** (it's generated and goes stale). Build it once locally; the

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -1,0 +1,61 @@
+# Graphify structural index (opt-in agent supplement)
+
+Graphify builds an AST-based code knowledge graph of the monorepo and serves it to agents
+over MCP. We adopted it for **one narrow, proven win**: fast, free, in-package answers to
+_"what directly calls / imports / consumes this symbol?"_ plus a god-node orientation map.
+It is a **supplement to `CodeExplorer`/grep and `nx affected`, not a replacement.**
+
+See issue #158 and `graphify-eval-notes.md` for the full evaluation. Scope was deliberately
+limited because of measured blind spots (below).
+
+## What it's good for
+
+- `get_neighbors <symbol>` — direct callers/importers/consumers within reach (accurate, instant).
+- `god_nodes` — most-connected nodes; good first orientation in an unfamiliar area.
+- `query_graph "<question>"` — broad "what relates to X" context.
+- The labeled `graphify-out/GRAPH_REPORT.md` — a navigable, domain-named community map for onboarding.
+
+## What it must NOT be used for
+
+- **Cross-package / cross-HTTP-boundary impact** ("what breaks if `VaultController` changes").
+  The graph is AST-only and has no edge across the OpenAPI/codegen seam. **Use `nx affected
+--files=<path>` instead** — it is authoritative for cross-project impact.
+- **PR/slice review-priority ranking.** Graphify's `triage_prs` blast-radius counts a changed
+  file's own community span, not its dependents, so it _inverts_ risk for hub/barrel files.
+  Use `nx affected` for PR scoping.
+- **TypeScript type-reference blast radius** (type usages aren't edges) or any symbol whose
+  name appears in more than one file (it can't disambiguate).
+
+Always confirm a graph result against the actual file before trusting it — the graph can be stale.
+
+## Build / refresh
+
+The graph is **not committed** (it's generated and goes stale). Build it once locally; the
+`graphify` MCP server in `.mcp.json` then serves `graphify-out/graph.json`.
+
+Prerequisite: `uv tool install graphifyy --with mcp` (provides `graphify` + `graphify-mcp`).
+The `--with mcp` extra is **required** — without it `graphify-mcp` crashes with
+`ModuleNotFoundError: No module named 'mcp'` and the MCP server in `.mcp.json` won't start.
+
+```pwsh
+# Full rebuild (per-package extract + merge + cluster + label), zero external egress.
+# Uses --backend claude-cli, which routes doc/image semantic extraction through the local
+# Claude CLI (billed to your plan, no API key). Config files are excluded via .graphifyignore.
+$env:GRAPHIFY_OUT="graphify-out"
+graphify extract apps --backend claude-cli
+graphify extract libs --backend claude-cli
+graphify merge-graphs apps/graphify-out/graph.json libs/graphify-out/graph.json --out graphify-out/graph.json
+graphify cluster-only . --no-viz
+graphify label . --backend claude-cli      # domain names for communities + GRAPH_REPORT.md
+```
+
+Incremental refresh after code changes (much faster — reuses the content-hash cache):
+
+```pwsh
+graphify extract apps --backend claude-cli   # re-extracts only changed files
+graphify extract libs --backend claude-cli
+graphify merge-graphs apps/graphify-out/graph.json libs/graphify-out/graph.json --out graphify-out/graph.json
+```
+
+> **Maintenance reality:** there is no commit hook wiring this up. The graph reflects the
+> last manual build. Rebuild before relying on it for a fresh area of the code.

--- a/docs/sandcastle/RUNBOOK.md
+++ b/docs/sandcastle/RUNBOOK.md
@@ -1,0 +1,112 @@
+# Sandcastle dispatch — Runbook
+
+The orchestrator (`yarn dispatch-agents` / `yarn dispatch-waves`) runs one Docker-isolated
+agent per slice, one slice at a time. Each agent's dependencies are installed **inside the Linux container**
+(`hooks.sandbox.onSandboxReady` → `corepack yarn install --immutable`), so native modules
+(`bcrypt`, `prisma`, `@swc/core`) are always built for the container — correct on **macOS,
+native Linux, and WSL2** alike. Yarn's content-addressable global cache is bind-mounted from
+`.sandcastle/.yarn-cache` so installs are incremental across slices. See `docs/adr/0009`.
+
+## The one hard requirement
+
+**The repo (and therefore the slice worktrees under `.sandcastle/worktrees/`) must live on a
+native filesystem** — ext4 on Linux/WSL2, APFS on macOS. The in-container install writes
+`node_modules` to the bind-mounted worktree; on a native fs that's ~2 min, on a Windows-mounted
+path (`/mnt/d`, drvfs/9P) it's ~29 min. This is the difference between a usable and an unusable
+pipeline.
+
+| Host             | Where to put the repo                            | How to run dispatch                  |
+| ---------------- | ------------------------------------------------ | ------------------------------------ |
+| **macOS**        | anywhere on local disk (APFS)                    | run `yarn dispatch-*` normally       |
+| **native Linux** | anywhere on local disk (ext4/btrfs)              | run `yarn dispatch-*` normally       |
+| **Windows**      | **inside a WSL2 distro** (`~/...`, NOT `/mnt/d`) | run from the WSL2 distro (see below) |
+
+## Common setup (all platforms)
+
+1. **Toolchain:** Node 22 + corepack (`corepack enable` → provides `yarn` pinned to 4.13.0).
+2. **Docker:** a running Docker engine the dispatch shell can reach (`docker info` works).
+3. **Auth:** `gh auth status` green and `git config user.name/.email` set, for the dispatch host.
+4. **Secrets:** `cp .sandcastle/.env.example .sandcastle/.env` and set `ANTHROPIC_API_KEY`
+   (`GH_TOKEN` optional; otherwise the host's `gh` session is used).
+5. The `sandcastle:myorganizer` image builds automatically on first run if missing.
+
+The dispatch host does **not** need native build tools — compilation happens in-container.
+
+## Windows-specific setup (WSL2)
+
+Windows-native dispatch (from PowerShell, repo on `D:\`) works but is ~29 min/install — use WSL2.
+
+1. **Docker Desktop → Settings → Resources → WSL Integration → enable your distro (e.g. `Ubuntu`)
+   → Apply & Restart.** Verify in the distro: `docker info` prints a server version.
+2. Install Node 22 in the distro (userland, no sudo):
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+   exec bash && nvm install 22 && nvm alias default 22 && corepack enable
+   ```
+3. (Recommended) stop the Windows PATH leak so the Linux `node`/`yarn` win:
+   ```bash
+   sudo tee /etc/wsl.conf >/dev/null <<'EOF'
+   [interop]
+   appendWindowsPath=false
+   EOF
+   ```
+   then from PowerShell: `wsl --shutdown`, reopen the distro.
+4. `gh auth login` (or `export GH_TOKEN=...`) inside the distro.
+5. **Clone onto ext4** and run from there:
+   ```bash
+   git clone git@github.com:mnaimfaizy/myorganizer.git ~/projects/myorganizer
+   cd ~/projects/myorganizer
+   ```
+   Keep your `D:\` checkout for IDE editing; the WSL2 clone is only for dispatch. The feature
+   branch is built **locally** in this clone (never pushed during dispatch), so `git fetch origin`
+   keeps `main` current and, when a PRD is done, you push the feature branch from here by hand.
+
+## Running a dispatch
+
+```bash
+corepack yarn dispatch-agents --prd <issue-number>   # all ready AFK slices, one by one
+corepack yarn dispatch-waves  --prd <issue-number>   # dependency-ordered across waves
+```
+
+**Integration is local-only** (see `docs/adr/0010`). The feature branch `feat/<slug>` is created
+from `origin/main` **locally and is never pushed**. Slices run **one by one**: each branches off
+the _current_ local feature head (so it sees every earlier slice's work) → the agent container
+installs the slice's exact deps in-container (sharing the cache) → the agent implements and commits
+locally → the host runs the **gate** (a Docker container that installs the slice's tree and runs
+`nx lint` on the changed projects) → gate green → the host **fast-forwards the local feature branch**
+onto the slice. No per-slice push, no per-slice PR.
+
+GitHub is touched only to **read** the PRD/slice issues and **write** status labels + a completion
+comment back to each slice.
+
+When the run finishes, **you** finish the loop by hand:
+
+```bash
+git switch feat/<slug>                 # QA the integrated branch locally
+git push -u origin feat/<slug>         # publish it when you're satisfied
+gh pr create --base main               # open ONE PR; CI runs here; merge it on GitHub
+```
+
+### Tunables
+
+| Env var              | Default | Purpose                                                            |
+| -------------------- | ------- | ------------------------------------------------------------------ |
+| `SLICE_GATE`         | (on)    | `off` skips the lint gate (integrates without verification).       |
+| `SLICE_GATE_TARGETS` | `lint`  | Space/comma-separated Nx targets the gate runs (e.g. `lint test`). |
+
+Slices run **serially** (one by one), so there is no concurrency knob — each slice's ~2.6GB
+`node_modules` worktree exists one at a time during its run.
+
+## Maintenance & gotchas
+
+- **Disk:** `.sandcastle/.yarn-cache` (shared CAS cache, ~2GB) + the active slice's `node_modules`
+  (~2.6GB; one at a time since slices run serially) + a transient gate worktree. Check headroom
+  (`df -h .`).
+- **First run is cold:** the first dispatch on a fresh checkout warms `.sandcastle/.yarn-cache`
+  (downloads once); subsequent runs are incremental.
+- **The feature branch is local:** `feat/<slug>` lives only in this clone until you push it by hand
+  for the PRD PR. If you delete the local branch you lose the integrated work — push it first.
+- **Retire the old cache:** delete `.sandcastle/node_modules_linux_cache/` if present — it's no
+  longer used (the seed step and lockfile-hash invalidation were removed).
+- **Never put the repo on `/mnt/d`** (or any drvfs/9P mount) for dispatch — that's the ~29 min
+  trap.

--- a/docs/sandcastle/RUNBOOK.md
+++ b/docs/sandcastle/RUNBOOK.md
@@ -77,7 +77,8 @@ locally → the host runs the **gate** (a Docker container that installs the sli
 onto the slice. No per-slice push, no per-slice PR.
 
 GitHub is touched only to **read** the PRD/slice issues and **write** status labels + a completion
-comment back to each slice.
+comment back to each slice, then **close** each slice that integrates successfully (reason:
+completed). The PRD issue stays open until you merge the manual PRD PR.
 
 When the run finishes, **you** finish the loop by hand:
 

--- a/graphify-eval-notes.md
+++ b/graphify-eval-notes.md
@@ -1,0 +1,258 @@
+# Graphify pilot — working notes (issue #158)
+
+Branch: `research/graphify-eval-158`. Throwaway. Nothing here merges to main.
+
+## Environment
+
+- Installed `graphifyy` 0.8.42 via `uv tool install` (executables: `graphify`, `graphify-mcp`).
+- No LLM API keys present in env (only `CLAUDE_CODE_*`) → hard zero-egress guarantee for Run 1; semantic + community-naming steps auto-skip, leaving a pure-AST graph.
+- `.graphifyignore` excludes deps, build output, coverage, generated `app-api-client`, OpenAPI artifacts.
+
+## Run 1 — code-only extraction
+
+### BLOCKER: `graphify extract .` at repo root ingests node_modules
+
+- `graphify extract .` scanned **44,175 code + 3,194 docs + 298 images** and FAILED after **~20 min** (1188s) demanding an LLM key for node_modules READMEs/assets.
+- Git tracks only **930 files** (~490 code, 189 md, 12 png). node_modules = **187,810 files** on disk.
+- `node_modules` is a hardcoded skip in graphify (`_SKIP_DIRS`, detect.py:654) AND in `.gitignore` AND my `.graphifyignore` — yet it was walked anyway. The root-level prune misfired on this Windows/Nx setup. **Real adoption friction.**
+
+### Workaround that produced a usable graph: scoped, code-only, many `--exclude`
+
+- Keyless guard trips on ANY doc/image (`DOC_EXTENSIONS = .md/.mdx/.qmd/.txt/.rst/.html/.yaml/.yml`, detect.py:30). Reaching a pure-code corpus took iterative discovery: md, html, toml, ico, yaml/yml, openapi artifacts, RN manifests (Gemfile/Podfile).
+- `libs/` (scoped): **349 code → 1455 nodes / 3239 edges / 128 communities in 32.8s.** Fast, correct corpus, zero-egress (no key used).
+- `apps/` (backend+web, mobile+e2e excluded): **104 code → 396 nodes / 662 edges / 52 communities in 7.9s.**
+- merged: **1851 nodes / 3901 edges.**
+
+### Findings against the bars (Run 1, in progress)
+
+- ✅ AST extraction is genuinely local, fast, zero-egress. Crypto layer extracted well: `AesGcmKey`, `deriveKeyFromPassphrase`, `aesGcmEncrypt/Decrypt`, `EncryptedBlob`, `EncryptedBlobSchema`, `VaultCrypto`, `wrapMasterKeyWithKey`, `MobileVaultCrypto`.
+- ⚠️ **Bar 1 — graph speaks code, not domain language.** No `Ciphertext` node exists (`path … "Ciphertext"` → "No node found"). Must know code identifiers (`EncryptedBlob`). Undercuts domain-term querying / onboarding (bars 1, 4).
+- ⚠️ **Bar 1 — `path` traverses structural import/re-export edges, not data flow.** `Task → EncryptedBlob` routed through barrel `index.ts` re-exports + irrelevant `vaultImportErrorMessages.ts`. Misleading as an architecture trace.
+- ⚠️ Duplicate nodes (EncryptedBlob ×N across vault-core/mobile/web-vault-ui) → ambiguous `path` matches.
+- ⚠️ Community fragmentation: 128 communities / 349 libs files (~11 nodes each) — bar-3 signal, pending report/viz.
+
+### Build cost (for bar 5 break-even)
+
+- libs 32.8s + apps 7.9s + merge ≈ **~41s build** for the scoped code-only corpus (excludes the failed 20-min root run). Per-query (`query`/`path`) is sub-second, local, zero-token. Caveat: graph goes stale on every code change (needs `graphify update`).
+
+## Bar 5 — REFRAMED: agent finds correct + related context in <1s (graphify vs CodeExplorer)
+
+**Reframe (user, 2026-06-19):** grep is a retrieval tool, not a comparison peer — it returns matches, not relationships. Graphify's differentiator is the RELATIONAL layer (communities, neighbors, reverse-impact, similarity). Goal = fastest + most accurate way for an AI agent (small OR large context) to find what it needs AND what it relates to, in <1s.
+
+**Baseline = CodeExplorer** (the agent's real current method: wraps grep/glob/read + structured summary). NOT raw grep (strawman).
+
+**Primary metric = relational accuracy + latency.** Per question, vs independent ground truth:
+
+- Accuracy: precision + recall of the returned related set (missing a neighbor = failure).
+- Latency: is it actually sub-second?
+- Cost/tokens = secondary tiebreaker only.
+  Secondary observations: relational completeness; one-shot-ness (usable in one call vs needs follow-ups).
+
+**Ground truth (independent of CodeExplorer):** `nx graph` / `project.json` for dependency questions; direct file reads for flow/neighbor questions.
+
+**Scope fairness:** graphify graph = libs/ + apps/(backend,web) only (mobile, e2e, generated app-api-client excluded). Keep questions within that scope; note where CodeExplorer's whole-repo reach is an unfair advantage/disadvantage.
+
+### Question set (relational-weighted; literal controls marked [CTRL])
+
+R1. What is affected if the vault blob schema (`EncryptedBlob`) changes? (reverse-impact)
+R2. What consumes `@myorganizer/design-tokens`? (dep — nx authoritative)
+R3. What is directly related to `saveEncryptedData()` (vault encryption)? (neighborhood)
+R4. What depends on the auth library / what does it touch? (dep — nx authoritative)
+R5. What is affected if `VaultController` changes? (reverse-impact)
+R6. What symbols/files group with the Task feature? (community/similarity)
+C7. [CTRL] Where is `deriveKeyFromPassphrase` defined? (literal — grep should win)
+C8. [CTRL] List the functions defined in `vault.ts`. (literal — grep should win)
+
+### RESULTS — graphify (CLI) vs CodeExplorer
+
+| Q                               | Ground truth                                                                         | graphify                                                                                         | CodeExplorer                                                                     | Winner                                                             |
+| ------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| R1 EncryptedBlob blast radius   | ~20 files vault-core→web-vault→api-client→backend                                    | **FAIL** "no unique node match" (dup nodes)                                                      | full, accurate, grouped (81s, 60k tok)                                           | **CodeExplorer**                                                   |
+| R2 design-tokens consumers      | web-pages-home, mobile-ui (nx)                                                       | both found but buried in ~21 noise nodes; "token" matched auth `TokenStorageMode` (false friend) | accurate + caught CSS consumer + transitive (228s, 67k tok)                      | **CodeExplorer** (graphify wrong granularity; nx is the real tool) |
+| R3 saveEncryptedData consumers  | ~13 sites (addresses/mobile-numbers/subs/tasks/groceries)                            | **19 edges, accurate set** (~1s, 0 tok)                                                          | same set + line cites (137s, 33k tok)                                            | **graphify** (≈equal accuracy, ~100× faster, free)                 |
+| R5 VaultController blast radius | client via generated VaultApi → serverVaultSync → migration → mobile → HTTP boundary | **FAIL** "no affected nodes" (HTTP/generated-client boundary invisible)                          | excellent; correctly reasons across HTTP boundary + OpenAPI regen (87s, 53k tok) | **CodeExplorer**                                                   |
+| R6 Task grouping                | Task feature surface                                                                 | accurate (10 conns, ~1s)                                                                         | (not run)                                                                        | graphify ok                                                        |
+| C7/C8 controls (literal)        | —                                                                                    | partial / 217-node dump (wrong tool)                                                             | n/a                                                                              | grep/read                                                          |
+
+**Latency:** graphify CLI ~0.8–1.2s, **0 tokens**. CodeExplorer **81–228s, 33–67k tokens**.
+
+### Bar 5 verdict: FAIL (does not meet reframed goal)
+
+- graphify's headline pitch — **"show ripple/what's affected if X changes"** (issue value-prop #5) — is exactly where it **FAILED** (R1, R5): duplicate-node ambiguity breaks `affected`, and it is **blind to the HTTP/generated-client boundary** that carries this monorepo's most important contract ripple.
+- Its one genuine win (R3/R6: instant consumers of a single _unambiguous_ symbol, ~100× faster, free) is a question shape **already served by a plain grep-for-importers or `nx affected`** — the relational graph adds little there.
+- Where the graph's relational layer _should_ shine (transitive R2, impact R1/R5) it was noisy, wrong-granularity, or empty.
+- For an autonomous agent, a **fast wrong/empty answer (R1,R5 returned nothing) is worse than a slow correct one**, and the agent can't predict in advance whether a question lands in graphify's narrow sweet spot.
+- Accuracy is the primary metric; graphify loses 3 of 4 relational questions to the incumbent. Speed advantage doesn't rescue it.
+
+## Bar 1 — vault flow accuracy + safety → MIXED (safety PASS, accuracy FAIL)
+
+- **Safety: PASS.** Backend vault surface = `VaultController.putVaultBlob/getVaultBlob`, `VaultService`, `EncryptedBlobV1`, `VaultBlobType` — server touches encrypted blobs only. Edge scan backend↔(DecryptedTask/Task plaintext) = EMPTY. Graph asserts NO false "plaintext crosses server" relationship.
+- **Accuracy: FAIL as an end-to-end flow trace.** No `Ciphertext` node (domain term absent). `path "Task" "EncryptedBlob"` returns a structural route through barrel `index.ts` re-exports + irrelevant `vaultImportErrorMessages.ts`, not the real flow. `query` BFS surfaced the right neighborhood (`saveEncryptedData`, `taskNormalization`, `loadDecryptedData`) but as a flat list, not a directed flow. Pieces present; flow not assembled.
+
+## Bar 3 — noise / navigability → FAIL in zero-egress mode
+
+- merged: 1851 nodes / 3901 edges / **187 communities (~10 nodes each)** — heavy fragmentation.
+- `--no-label` (zero-egress) report = wall of unnamed `Community 0..186` links. Not navigable for onboarding WITHOUT the LLM labeling pass (= Run 2, egress).
+- Good: 97% EXTRACTED / 3% INFERRED (conf 0.8) / **token cost 0** confirms hard AST edges + true zero-egress.
+- Verdict: code-only graph is structurally sound but semantically unlabeled → onboarding value (bars 3,4) depends on Run 2.
+
+## Internet recon + "are we missing config?" — RESOLVED (2026-06-19)
+
+- Guides confirm: monorepos >5k files should run graphify PER SUB-PACKAGE, not root. Our libs/+apps/ scoping IS the recommended setup — we configured it right; root node_modules ingestion is the known misuse.
+- Famous "49×/71.5× fewer tokens" claim = self-reported, mixed-corpora, NO published precision/recall benchmark (independent reviewers flag accuracy concerns). Adoption is driven by cheap compact retrieval + docs/multimodal + visual graph, NOT code-impact accuracy.
+- **Graphify NEVER runs an LLM over code** (by design: `needs_llm = bool(docs/papers/images)`; code is always tree-sitter AST). Verified: `--mode deep --backend claude-cli` on vault-core = 2.2s, 0 LLM calls. The Claude/`claude-cli` backend only enriches DOCS/images (→ bar 4 onboarding), not code edges.
+- `claude-cli` backend exists (routes through local Claude Code CLI, billed to Pro/Max plan, no API key) — relevant only for a doc/onboarding pass, not bar 5.
+- **`--mode deep` rebuild = byte-identical graph (1851/3901), added ZERO edges. R1/R5 still fail identically.** => code-relational accuracy is AST-bounded; R1/R5 impact failures are FUNDAMENTAL, not fixable by config/backend. Bar 5 verdict stands and is now airtight.
+
+## Bar 2 — PR triage vs nx affected (deferred to after Run 1 code bars)
+
+- Throwaway draft PRs from slices 120–124 → feat/task-management.
+- `graphify prs` (if available) / graph-community overlap vs `nx affected`.
+
+## RERUN 2 (2026-06-19) — clean slate, by-the-book documented config
+
+User asked to wipe everything and re-test following graphify's OWN shipped skill
+(`site-packages/graphify/skill.md` + `references/`), to rule out our misconfiguration.
+Found and corrected THREE first-pass config errors:
+
+1. **Wrong entry point.** First pass used headless `graphify extract` which tripped the
+   "no LLM API key" guard on docs. The documented zero-API-key backend is `--backend
+claude-cli` (routes doc/image semantic extraction through the local Claude CLI, no
+   egress, billed to plan, $0). This WORKS and was never exercised before.
+2. **We excluded `libs/app-api-client`** (the generated API client) in `.graphifyignore`
+   — but that is exactly the package R5's impact chain runs through. Self-inflicted.
+   Removed the exclusion this run.
+3. **We queried with raw `affected`**, skipping the REQUIRED query-expansion flow in
+   `references/query.md`. This run used `affected` + `explain` + `path` properly, plus
+   the `diagnose multigraph` collapse check we never ran.
+
+### Rebuilt graph (documented monorepo flow: per-package extract + merge-graphs)
+
+- `graphify extract apps --backend claude-cli`: 147 code + 12 docs + 16 images →
+  **800 nodes / 1080 edges / 86 communities** (was 396/662 code-only). 184k in/7k out, $0.
+- `graphify extract libs --backend claude-cli`: 454 code (incl. app-api-client now) +
+  36 docs → **2655 nodes / 4254 edges / 251 communities** (was 1455/3239). 47k in/9k out, $0.
+- `merge-graphs` → **3455 nodes / 5334 edges** (was 1851/3901). Richer, fuller graph.
+- `diagnose multigraph`: **ZERO collapse** (same_endpoint_collapsed_edges=0). Graph is clean;
+  the old "no unique node match" was never edge corruption — it's `affected` refusing to
+  pick among duplicate-label nodes.
+
+### Re-test against the deciding bars — CORE FAILURES REPRODUCE under correct config
+
+| Q                                 | Documented method                                                           | Result                                                                                                                                                                                    | Verdict                                                                                                                                                                                                                |
+| --------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R5 VaultController blast radius   | `affected` + `path VaultController→VaultApi`/`→serverVaultSync` + `explain` | `affected`=empty; **NO path** to VaultApi or serverVaultSync; `explain` shows VaultController links only to `routes.ts` + its own methods                                                 | 🔴 **BLIND across HTTP/codegen boundary** — nodes now present but in DISCONNECTED components; client↔server is an HTTP contract + OpenAPI codegen, not a code import, so AST has no edge. **Fundamental, NOT config.** |
+| R1 EncryptedBlob/V1 blast radius  | `affected EncryptedBlob`, `affected EncryptedBlobV1`, `explain`             | `affected`=**"No unique node match"** (label in >1 file); `explain EncryptedBlob`→degree **1**                                                                                            | 🔴 `affected` unusable for any cross-cutting symbol; TS _type_ references aren't edges                                                                                                                                 |
+| R3 saveEncryptedData neighborhood | `explain`                                                                   | degree **20**, every consumer (Subscriptions/Tasks/Addresses/MobileNumbers/groceries) + callers (loadVault/saveVault/encryptJsonWithMasterKey), instant, $0                               | 🟢 **STRONG** — graphify's real value                                                                                                                                                                                  |
+| Bar 3 navigability                | `cluster-only` report                                                       | God Nodes accurate & useful out of the box (Button, cn, useToast, loadDecryptedData, saveEncryptedData); communities still `Community N` (low cohesion 0.03–0.09) until host-LLM labeling | 🟡 better than first-pass FAIL; hub map usable, clusters need labeling                                                                                                                                                 |
+| Bar 1/4 domain terms from docs    | node scan                                                                   | 36 docs + 16 images via claude-cli produced only **3 concept nodes** (all from swagger.yaml: EncryptedBlobV1/VaultBlobType/User Schema). **No `Ciphertext`, no domain glossary**          | 🔴 doc pass is shallow; onboarding domain-language still absent                                                                                                                                                        |
+
+### Bottom line of rerun 2
+
+- We DID mis-configure it the first time, and fixing that (claude-cli docs, include
+  app-api-client, proper query flow) produced a materially richer, cleaner graph and
+  a more useful onboarding map. The user's instinct was right to demand the redo.
+- BUT the two failures that drove the no-go — **cross-HTTP-boundary impact (R5)** and
+  **type-level blast radius (R1)** — reproduce IDENTICALLY under the correct config,
+  because they are inherent to AST extraction (no edge spans the codegen/HTTP seam;
+  TS type usages aren't call/import edges; `affected` can't disambiguate duplicate labels).
+- graphify's genuine, repeatable strength is now well-established: **instant, accurate,
+  free function-call/import neighborhoods within a package** (R3) and a useful God-Nodes
+  hub map. It is NOT a reliable cross-boundary impact-analysis engine for this monorepo.
+
+### MCP surface (how an agent really consumes it) — `python -m graphify.serve`
+
+Tools exposed: `query_graph`, `get_node`, `get_neighbors`, `get_community`, `god_nodes`,
+`graph_stats`, `shortest_path`, `list_prs`, `get_pr_impact`, `triage_prs`. These wrap the
+exact CLI capabilities, so an agent via MCP inherits the same strengths (get_neighbors/
+god_nodes strong) and the same limits (shortest_path/get_pr_impact blind across the
+HTTP/codegen seam). No new capability beyond the CLI.
+
+### Bar 2 — PR/slice triage vs `nx affected` (TESTED via compute_pr_impact, 2026-06-19)
+
+Bypassed the "no open PRs" blocker by calling `graphify.prs.compute_pr_impact(files, G)`
+directly on realistic single-file changesets and comparing to `nx affected --files`.
+
+| Changed file               | `nx affected` (authoritative, project-level)                     | graphify blast_radius    |
+| -------------------------- | ---------------------------------------------------------------- | ------------------------ |
+| web-vault/…/vault.ts       | **13 projects** (web-vault + 8 page consumers + e2e + root)      | 2 communities / 19 nodes |
+| backend/VaultController.ts | 1 (backend)                                                      | 1 community / 15 nodes   |
+| design-tokens/index.ts     | **7 projects** (design-tokens, home, mobile-ui/screens/app, e2e) | **1 community / 1 node** |
+
+**Root cause (serve.py / prs.py:243 `compute_pr_impact`):** it sums the communities/nodes of
+the nodes that live INSIDE the changed files only — it does **NOT** reverse-traverse to find
+dependents. So "blast_radius" = the changed file's own community span, not downstream impact.
+A thin barrel (`design-tokens/index.ts`) consumed by 7 projects scores blast_radius=1 (lowest)
+when it is actually the highest-risk change. **`triage_prs` therefore inverts merge risk for
+hub/barrel files.** `nx affected` traverses the real dep graph (incl. implicit/build deps),
+is authoritative, fast, and already integrated.
+
+**Bar 2 verdict: 🔴 `nx affected` wins decisively.** graphify's PR-impact is a file-membership
+proxy, not a dependency-impact analysis, and is unsafe for ranking review priority here.
+
+### Bar 3/4 — community labeling + onboarding (TESTED, 2026-06-19)
+
+Ran `graphify label . --backend claude-cli` (skill Step 5, automated via local Claude CLI,
+zero-egress, $0). Labeling SUCCEEDS and is accurate: domain communities get correct names —
+"Vault Controller API", "Vault Session Provider", "Vault Export/Import Logic", "Cloud Backup
+Coordinator", "Google Drive Provider", "Generated API Client Base", "Contact Record
+Normalization", "YouTube Token Encryption", etc.
+
+BUT signal-to-noise is poor out of the box. Of **216** labeled communities:
+
+- **122 (57%) are config/boilerplate**: "TypeScript Config" ×29, "TypeScript Lib Config" ×25,
+  "TypeScript Spec Config" ×15, "Nx Test Project Config" ×14, "Nx Project Config" ×14, lint/
+  webpack/babel/gradle/manifest clusters. Every package's tsconfig/project.json becomes its
+  own community.
+- The real DOMAIN communities are each singletons — accurate but buried under the 57% config sludge.
+
+**Bar 3/4 verdict: 🟡 Mixed.** Labeling works and names are accurate; the God-Nodes hub list is
+useful. But the community map is majority config noise → onboarding value is diluted unless you
+aggressively exclude config files (tsconfig/project.json/lint) in `.graphifyignore`. A navigation
+aid, not a knowledge base. Did NOT build `--wiki` — it is one article per community, so it would
+inherit the same 57% config-noise dilution.
+
+## OVERALL VERDICT (after fully-corrected, by-the-book rerun) — 2026-06-19
+
+The redo was worth it and corrected our 3 config errors. Net scorecard:
+| Use case | Verdict |
+|---|---|
+| In-package symbol neighborhood (callers/consumers) — R3 | 🟢 Strong, instant, free |
+| God-nodes / core-abstraction hub map | 🟢 Useful out of the box |
+| Cross-HTTP/codegen-boundary impact — R5 | 🔴 Blind (fundamental AST limit) |
+| Type-level / cross-cutting symbol blast radius — R1 | 🔴 affected can't disambiguate; type refs aren't edges |
+| PR/slice triage — bar 2 | 🔴 inverts hub-file risk; `nx affected` superior |
+| Onboarding / domain language — bar 3/4 | 🟡 accurate labels but 57% config noise; needs heavy ignore tuning |
+| Docs→domain concepts (Ciphertext glossary) | 🔴 shallow (3 swagger nodes) |
+
+**Recommendation unchanged: No-go for the impact-analysis / PR-triage / domain-onboarding use
+cases that motivated #158.** Residual narrow value: fast free in-package symbol neighborhoods
+(MCP `get_neighbors`/`god_nodes`) as a supplement to CodeExplorer — NOT a replacement, and NOT
+for cross-package impact. `nx affected` remains the authoritative impact tool.
+
+## ADOPTED THE NARROW WIN (2026-06-19, branch research/graphify-eval-158)
+
+Per decision to adopt the proven in-package-neighborhood win as a CodeExplorer supplement:
+
+1. **Cut config noise** — `.graphifyignore` now excludes tsconfig/project.json/_.config._/
+   eslint/babel/native build trees. Clean rebuild: **2072 nodes / 4083 edges / 84 communities**
+   (was 3455/5334/355). Config-noise communities dropped from **122/216 (57%) → 1/84 (1.2%)**.
+   The labeled community map is now almost all real domains ("Vault REST Controller",
+   "Encrypted Vault Storage Crypto", "Google Drive Provider", "Contact Record Normalization").
+2. **MCP server** — `.mcp.json` runs `graphify-mcp graphify-out/graph.json` (stdio). Verified
+   end-to-end: handshake + tools/list returns query_graph/get_neighbors/get_node/god_nodes/etc.
+   Requires `uv tool install graphifyy --with mcp` (the `mcp` extra; server crashes without it).
+3. **CodeExplorer wired** — `.claude/agents/explore.md` gains the read-only graphify MCP tools
+   plus guardrails: use for "who calls/consumes X" + god-nodes; NEVER for cross-boundary impact
+   (use `nx affected`) or duplicate-name/type-ref symbols; treat results as [inferred] until
+   confirmed by file read (graph can be stale).
+4. **Build/refresh doc** — `docs/graphify.md` (one-command rebuild, incremental refresh, scope
+   limits, maintenance reality: no commit hook, manual rebuild).
+5. **gitignore** — `graphify-out/` artifacts are generated, not committed; `.mcp.json` +
+   `.graphifyignore` + `docs/graphify.md` are committed.
+
+Smoke test on clean graph: `saveEncryptedData` still degree 20, community now nicely labeled
+"Encrypted Vault Storage Crypto". The win survives the config-pruned rebuild.
+
+Tracked footprint: M .claude/agents/explore.md, M .gitignore, + .graphifyignore, .mcp.json,
+docs/graphify.md (and this notes file). Everything on the research branch.

--- a/graphify-eval-notes.md
+++ b/graphify-eval-notes.md
@@ -256,3 +256,44 @@ Smoke test on clean graph: `saveEncryptedData` still degree 20, community now ni
 
 Tracked footprint: M .claude/agents/explore.md, M .gitignore, + .graphifyignore, .mcp.json,
 docs/graphify.md (and this notes file). Everything on the research branch.
+
+## REAL-WORKFLOW STRESS TEST (2026-06-19) — spike: alter Subscriptions + new mobile screen
+
+A separate clean-session agent (unaware Graphify was under test) implemented a small spike:
+add a `notes` field to Subscriptions (backend + web) and a new mobile screen. Its tooling retro:
+
+- **Graphify was NOT directly used.** The agent loaded the MCP tool schemas but defaulted to
+  CodeExplorer (×2) + grep + direct Reads. It never invoked a graphify tool itself.
+- **Value is now UNOBSERVABLE.** Because we wired Graphify _into_ CodeExplorer, the agent could
+  only say CodeExplorer "may have used them internally." The accurate cross-layer map it got
+  (blob type → page lib → mobile lib) is indistinguishable from plain grep+read output — no
+  evidence Graphify contributed. Wiring it inside CodeExplorer hid whether it adds value.
+- **Main friction was CodeExplorer's format, not Graphify:** prose + _approximate_ line numbers
+  meant the agent re-read every target file anyway. Flagged as a bottleneck for 20+ file refactors.
+  (Graphify's coarse `source_location` would feed the same imprecision.)
+- **Architectural nuance missed:** the mobile navigator uses conditional rendering, not a push
+  stack — a _pattern_, not a symbol edge, so structurally outside Graphify's AST model. Consistent
+  with the blind-spot findings.
+- **Caveat — boundary not exercised:** the agent chose a Vault-blob-backed feature
+  (`VaultBlobType.Subscriptions`), so data flowed through the encrypted blob, NOT a generated
+  REST endpoint. The spike sidestepped the HTTP/codegen seam (Graphify's worst case); the
+  "no wrong answers" outcome does not clear it there.
+
+**Implication for the adoption:** a "narrow win" that the main agent never invokes, and whose
+contribution inside CodeExplorer is unmeasurable, is close to dead weight in practice. Either make
+its use deliberate + logged (call graphify first for "who consumes X", record hits) to prove value,
+or concede the adoption isn't earning its maintenance cost (manual rebuilds + staleness). Verdict
+on the tool itself is unchanged; the integration design is the open question.
+
+### DECISION (2026-06-19): put it on probation — deliberate + measurable
+
+Chose to make the integration prove itself rather than concede yet:
+
+- `.claude/agents/explore.md`: for relationship/consumer Goals, CodeExplorer MUST query Graphify
+  FIRST (before grep), and MUST emit a `Graphify Usage` block every run with a verdict of
+  `helped` / `redundant` / `wrong/missed` vs verified file evidence. Makes the value observable.
+- `docs/graphify.md`: documented the "on probation — usage is measured" stance and the kill
+  criterion (consistent `redundant`/`wrong/missed` → drop it).
+- Spike (`spike/notes-field`) reverted: discarded the uncommitted notes-field + mobile-screen
+  edits, deleted the branch. It was always throwaway.
+  Next: gather a few CodeExplorer `Graphify Usage` logs from real tasks, then keep-or-kill on evidence.

--- a/graphify-eval-notes.md
+++ b/graphify-eval-notes.md
@@ -297,3 +297,36 @@ Chose to make the integration prove itself rather than concede yet:
 - Spike (`spike/notes-field`) reverted: discarded the uncommitted notes-field + mobile-screen
   edits, deleted the branch. It was always throwaway.
   Next: gather a few CodeExplorer `Graphify Usage` logs from real tasks, then keep-or-kill on evidence.
+
+### PROBATION EVIDENCE — spike 2 (2026-06-19): alter a REST/generated-client feature + new mobile screen
+
+Second clean-session spike (FilteredUserInterface / profile-area field, routed through the REST
+generated client — deliberately hitting the codegen boundary). This time the probation wiring
+WORKED: CodeExplorer actually invoked Graphify and reported a usage verdict.
+
+- **Invoked: YES** (unlike spike 1). CodeExplorer used Graphify on the relationship question.
+- **Got right:** the import graph — `FilteredUserInterface` node present, imports traced
+  accurately to AuthContext.tsx, auth.ts, account components.
+- **Got wrong/missed:** (a) **type-member level is invisible** — it cannot say which fields
+  `FilteredUserInterface` has, or that `createdAt` exists on `UserInterface` but not on the
+  filtered type. That field-level fact was THE decisive fact for the task, and only a direct
+  read of `types/index.ts` gave it. (b) **No awareness of generation-chain direction**
+  (TSOA decorators → OpenAPI → generated client) — required reading `filterUser.ts` + auth lib.
+- **Net verdict: `redundant`** (agent's words: _"Accurate but not additive. Every node it
+  surfaced was one `grep -r FilteredUserInterface` away; it didn't surface anything that grep +
+  targeted reads missed."_). No confidently-wrong answer.
+
+### KEEP-OR-KILL TALLY (real-workflow evidence)
+
+| Spike                            | Invoked?     | Verdict       | Notes                                                                                            |
+| -------------------------------- | ------------ | ------------- | ------------------------------------------------------------------------------------------------ |
+| 1 — Subscriptions (vault-blob)   | not directly | unmeasurable  | value hidden inside CodeExplorer; sidestepped the boundary                                       |
+| 2 — profile field (REST/codegen) | yes          | **redundant** | accurate import graph but reproducible by `grep -r`; decisive type-member fact outside its model |
+
+Two real tasks, **zero clear `helped`**. The one thing Graphify does well (in-package symbol
+import neighborhoods) is reproduced by `grep -r` in this monorepo, and the facts that actually
+decide real edits (type members, codegen-chain direction, HTTP-boundary impact) are all outside
+its AST-symbol model. Against this sits a real cost: manual rebuilds + staleness, the `--with mcp`
+dependency, and an extra indirection in CodeExplorer. Per the documented kill criterion
+(consistent `redundant`/`wrong-missed` → drop it), the evidence now points to **KILL the
+adoption**. Tool verdict (no-go as primary exploration/impact engine) is unchanged and reinforced.

--- a/graphify-test-notes.md
+++ b/graphify-test-notes.md
@@ -1,0 +1,436 @@
+# Graphify Evaluation — Independent Test Notes
+
+**Date**: 2026-06-19  
+**Tool version**: graphify 0.8.42  
+**Graph commit**: f960e96a (HEAD — fresh)  
+**Graph stats**: 2072 nodes · 4083 edges · 177 communities (99% EXTRACTED, 1% INFERRED)  
+**Evaluator**: Claude Sonnet 4.6 (independent run — prior notes read AFTER verdict)
+
+---
+
+## Setup Verification
+
+| Step                  | Result                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tool installed        | `graphify 0.8.42` via `uv tool install graphifyy --with mcp`                                                                                                        |
+| Graph freshness       | Built from `f960e96a` = HEAD ✓                                                                                                                                      |
+| Multigraph diagnostic | 0 edge collapse, 0 dangling endpoints, 58 suppression sites (normal dedup) ✓                                                                                        |
+| `.graphifyignore`     | node_modules, build outputs, configs, Android/iOS trees, OpenAPI specs. README/AGENTS.md NOT excluded (minor noise leak). `libs/app-api-client` intentionally kept. |
+| MCP server config     | `.mcp.json` → `graphify-mcp graphify-out/graph.json`                                                                                                                |
+| LLM API keys          | None set in env. `--backend claude-cli` used for extraction.                                                                                                        |
+
+---
+
+## Bar 1 — Vault Data-Flow Accuracy + Safety
+
+### Ground Truth (grep + reads)
+
+The vault has three layers:
+
+1. **Client encryption** (`web-vault/src/lib/vault/vault.ts`):
+   - `saveEncryptedData()` at L252: calls `importAesGcmKey(masterKeyBytes)` → `encryptJsonWithMasterKey()` → `aesGcmEncrypt()` → stores `EncryptedBlob {iv, ciphertext}` to localStorage via `saveVault()`
+   - `masterKeyBytes` is derived from passphrase via PBKDF2 (`crypto.ts:44`), lives only in memory, never transmitted.
+
+2. **Client→server sync** (`web-vault/src/lib/vault/serverVaultSync.ts`):
+   - `putServerVaultBlobEtagAware()` at L181: takes `EncryptedBlobV1 {iv, ciphertext, alg}`, calls `api.putVaultBlob()` — only the opaque blob reaches the wire.
+
+3. **Server** (`apps/backend/src/controllers/VaultController.ts`):
+   - `.putVaultBlob()` accepts `EncryptedBlobV1` via VaultService. No decryption occurs. Server stores and retrieves opaque blobs only.
+
+**Security property**: Server never sees plaintext or masterKeyBytes. This is provably true from the code.
+
+### Graphify Commands + Outputs
+
+```
+shortest_path("saveEncryptedData", "VaultController")
+→ No path found
+
+shortest_path("deriveKeyFromPassphrase", "putVaultBlob")
+→ No path found
+
+get_node("Ciphertext")
+→ No node matching 'ciphertext' found.
+
+query_graph("EncryptedBlobV1 ciphertext server vault plaintext", depth=3)
+→ 75 nodes: serverVaultSync.ts, vaultExportImport.ts, vaultShapes.ts,
+  EncryptedBlobV1 [app-api-client/src/api.ts L144],
+  EncryptedBlobV1 [backend/src/services/VaultService.ts L21],
+  putServerVaultBlobEtagAware(), normalizeEncryptedBlobV1(), etc.
+```
+
+### Analysis
+
+- **Path queries fail entirely**: There is no graph path from `saveEncryptedData` to `VaultController` because the HTTP call boundary is invisible to AST extraction. A path-based security assertion is impossible.
+- **Domain vocabulary absent**: "Ciphertext" (the preferred domain term per CONTEXT.md) does not exist as a node. The graph uses code identifiers: `EncryptedBlob`, `EncryptedBlobV1`.
+- **Nodes ARE present**: `query_graph` surfaces both the client-side `EncryptedBlobV1` (api-client) and server-side `EncryptedBlobV1` (VaultService), plus all sync functions. An agent with domain knowledge can INFER the security property from these nodes, but cannot PROVE it via a single traversal.
+- **Community labels are accurate**: "Encrypted Vault Storage Crypto", "Server Vault Sync", "Vault REST Controller" correctly segment the three layers.
+
+### Verdict: **PARTIAL**
+
+The relevant nodes exist and their community placement is correct. But Graphify cannot trace a data-flow path across the HTTP boundary (fundamental AST limitation), cannot speak domain vocabulary ("Ciphertext", "Master Key"), and therefore cannot independently assert the security invariant. An agent using Graphify for vault safety analysis would need to combine it with manual reads.
+
+---
+
+## Bar 2 — PR/Slice Triage vs `nx affected`
+
+### Ground Truth (nx)
+
+Three realistic file changes:
+
+| File                                              | nx affected projects                                                                                                                                                                                                                                          | Count |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `libs/design-tokens/src/index.ts`                 | design-tokens, web-pages-home, myorganizer, myorganizer-e2e, mobile-ui, mobile-screens, mobile                                                                                                                                                                | 7     |
+| `apps/backend/src/controllers/VaultController.ts` | backend                                                                                                                                                                                                                                                       | 1     |
+| `libs/web-vault/src/lib/vault/vault.ts`           | web-vault, web-pages-mobile-numbers, myorganizer, myorganizer-e2e, web-pages-vault-settings, web-pages-account, web-pages-subscriptions, web-pages-vault-export, web-pages-addresses, web-pages-dashboard, web-pages-groceries, web-pages-tasks, web-vault-ui | 13    |
+
+### Graphify Commands + Outputs
+
+**File 1: design-tokens/src/index.ts**
+
+```
+get_node("design-tokens")
+→ No node matching 'design-tokens' found.
+
+query_graph("design tokens CSS variables token values imported NativeWind tailwind colors spacing")
+→ 3 nodes: tailwind-preset.native.js, tailwind-preset.js, TokenStorageMode (from auth.ts — WRONG)
+```
+
+Graphify finds the two generated JS preset files inside the package but NOT the two external consumers:
+
+- `libs/mobile/ui/src/theme.ts` (imports via `@myorganizer/design-tokens`) — **MISSED**
+- `libs/web/pages/home/src/components/LandingContent.tsx` (imports via `@myorganizer/design-tokens`) — **MISSED**
+
+The root cause: design-tokens is consumed via the TypeScript path alias `@myorganizer/design-tokens`, not a relative import. Graphify's AST extractor resolves relative imports but NOT monorepo path aliases in this configuration.
+
+**File 2: VaultController.ts**
+
+```
+get_neighbors("VaultController")
+→ Methods (.putVaultBlob, .getVaultMeta, etc.) + routes.ts import
+→ No cross-package links
+```
+
+Consistent with nx: only `backend` is affected. ✓
+
+**File 3: vault.ts**
+
+```
+get_neighbors("vault.ts")
+→ 18 internal function nodes (contains),
+  5 internal imports (vaultExportImport, vaultMigration, etc.)
+  + index.ts [re_exports]
+
+get_neighbors("saveEncryptedData()")
+→ 15 downstream consumers across addresses, mobile-numbers, subscriptions, tasks, groceries
+```
+
+At the FUNCTION level, Graphify correctly identifies the 15 downstream page-client callers of `saveEncryptedData()` (ground truth grep: 22 call-site lines across those same files ✓). But at the FILE level, `get_neighbors("vault.ts")` only returns the internal vault module files — the cross-package consumers are only reachable via the exported function nodes.
+
+### Analysis
+
+- **Alias import gap is critical**: The most compelling use case for triage (thin-but-widely-depended-on barrels like design-tokens) completely fails. Any library consumed via `@myorganizer/*` aliases is invisible to Graphify's impact analysis.
+- **Graphify's impact is at function granularity, not project granularity**: For hub files like vault.ts, you need to query the exported symbols (e.g., `saveEncryptedData`) rather than the file node itself. This is richer than nx (you see WHICH functions are consumed) but less reliable (you might miss alias consumers).
+- **Leaf-node impact (VaultController) is correct and useful**: Graphify correctly shows VaultController is backend-only with no cross-package links.
+
+### Verdict: **PARTIAL**
+
+Correct for server-side leaf nodes. Provides RICHER (function-level) impact data for vault.ts hub. **Fails completely** for alias-resolved barrel imports (design-tokens), which is exactly the class of file where triage is most valuable. Cannot replace `nx affected` for cross-package blast radius.
+
+---
+
+## Bar 3 — Noise / Navigability
+
+### Community Quality Assessment
+
+Total: 177 communities (136 shown, 41 thin omitted)
+
+**Noisy communities** (docs/config that leaked past `.graphifyignore`):
+
+- "Library Agent Guides" — AGENTS.md files
+- "Core Library Docs" — README/doc files
+- "Account & Subscriptions READMEs" — README files
+- "App Documentation Guides" — docs
+- "Dashboard Page Guide" — docs
+- "Addresses Page README" — docs
+- "Dashboard Page README" — docs
+- "Home Page README" — docs
+- "Mobile Numbers Page README" — docs
+- "Vault Export Page README" — docs
+- "Git Push Script" — shell script, entirely non-domain
+- "Storybook Preview Config" — config file
+
+**Count**: ~12 noisy communities / 136 shown = **~9% noise**
+
+Root cause: `.graphifyignore` excludes `*.config.*` but not `*.md` and shell scripts. README files, AGENTS.md, and shell scripts were indexed.
+
+**Signal communities** (correctly labeled real domains):
+
+- "Vault REST Controller", "Vault Session Provider", "Vault Migration & HTTP Status", "Encrypted Vault Storage Crypto", "Server Vault Sync" — correctly segments the vault subsystem
+- "Subscriptions Pages", "Task Form Components", "Groceries Vault Hook & Detail" — correct feature domains
+- "Authentication API Client", "Auth API Client & Tokens", "Token Generation & Auth" — correctly clusters auth
+
+**God Nodes assessment** (top 10):
+
+1. Button (43), cn() (42), useToast() (35), Card/CardTitle/CardContent (27) — UI noise
+2. `loadDecryptedData()` (27 edges) — DOMAIN SIGNAL ✓ vault read path is a core abstraction
+3. `saveEncryptedData()` (20 edges) — DOMAIN SIGNAL ✓ vault write path
+4. `getApiBaseUrl()` (17), `randomId()` (17) — utility signal
+
+The vault operations appearing at #7/#10 correctly identifies them as central to the codebase. A newcomer would immediately know these 20-edge functions are high-risk change points.
+
+**Surprising Connections** section: Found real cross-file coupling:
+
+- `GroceryItem → EditItemDialogProps` (core constants referencing a page component type) — genuine unexpected dependency worth knowing about.
+
+### Verdict: **PASS**
+
+~91% of shown communities are genuine domain areas with accurate labels. The God Nodes correctly surface the vault read/write functions as the most-connected domain abstractions. The GRAPH_REPORT.md is navigable — a newcomer could scan the community list in 5 minutes and understand the feature domains. ~9% documentation noise is manageable and fixable by adding `*.md` to `.graphifyignore`.
+
+---
+
+## Bar 4 — Onboarding / Domain Language
+
+### CONTEXT.md Domain Terms vs. Graph Presence
+
+| CONTEXT.md term   | In graph?   | Graph representation                                                     |
+| ----------------- | ----------- | ------------------------------------------------------------------------ |
+| Vault             | YES         | Community names: "Vault REST Controller", "Vault Session Provider", etc. |
+| Ciphertext        | **NO NODE** | Uses code identifier `EncryptedBlob`/`EncryptedBlobV1`                   |
+| Task              | YES         | "Task Form Components", "Task Item & List"                               |
+| Subscription      | YES         | "Subscriptions Pages", "Subscription Manager"                            |
+| Master Key        | **NO**      | Only appears as `masterKeyBytes`, `masterKey` identifiers                |
+| Vault Unlock      | **NO**      | Function `unlockVaultWithPassphrase()` exists but concept not labeled    |
+| Platform Adapter  | **NO**      | Interface `VaultCrypto` exists but "Platform Adapter" concept absent     |
+| UI Primitive      | PARTIAL     | "UI Component Primitives" community ✓                                    |
+| Feature Component | **NO**      | Not as a labeled concept                                                 |
+
+**What the graph adds vs. DEVELOPMENT.md/CONTEXT.md:**
+
+- GRAPH_REPORT.md gives: which files are most connected (God Nodes), which code units cluster together, surprising cross-file dependencies
+- DEVELOPMENT.md gives: setup, workflow, how to run things
+- CONTEXT.md gives: domain vocabulary, preferred terms, business concepts
+
+These are complementary. GRAPH_REPORT.md is a **code navigation map**, not a domain dictionary. A newcomer benefits from both, not one instead of the other.
+
+**Quantitative**: The labeling pass used Claude to name communities from code content. This produced accurate code-level labels ("Encrypted Vault Storage Crypto") but did NOT match CONTEXT.md vocabulary. The label "Vault" appears frequently but "Ciphertext", "Master Key", "Vault Unlock" never appear.
+
+### Verdict: **PARTIAL**
+
+The graph provides real onboarding value as a code navigation map — community segmentation is accurate, God Nodes highlight change-risk abstractions, Surprising Connections expose hidden couplings. However, it speaks code-identifier language, not domain language. It cannot substitute for CONTEXT.md and would not speed up understanding domain intent (only code structure). Value to a newcomer: medium, complementary to existing docs.
+
+---
+
+## Bar 5 — Agent Retrieval: Accuracy + Latency vs. Baseline
+
+### Q1: "What directly consumes function `saveEncryptedData()`?" (neighborhood)
+
+**Ground truth** (grep): 22 call-site lines across addresses/mobile-numbers/subscriptions/tasks/groceries page clients.
+
+**Graphify** (`get_neighbors("saveEncryptedData()")`):
+
+```
+--> AddressDetailPageClient.tsx [imports] [EXTRACTED]
+--> AddressDetailsInner() [calls] [EXTRACTED]
+--> AddressesPageClient.tsx [imports] [EXTRACTED]
+--> MobileNumberDetailPageClient.tsx [imports] [EXTRACTED]
+--> MobileNumberDetailsInner() [calls] [EXTRACTED]
+--> MobileNumbersPageClient.tsx [imports] [EXTRACTED]
+--> SubscriptionDetailPageClient.tsx [imports] [EXTRACTED]
+--> SubscriptionsPageClient.tsx [imports] [EXTRACTED]
+--> SubscriptionsInner() [calls] [EXTRACTED]
+--> TasksPageClient.tsx [imports] [EXTRACTED]
+--> useGroceriesVault.ts [imports] [EXTRACTED]
+--> AddLocationPageClient.tsx [imports] [EXTRACTED] (x2: addresses + mobile)
+--> AddLocationInner() [calls] [EXTRACTED]
+(+ internal callers: importAesGcmKey, vault.ts, loadVault, saveVault, encryptJsonWithMasterKey)
+```
+
+**Score**: PRECISION HIGH, RECALL HIGH. Graphify correctly identifies all downstream consumers and distinguishes imports vs. call edges. Missing: `vault-core/src/lib/interfaces.ts` interface definition (minor — it's the abstract declaration, not a caller).
+
+**Latency**: MCP tool call ~instant (<0.3s). grep on same codebase: also instant. **PARITY**.
+
+### Q2: "What is affected if backend `VaultController` changes?" (cross-package impact)
+
+**Ground truth** (nx): Only `backend` project affected (1 project).
+
+**Graphify** (`query_graph("VaultController", depth=3)`):
+
+```
+VaultController → routes.ts → RegisterRoutes()
+All nodes stay within backend/src/. No cross-package edges.
+```
+
+**Score**: PASS — consistent with nx. Correctly bounded. No false positives.
+
+**Latency**: MCP ~instant vs. nx: ~8-15s (project graph computation). **GRAPHIFY WINS on latency for leaf-node queries.**
+
+### Q3: "What is affected if `EncryptedBlob`/`EncryptedBlobV1` schema changes?" (type blast radius)
+
+**Ground truth** (grep — excluding generated): serverVaultSync.ts, vaultExportImport.ts, serverVaultSync.test.ts, vaultShapes.ts, vaultMigration.ts. Plus backend VaultService.ts and VaultController.ts.
+
+**Graphify** (`query_graph("EncryptedBlobV1 schema", depth=3)`, 75 nodes):
+Correctly found: serverVaultSync.ts, vaultExportImport.ts, vaultShapes.ts, vaultMigration.ts, ImportVaultCard.tsx, ExportVaultCard.tsx, serverVaultSync.test.ts, backend EncryptedBlobV1 node.
+
+But: `get_node("EncryptedBlobV1")` returned the BACKEND definition (Degree: 3) and `get_neighbors` then showed only 3 backend-side nodes — missing the entire client-side usage. `query_graph` was required to get the full picture.
+
+**Score**: PARTIAL — `query_graph` gives 75-node BFS result that's comprehensive but noisy. Point lookups via `get_node`/`get_neighbors` hit node collision (picked backend EncryptedBlobV1, not app-api-client one) and MISS all client-side consumers.
+
+### Q4: "What consumes `@myorganizer/design-tokens`?" (dependency, cross-check with nx)
+
+**Ground truth** (grep + nx):
+
+- `libs/mobile/ui/src/theme.ts` — imports `from '@myorganizer/design-tokens'`
+- `libs/web/pages/home/src/components/LandingContent.tsx` — imports `from '@myorganizer/design-tokens'`
+- nx affected: 7 projects transitively
+
+**Graphify**:
+
+```
+get_node("design-tokens")
+→ No node matching 'design-tokens' found.
+
+query_graph("design tokens CSS variables imported NativeWind", depth=2)
+→ 3 nodes: tailwind-preset.native.js, tailwind-preset.js, TokenStorageMode (IRRELEVANT)
+```
+
+**COMPLETE MISS**: Both actual consumers (theme.ts, LandingContent.tsx) are absent. Graphify's AST extractor does not resolve `@myorganizer/*` TypeScript path aliases, so imports via the package alias are dropped.
+
+**Score**: **FAIL** — returns 0 of 2 real consumers, includes 1 false positive (TokenStorageMode).
+
+### Q5 (control): "Where is `deriveKeyFromPassphrase` defined?" (grep should win)
+
+**Ground truth** (grep): 3 definitions:
+
+1. `vault-core/src/lib/interfaces.ts:14` — abstract interface
+2. `web-vault/src/lib/vault/crypto.ts:44` — web implementation
+3. `mobile/feat/vault/src/crypto.ts:96` — mobile implementation
+
+**Graphify**:
+
+```
+get_node("deriveKeyFromPassphrase()")
+→ Node: .deriveKeyFromPassphrase()
+   ID: libs::src_crypto_mobilevaultcrypto_derivekeyfrompassphrase
+   Source: mobile/feat/vault/src/crypto.ts L96
+   Community: Vault Session Provider
+   Degree: 2
+```
+
+**WRONG IMPLEMENTATION returned**. The mobile implementation was found; the primary web vault implementation (`web-vault/src/lib/vault/crypto.ts:44`) was silently missed. The abstract interface (`vault-core/src/lib/interfaces.ts:14`) was also missed.
+
+`get_neighbors` on this node returned only mobile-internal relationships (MobileVaultCrypto, deriveKeyFromPassphraseSync), missing the 3 call sites in vault.ts.
+
+`query_graph` with expanded vocabulary DID correctly find the web vault node, but this requires a second query after the `get_node` failure.
+
+**Score**: **FAIL for `get_node`, PARTIAL for `query_graph`**. grep wins unambiguously: one command, three correct definitions, no ambiguity.
+
+### Bar 5 Summary
+
+| Question                           | Type              | Ground Truth              | Graphify Result                         | Score       |
+| ---------------------------------- | ----------------- | ------------------------- | --------------------------------------- | ----------- |
+| saveEncryptedData() callers        | neighborhood      | 7 files, 22 call sites    | 13-15 neighbors, all correct            | **PASS**    |
+| VaultController blast radius       | cross-package     | backend only (1 proj)     | backend only, consistent                | **PASS**    |
+| EncryptedBlobV1 schema blast       | type blast radius | 7 files across 3 packages | 75-node BFS correct, point lookup wrong | **PARTIAL** |
+| design-tokens consumers            | alias import      | 2 files, 7 nx projects    | 0 found, 1 false positive               | **FAIL**    |
+| deriveKeyFromPassphrase definition | symbol lookup     | 3 definitions             | 1 wrong (mobile), 2 missed              | **FAIL**    |
+
+---
+
+## Scorecard
+
+| Bar   | Description                        | Verdict     | Key Evidence                                                                                                        |
+| ----- | ---------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------- |
+| Bar 1 | Vault data-flow accuracy + safety  | **PARTIAL** | Correct nodes, can't trace HTTP boundary, no domain vocabulary ("Ciphertext" absent)                                |
+| Bar 2 | PR/slice triage vs nx affected     | **PARTIAL** | VaultController correct; alias imports (design-tokens) completely invisible; hub files require symbol-level queries |
+| Bar 3 | Noise / navigability               | **PASS**    | ~91% real domains, God Nodes correctly surface vault ops, GRAPH_REPORT navigable, ~9% docs noise fixable            |
+| Bar 4 | Onboarding / domain language       | **PARTIAL** | Useful code map, missing domain vocabulary (Ciphertext, Master Key, Vault Unlock), complementary not substitute     |
+| Bar 5 | Agent retrieval accuracy + latency | **PARTIAL** | 2/5 PASS, 1/5 PARTIAL, 2/5 FAIL; node collisions and alias imports are critical failure modes                       |
+
+**Overall: 1 PASS · 4 PARTIAL · embedded FAILs in Bar 2 and Bar 5**
+
+---
+
+## Go / No-Go Recommendation
+
+### **Conditional NO-GO for autonomous agent adoption in this repo**
+
+Graphify is not ready to be trusted as an autonomous agent's primary code-exploration tool for this monorepo. The two critical failure modes each affect common, important use cases:
+
+1. **Monorepo alias import blindness** (design-tokens, any `@myorganizer/*` import): impact analysis for cross-package dependencies is incorrect. An agent relying on Graphify's blast radius would under-estimate impact for the most widely-consumed shared libraries.
+
+2. **Node collision on polymorphic symbols** (`deriveKeyFromPassphrase`, `EncryptedBlobV1`): `get_node` and `get_neighbors` return the wrong implementation when multiple nodes share a name. A fast wrong answer is worse than grep.
+
+### Where Graphify genuinely wins (narrow use cases)
+
+| Use case                                                                | Graphify advantage                                  |
+| ----------------------------------------------------------------------- | --------------------------------------------------- |
+| "What calls function X?" (concrete, non-aliased, single implementation) | Fast, correct, shows import+call granularity        |
+| Community navigation (which files belong to which domain)               | Good community names, GRAPH_REPORT is scannable     |
+| God Nodes for newcomer orientation                                      | Correctly highlights vault ops as core abstractions |
+| Intra-package impact for backend leaf controllers                       | Consistent with nx, faster than nx                  |
+
+### Where existing tools are better
+
+| Task                          | Better tool       | Why                                                                       |
+| ----------------------------- | ----------------- | ------------------------------------------------------------------------- |
+| Cross-package blast radius    | `nx affected`     | Authoritative; resolves all tsconfig paths; Graphify misses alias imports |
+| Symbol definition lookup      | `grep`            | No node collisions; finds all implementations; instant                    |
+| HTTP/service boundary tracing | Manual code reads | Static AST cannot model HTTP calls (fundamental)                          |
+| Domain vocabulary queries     | CONTEXT.md + grep | Graph doesn't know "Ciphertext", "Master Key"                             |
+
+---
+
+## Limitation Classification
+
+### Fundamental (inherent to AST extraction, not fixable by config)
+
+- **HTTP boundaries are invisible**: No static AST can trace a data-flow path that crosses an HTTP call. `saveEncryptedData → VaultController` will never have a graph path. Any claim about server-side security properties requires manual verification.
+- **Dynamic imports / runtime dispatch**: Anything resolved at runtime is absent from the graph.
+
+### Configurable (fixable by setup)
+
+- **TypeScript path alias resolution** (HIGH IMPACT): `@myorganizer/*` aliases must be configured in graphify's tsconfig.json resolution. Without this, all inter-library imports via package aliases are dropped — which in an Nx monorepo means most cross-library edges. This is fixable by providing `tsconfig.base.json` paths to the extractor.
+- **README/AGENTS.md noise** (LOW IMPACT): Add `*.md` and `*.sh` to `.graphifyignore` to remove ~12 documentation communities.
+- **Node collision on shared names** (MEDIUM IMPACT): The `get_node` API needs disambiguation (e.g., filter by package/path). Currently picks an arbitrary match. This may be a product gap rather than a user-configurable issue.
+
+---
+
+## Prior Notes Comparison
+
+_(Now read — see comparison below)_
+
+### Comparison with Prior Evaluation (`graphify-eval-notes.md`)
+
+The prior notes document three runs: a misconfigured Run 1, a corrected Run 2 (with `--backend claude-cli`, app-api-client included, proper query flow), and a final adoption step with the tuned `.graphifyignore`.
+
+**Where we AGREE:**
+
+| Finding                                                                  | Prior                     | Mine            | Match    |
+| ------------------------------------------------------------------------ | ------------------------- | --------------- | -------- |
+| "Ciphertext" absent from graph                                           | ✓ confirmed               | ✓ confirmed     | **Full** |
+| HTTP boundary invisible, path queries fail                               | ✓ "fundamental AST limit" | ✓ "fundamental" | **Full** |
+| saveEncryptedData neighborhood accurate and fast                         | 🟢 "STRONG"               | PASS            | **Full** |
+| VaultController blast radius correct (backend-only)                      | 🟢 consistent             | PASS            | **Full** |
+| Design-tokens impact wrong/missing                                       | wrong granularity         | FAIL            | **Full** |
+| Doc labeling: no real domain concepts ("Ciphertext")                     | 🔴 3 swagger nodes        | ✗ absent        | **Full** |
+| Node collision for duplicate-label symbols                               | "dup nodes"               | ✓ documented    | **Full** |
+| Community labeling is accurate once config noise excluded                | 🟡 accurate               | PASS            | **Full** |
+| Overall verdict: no-go for impact analysis, narrow win for neighborhoods | no-go                     | no-go           | **Full** |
+
+**Where prior notes go deeper than mine:**
+
+1. **`compute_pr_impact` root cause** (Bar 2): Prior inspected the actual source (`prs.py:243`) and found that "blast_radius" sums the changed file's own community membership — it does NOT reverse-traverse to dependents. This explains why thin barrels like design-tokens (7 downstream projects) score blast_radius=1 while they're actually the highest-risk change. I found the symptom (design-tokens invisible) but not the code-level cause. Their finding is stronger.
+
+2. **Run 1 vs Run 2 comparison**: Prior documented that three config errors caused Run 1 to fail (wrong entry point, excluded app-api-client, wrong query method). My evaluation ran on the already-corrected final graph, so I'm testing the best version. Prior proved the failures reproduce even with correct config.
+
+3. **TS type reference gap**: Prior explicitly found that TS type usages are not call/import edges, so `affected` cannot trace type-level blast radius. I found the same symptom (EncryptedBlobV1 point lookup wrong) but attributed it to node collision rather than the deeper AST model limitation (type annotations aren't AST edges).
+
+**Where my notes add to prior:**
+
+1. **Node collision mechanism documented**: I explicitly showed that `get_node("deriveKeyFromPassphrase()")` returns the mobile implementation (ID: `libs::src_crypto_mobilevaultcrypto_derivekeyfrompassphrase`), silently missing the web vault version and the abstract interface. This is a concrete, reproducible MCP-surface failure not in the prior notes.
+
+2. **`get_neighbors` directional gap for `EncryptedBlobV1`**: `get_neighbors` on the resolved (backend) node returns only 3 neighbors, missing the entire client-side usage. `query_graph` at depth=3 is required. Prior noted the `affected` failure but didn't document the point-lookup/neighborhood mismatch specifically.
+
+3. **`@myorganizer/*` alias imports as a distinct failure mode**: Prior attributed design-tokens failure to "wrong granularity." I identified the mechanism more precisely: path alias imports are dropped by the AST extractor, making ANY `@myorganizer/*` import boundary invisible. This affects ALL inter-library imports in this monorepo, not just design-tokens.
+
+**Verdict comparison**: Both evaluations converge on the same go/no-go: **no-go for autonomous agent use, narrow win for in-package symbol neighborhoods**. The prior notes are more thorough (3 runs, source code inspection), mine independently replicate the core findings and add the node-collision and alias-import mechanisms as distinct documented failure modes.

--- a/tools/scripts/ai/create-labels.mjs
+++ b/tools/scripts/ai/create-labels.mjs
@@ -45,7 +45,8 @@ const LABELS = [
   {
     name: 'status:done',
     color: '0e8a16',
-    description: 'Agent finished; PR opened',
+    description:
+      'Agent finished; slice integrated into the local feature branch',
   },
   {
     name: 'prd',


### PR DESCRIPTION
## Why
Evaluate knowledge-graph tool and adopt narrow MCP index (#158). Follow-up commits refine the branch before merging `chore/sandcastle-local-dispatch` into `main`.

## Changes
- Evaluated Graphify (graphifyy) as an AI-agent code-exploration and impact-analysis
- tool for the Nx monorepo, under correct configuration, and adopted the one proven
- win as an opt-in CodeExplorer supplement.
- Findings (full record in graphify-eval-notes.md; independent second run in
- graphify-test-notes.md converges on the same verdict):
- Strong, free, instant in-package symbol neighborhoods (e.g. saveEncryptedData
- consumers) and an accurate god-node/community onboarding map once config noise
- is excluded.
- Fundamental AST limits remain: blind across the HTTP/OpenAPI codegen boundary,
- no type-level blast radius, get_node collisions on duplicate symbol names. Not a
- replacement for `nx affected` (impact) or grep (definitions).
- Verdict: no-go as a primary/autonomous exploration tool; adopt narrowly.
- Changes:
- .graphifyignore: focus the graph on authored+generated source; exclude build/tool
- config so the community map surfaces real domains (config-noise communities 57% -> ~1%).
- .mcp.json: serve graphify-out/graph.json over the graphify MCP server (read-only).
- .claude/agents/explore.md: give CodeExplorer the read-only graphify tools with
- guardrails (use for "who calls/consumes X"; never for cross-boundary impact or
- duplicate/type symbols; treat results as [inferred] until confirmed against files).
- docs/graphify.md: build/refresh commands, scope limits, maintenance caveat.
- .gitignore: ignore generated graphify-out/ artifacts.
- The generated graph is not committed; rebuild via docs/graphify.md. MCP server
- requires `uv tool install graphifyy --with mcp`.
- Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
- A real-workflow spike (alter Subscriptions + add a mobile screen) showed the
- implementing agent never invoked Graphify directly and its contribution buried
- inside CodeExplorer was unmeasurable. Rather than concede or keep it unproven,
- make the integration earn its keep with observable usage.
- .claude/agents/explore.md: for relationship/consumer Goals, CodeExplorer now
- queries Graphify FIRST (before grep) and MUST emit a `Graphify Usage` block every
- run with a verdict of helped / redundant / wrong-missed vs verified file evidence.
- Also hardened the get_node duplicate-symbol caveat surfaced by the independent run.
- docs/graphify.md: documented the "on probation — usage is measured" stance and the
- kill criterion (consistent redundant/wrong-missed -> drop it).
- graphify-eval-notes.md: recorded the real-workflow finding and this decision.
- Spike branch (spike/notes-field) reverted and deleted — it was always throwaway.
- Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
- Second real-workflow spike: CodeExplorer invoked Graphify (probation wiring
- worked) but verdict was redundant — accurate import graph, reproducible by
- grep -r; decisive type-member/codegen facts outside its model. Keep-or-kill
- tally now 2 spikes / 0 clear helped; integration stays on probation per #158.
- Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
- Make `dispatch-agents` portable across hosts and decouple it from GitHub for
- integration.
- Dependency install (ADR-0009):
- Install each slice's deps INSIDE the Linux container via a
- hooks.sandbox.onSandboxReady hook, so native binaries (bcrypt, prisma,
- @swc/core) are built for the container — correct on WSL2, native Linux, and
- macOS. Bind-mount a shared content-addressable Yarn global cache from
- .sandcastle/.yarn-cache so installs are incremental. Removes the old Docker
- node_modules seed + lockfile-hash invalidation.
- Integration (ADR-0010):
- Create the feature branch locally from origin/main and never push it.
- Run slices one by one; each branches off the current local feature head and
- the host fast-forwards it into the local feature branch after a lint gate.
- No per-slice push, no per-slice PR, no gh pr merge.
- Reduce GitHub coupling to reading issues + writing status labels and a
- completion comment. Gate runs on local refs. Removes pushSliceBranch, PR
- creation/merge, and the parallel fan-out + concurrency semaphore.
- Sync docs/labels to the new model: CLAUDE.md, CONTEXT.md, ADR-0002,
- to-prd/to-issues config, RUNBOOK, create-labels (status:done meaning), and the
- dispatch-waves header.
- Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
- When a slice fast-forwards into the local feature branch, the orchestrator now
- closes the slice issue (reason: completed) alongside the status:done label and
- completion comment. status:done + closed makes re-runs fully idempotent.
- dispatch-waves must stay correct now that slices get closed: fetchSlices uses
- --state all so a completed (closed) slice is still visible for blocker
- resolution and wave verification, and isDone() treats a closed slice as done.
- Without this, a closed slice would look "missing" and falsely fail the wave.
- Docs synced: CLAUDE.md, CONTEXT.md, RUNBOOK, ADR-0010.
- Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Validation
- Generated from 5 commit(s) on `chore/sandcastle-local-dispatch`.
- Compared against base branch `main`.
