### PR TITLE
feat(skills): add prototype, handoff, and ask-matt workflows

### DIFF
--- a/.claude/commands/ask-matt.md
+++ b/.claude/commands/ask-matt.md
@@ -1,0 +1,11 @@
+# Ask Matt Command
+
+Use this workflow when it is unclear which MyOrganizer skill or sequence should be used next.
+
+1. Read and follow `.github/skills/ask-matt/SKILL.md` exactly.
+2. Route the request to the correct flow:
+   - Planned feature -> `/to-prd` then `/to-issues`
+   - Design uncertainty -> `/grill-with-docs`
+   - Runnable exploration needed -> `/prototype` (and `/handoff` if crossing sessions)
+   - Test updates -> `/unit-test-delegation-workflow` or `/playwright-e2e-workflow`
+3. Prefer repository-native workflows and avoid invented process branches.

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,9 @@
+# Handoff Command
+
+Use this workflow when you need to move work to a fresh session or another agent without losing context.
+
+1. Read and follow `.github/skills/handoff/SKILL.md` exactly.
+2. Write a concise handoff document into OS temporary/session storage, not the repo workspace.
+3. Include context summary, current status, open decisions, next concrete steps, verification state, and a suggested skills list.
+4. Reference existing artifacts (PRDs, issues, ADRs, commits) instead of duplicating them.
+5. Redact sensitive information.

--- a/.claude/commands/prototype.md
+++ b/.claude/commands/prototype.md
@@ -1,0 +1,11 @@
+# Prototype Command
+
+Use this workflow when the user needs a quick throwaway prototype to answer a design question before production implementation.
+
+1. Read and follow `.github/skills/prototype/SKILL.md` exactly.
+2. Choose the correct branch:
+   - Logic/state behavior -> `.github/skills/prototype/LOGIC.md`
+   - UI direction comparison -> `.github/skills/prototype/UI.md`
+3. Keep prototype code explicitly throwaway and easy to remove.
+4. Use existing MyOrganizer tooling and structure (thin app wrappers, page logic in `libs/web/pages/**`).
+5. Capture the decision, then delete or absorb prototype code.

--- a/.cursor/rules/ask-matt-workflow.mdc
+++ b/.cursor/rules/ask-matt-workflow.mdc
@@ -1,0 +1,27 @@
+---
+description: Route ambiguous requests to the right MyOrganizer skill flow. Use when it is unclear which workflow should run next.
+alwaysApply: false
+---
+
+# Ask Matt Workflow
+
+## When to Use
+
+- The next workflow/skill is unclear.
+- A request could fit multiple paths (planned feature, ad-hoc task, testing, architecture, release).
+
+## Core Approach
+
+Read and follow `.github/skills/ask-matt/SKILL.md` exactly.
+
+Routing highlights:
+
+- Planned feature -> `to-prd` then `to-issues`
+- Design ambiguity -> `grill-with-docs`
+- Runnable validation required -> `prototype` (+ `handoff` if crossing sessions)
+- Jest/Playwright work -> matching test delegation workflow
+- Release preparation -> `release-and-deploy-workflow`
+
+## Skill Files
+
+- `.github/skills/ask-matt/SKILL.md`

--- a/.cursor/rules/handoff-workflow.mdc
+++ b/.cursor/rules/handoff-workflow.mdc
@@ -1,0 +1,28 @@
+---
+description: Compact the current conversation into a handoff document for a fresh session or agent. Use when crossing context windows or pausing work for continuation.
+alwaysApply: false
+---
+
+# Handoff Workflow
+
+## When to Use
+
+- The session is transitioning to another context window.
+- Work is being paused and needs a robust restart point.
+- A branch/prototype thread needs to be handed back to a main thread.
+
+## Core Approach
+
+Read and follow `.github/skills/handoff/SKILL.md` exactly.
+
+Key points:
+
+- Write handoff in OS temp/session storage, not repo workspace.
+- Include current status, open decisions, next steps, verification state.
+- Include suggested skills for the next session.
+- Reference existing artifacts (issues/PRDs/ADRs/commits) instead of duplicating content.
+- Redact sensitive data.
+
+## Skill Files
+
+- `.github/skills/handoff/SKILL.md`

