### PR TITLE
[Slice] Add local-dispatch smoke marker doc

### DIFF
--- a/docs/sandcastle/SMOKE-TEST.md
+++ b/docs/sandcastle/SMOKE-TEST.md
@@ -1,0 +1,3 @@
+# Sandcastle local-dispatch smoke test
+
+Local-only dispatch verified for PRD #167.


### PR DESCRIPTION
Closes #168

Part of `feat/sandcastle-local-dispatch-smoke-test` — see PRD #167.