--- a/.cursor/rules/prototype-workflow.mdc
+++ b/.cursor/rules/prototype-workflow.mdc
@@ -1,0 +1,31 @@
+---
+description: Build a throwaway prototype to answer a design question quickly. Use when validating logic/state behavior or comparing UI directions before production implementation.
+alwaysApply: false
+---
+
+# Prototype Workflow
+
+## When to Use
+
+- The user needs a fast proof-of-concept to validate an idea.
+- Logic/state transitions are unclear and need interactive validation.
+- Multiple UI directions need visual comparison before committing.
+
+## Core Approach
+
+Read and follow `.github/skills/prototype/SKILL.md` exactly.
+
+Key points:
+
+- Pick the correct branch:
+  - logic/state -> `.github/skills/prototype/LOGIC.md`
+  - UI direction -> `.github/skills/prototype/UI.md`
+- Keep prototype code explicitly throwaway and removable.
+- Use existing MyOrganizer conventions and structure.
+- Capture the decision and clean up prototype artifacts after learning.
+
+## Skill Files
+
+- `.github/skills/prototype/SKILL.md`
+- `.github/skills/prototype/LOGIC.md`
+- `.github/skills/prototype/UI.md`

--- a/.gemini/commands/ask-matt.md
+++ b/.gemini/commands/ask-matt.md
@@ -1,0 +1,11 @@
+# Ask Matt Command
+
+Use this workflow when it is unclear which MyOrganizer skill or sequence should be used next.
+
+1. Read and follow `.github/skills/ask-matt/SKILL.md` exactly.
+2. Route the request to the correct flow:
+   - Planned feature -> `/to-prd` then `/to-issues`
+   - Design uncertainty -> `/grill-with-docs`
+   - Runnable exploration needed -> `/prototype` (and `/handoff` if crossing sessions)
+   - Test updates -> `/unit-test-delegation-workflow` or `/playwright-e2e-workflow`
+3. Prefer repository-native workflows and avoid invented process branches.

--- a/.gemini/commands/handoff.md
+++ b/.gemini/commands/handoff.md
@@ -1,0 +1,9 @@
+# Handoff Command
+
+Use this workflow when you need to move work to a fresh session or another agent without losing context.
+
+1. Read and follow `.github/skills/handoff/SKILL.md` exactly.
+2. Write a concise handoff document into OS temporary/session storage, not the repo workspace.
+3. Include context summary, current status, open decisions, next concrete steps, verification state, and a suggested skills list.
+4. Reference existing artifacts (PRDs, issues, ADRs, commits) instead of duplicating them.
+5. Redact sensitive information.

--- a/.gemini/commands/prototype.md
+++ b/.gemini/commands/prototype.md
@@ -1,0 +1,11 @@
+# Prototype Command
+
+Use this workflow when the user needs a quick throwaway prototype to answer a design question before production implementation.
+
+1. Read and follow `.github/skills/prototype/SKILL.md` exactly.
+2. Choose the correct branch:
+   - Logic/state behavior -> `.github/skills/prototype/LOGIC.md`
+   - UI direction comparison -> `.github/skills/prototype/UI.md`
+3. Keep prototype code explicitly throwaway and easy to remove.
+4. Use existing MyOrganizer tooling and structure (thin app wrappers, page logic in `libs/web/pages/**`).
+5. Capture the decision, then delete or absorb prototype code.

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -33,6 +33,12 @@ Committed sixth wave:
 
 - `unit-test-delegation-workflow`
 
+Committed seventh wave:
+
+- `prototype` (adapted from `mattpocock/skills`)
+- `handoff` (adapted from `mattpocock/skills`)
+- `ask-matt` (adapted from `mattpocock/skills`, tweaked for MyOrganizer routing)
+
 These skills capture project-specific workflows that are easy for agents to miss even after reading the general repo instructions.
 
 Note: these are VS Code workspace skills stored in `.github/skills`. They are intended for agent discovery inside the editor. They may not appear in `npx skills list`, which focuses on skills installed through the `skills` CLI.

--- a/.github/skills/ask-matt/SKILL.md
+++ b/.github/skills/ask-matt/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: ask-matt
+description: Ask which MyOrganizer skill or workflow to run next. Use when the right path is unclear and you need a routing recommendation.
+disable-model-invocation: true
+---
+
+# Ask Matt
+
+Adapted from `mattpocock/skills`, adjusted to MyOrganizer's actual skill set and workflow conventions.
+
+Use this as a **router** when you are unsure which workflow to run.
+
+## Main MyOrganizer flow: idea -> implementation
+
+1. **`/grill-with-docs`**  
+   Start here to sharpen a feature/problem statement against domain language and existing decisions.
+
+2. **If the idea needs runnable validation first**  
+   Use **`/prototype`** for throwaway validation (logic or UI), optionally bridged across sessions using **`/handoff`**.
+
+3. **Planned feature path (multi-slice work)**
+   - `/to-prd` -> publish PRD issue
+   - `/to-issues` -> split into slice issues
+   - then run `yarn dispatch-agents --prd <issue-number>` for AFK slices
+
+4. **Ad-hoc or single-shot implementation**
+   - If request is issue creation: `/github-issue-creation-workflow`
+   - If request is direct implementation in current session: implement with relevant domain workflow skill (for example `/frontend-page-library-workflow`, `/backend-api-contract-change`, `/vault-feature-workflow`, `/youtube-integration-workflow`)
+
+## Quality and delivery routing
+
+- Jest unit/integration tests -> `/unit-test-delegation-workflow`
+- Playwright E2E work -> `/playwright-e2e-workflow`
+- Storybook story changes -> `/storybook-delegation-workflow`
+- Prisma/schema/migrations -> `/prisma-migration-workflow`
+- Release/deploy preparation -> `/release-and-deploy-workflow`
+- Architecture deepening pass -> `/improve-codebase-architecture`
+
+## Session transitions
+
+- Use **`/handoff`** when changing sessions or branching work into a fresh context.
+- Keep one unbroken context for tightly coupled planning phases when possible (for example grilling -> PRD -> issue slicing), then split implementation into fresh sessions if needed.
+
+## Rule of thumb
+
+If the work is:
+
+- **New planned feature** -> `/to-prd`
+- **Incoming raw request/bug report** -> `/github-issue-creation-workflow`
+- **Test-heavy or test-file changes** -> delegate through the matching test workflow skill
+- **Architecture/terminology uncertainty** -> `/grill-with-docs` (and `/domain-modeling` when actively updating glossary/ADRs)

--- a/.github/skills/handoff/SKILL.md
+++ b/.github/skills/handoff/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another session or agent to continue from.
+argument-hint: 'What will the next session focus on?'
+disable-model-invocation: true
+---
+
+# Handoff
+
+Adapted from `mattpocock/skills` for MyOrganizer workflows.
+
+Write a handoff document that allows a fresh session to continue work with minimal drift.
+
+## Requirements
+
+- Save the handoff document to the OS temporary/session area, **not** the repository workspace.
+- Include: context summary, current status, open decisions, next concrete steps, and verification state.
+- Include a **Suggested Skills** section listing relevant repo skills (for example: `to-prd`, `to-issues`, `unit-test-delegation-workflow`, `playwright-e2e-workflow`, `release-and-deploy-workflow`, `grill-with-docs`).
+- Do not duplicate full content already present in PRDs/issues/ADRs/commits/diffs; reference those paths or URLs instead.
+- Redact sensitive data (tokens, passwords, keys, personal data).
+- If arguments are provided, tailor the handoff toward that next-session focus.

--- a/.github/skills/prototype/LOGIC.md
+++ b/.github/skills/prototype/LOGIC.md
@@ -1,0 +1,39 @@
+# Logic Prototype
+
+Adapted from `mattpocock/skills` for MyOrganizer.
+
+Use this when the question is about **business logic, state transitions, or data shape** and you need to drive the model interactively.
+
+## Use this shape when
+
+- Edge-case transitions are hard to reason about on paper.
+- You want to validate reducer/state-machine behavior before production code.
+- You need to feel out interface shape with fast feedback.
+
+If the question is visual/layout-focused, use [UI.md](UI.md) instead.
+
+## Process
+
+1. **State the question**
+   - Record the exact question being answered in the prototype file header or nearby notes.
+2. **Use existing runtime/tooling**
+   - Match current project conventions; do not introduce new package managers/runtimes.
+3. **Isolate portable logic**
+   - Keep prototype logic behind a small pure surface (reducer/state machine/pure functions/small module).
+   - Keep terminal shell separate from logic.
+4. **Build the smallest interactive shell**
+   - Render current state and available actions after each input.
+   - Re-render the frame each interaction for easy comparison.
+5. **Make it runnable in one command**
+   - Add a single run entry via existing scripts/targets where appropriate.
+6. **Hand over**
+   - Share command and expected interactions.
+7. **Capture conclusion**
+   - Save what was learned, then remove throwaway shell code.
+
+## Anti-patterns
+
+- Adding tests for the throwaway shell.
+- Using production persistence by default.
+- Over-generalizing beyond the single question.
+- Mixing terminal I/O with logic internals.

--- a/.github/skills/prototype/SKILL.md
+++ b/.github/skills/prototype/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: prototype
+description: Build throwaway prototypes to answer design questions quickly. Use when you need to sanity-check logic/state behavior or compare multiple UI directions before committing to production implementation.
+---
+
+# Prototype
+
+Adapted from `mattpocock/skills` for MyOrganizer workflows.
+
+A prototype is **throwaway code that answers a question**. The question decides the shape.
+
+## Pick a branch
+
+Identify the question first:
+
+- **"Does this logic/state model feel right?"** → follow [LOGIC.md](LOGIC.md)
+- **"What should this look like?"** → follow [UI.md](UI.md)
+
+If the question is ambiguous and the user is AFK, choose the branch that best matches the touched area and state that assumption in the prototype.
+
+## Rules for both branches
+
+1. **Throwaway from day one**: make it obvious this is prototype-only (name/path/comment).
+2. **One command to run**: use existing project tooling (`yarn nx ...`, `yarn ...`).
+3. **No persistence by default**: keep state in memory unless persistence itself is the question.
+4. **Skip polish**: no tests, no production hardening, minimal error handling.
+5. **Surface state clearly**: every interaction should expose resulting state/shape.
+6. **Delete or absorb quickly**: once answered, remove prototype code or fold validated decisions into real implementation.
+
+## MyOrganizer constraints
+
+- Keep Next.js route wrappers in `apps/myorganizer/src/app/**` thin. For UI prototypes, prefer putting throwaway implementation in an appropriate `libs/web/pages/<route>/` area and expose it via a temporary wrapper route only if needed.
+- Do not add plaintext persistence for vault-backed domains.
+- Do not hand-edit generated outputs (API client/spec artifacts) just to prototype behavior.
+
+## After the prototype
+
+Capture the **answer** (question + conclusion) in a durable place (issue, ADR, PR note, or nearby notes), then clean up the prototype.

--- a/.github/skills/prototype/UI.md
+++ b/.github/skills/prototype/UI.md
@@ -1,0 +1,42 @@
+# UI Prototype
+
+Adapted from `mattpocock/skills` for MyOrganizer.
+
+Generate **radically different UI variants** for a single surface, switchable with a `?variant=` query param, then pick/merge and delete the rest.
+
+If the question is logic/state-focused, use [LOGIC.md](LOGIC.md).
+
+## Preferred shape
+
+### A) Existing page adjustment (default)
+
+- Keep the same route and data loading.
+- Swap only the rendered UI subtree using `?variant=`.
+
+### B) Temporary route (fallback)
+
+- Only when no existing page can host the prototype.
+- Use a clearly throwaway route naming pattern and remove after decision.
+
+## Process
+
+1. **State the question and variant count**
+   - Default to 3 variants, max 5.
+2. **Create structurally different variants**
+   - Different hierarchy/layout/primary affordance, not cosmetic-only differences.
+3. **Wire variant switch**
+   - Read query param and render variant A/B/C.
+4. **Add floating variant switcher**
+   - Prev/next controls + label.
+   - Updates URL query param for shareable/reload-stable state.
+   - Keyboard left/right supported (without hijacking focused text inputs).
+   - Hidden in production.
+5. **Gather decision**
+   - Capture what won and why.
+6. **Cleanup**
+   - Keep winner in real implementation path, delete prototype variants/switcher.
+
+## MyOrganizer constraints
+
+- App route wrappers in `apps/myorganizer/src/app/**` must remain thin; place page logic in `libs/web/pages/<route>/`.
+- Follow existing UI conventions and design tokens where practical, but do not over-polish prototype code.


### PR DESCRIPTION
## Why
Add prototype, handoff, and ask-matt workflows.

## Changes
- add new `.github/skills` definitions for `prototype`, `handoff`, and `ask-matt`
- add `prototype` branch guides in `LOGIC.md` and `UI.md`
- mirror command/rule wrappers in `.claude/commands`, `.cursor/rules`, and `.gemini/commands`
- update `.github/skills/README.md` with the seventh wave entries
- Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Validation
- Generated from 1 commit(s) on `chore/add-prototype-handoff-ask-matt-skills`.
- Compared against base branch `main`.
