### PR TITLE
feat(sandcastle): add multi-provider agent support with runtime selection

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -2,8 +2,29 @@
 # Copy this file to .sandcastle/.env and fill in the values.
 # .env is gitignored — never commit your API key.
 
-# Required: Anthropic API key for Claude Code agents running in Docker.
+# Optional: default agent provider for dispatch.
+# Supported values: claude, cursor, copilot
+SANDCASTLE_AGENT=claude
+
+# Optional: default model overrides per provider.
+# Claude still falls back to the issue complexity labels when this is unset.
+# SANDCASTLE_MODEL=claude-sonnet-4.6
+# SANDCASTLE_CLAUDE_MODEL=
+SANDCASTLE_CURSOR_MODEL=composer-2
+SANDCASTLE_COPILOT_MODEL=claude-sonnet-4.5
+
+# Required for Claude Code agents.
+# Provide one of:
+# CLAUDE_CODE_OAUTH_TOKEN=your-token-here
 ANTHROPIC_API_KEY=your-key-here
+
+# Required for Cursor agents.
+# CURSOR_API_KEY=your-cursor-api-key
+
+# Required for GitHub Copilot CLI agents.
+# COPILOT_GITHUB_TOKEN=your-github-token-here
+# GH_TOKEN=your-github-token-here
+# GITHUB_TOKEN=your-github-token-here
 
 # Optional: GitHub token for gh CLI operations inside the sandbox.
 # If unset, the agent falls back to the host's authenticated gh session (bind-mount mode).

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -32,12 +32,16 @@ ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
 RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
-USER ${AGENT_UID}:${AGENT_GID}
 
-# Install Claude Code CLI
+# Install the supported agent CLIs
+# Copilot installs globally before we drop to the agent user; Cursor and Claude
+# install into the agent home directory and share the same PATH entry.
+RUN npm install -g @github/copilot
+USER ${AGENT_UID}:${AGENT_GID}
+RUN curl https://cursor.com/install -fsS | bash
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
-# Add Claude to PATH
+# Add Cursor/Claude to PATH
 ENV PATH="/home/agent/.local/bin:$PATH"
 
 WORKDIR /home/agent

--- a/.sandcastle/dispatch-waves.mts
+++ b/.sandcastle/dispatch-waves.mts
@@ -17,13 +17,34 @@
  *
  * Usage: npx tsx .sandcastle/dispatch-waves.mts --prd <issue-number>
  */
+import dotenv from 'dotenv';
 import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+dotenv.config({ path: join(process.cwd(), '.sandcastle', '.env') });
 
 const REPO = 'mnaimfaizy/myorganizer';
 
 function fail(message: string, code = 1): never {
   console.error(`\nError: ${message}`);
   process.exit(code);
+}
+
+function printHelp(): void {
+  console.log(`
+Usage:
+  npx tsx .sandcastle/dispatch-waves.mts --prd <issue-number> [--agent claude|cursor|copilot] [--model <model>]
+
+Flags:
+  --prd <issue-number>   PRD issue number to dispatch
+  --agent <name>         Forwarded to dispatch-agents
+  --model <model>        Forwarded to dispatch-agents
+  --plan                 Preview wave ordering only
+  --help                 Show this help text
+
+Environment:
+  .sandcastle/.env is loaded automatically.
+`);
 }
 
 function ghJson<T>(args: string[]): T {
@@ -39,12 +60,30 @@ function ghSilent(args: string[]): void {
 
 // ─── Parse --prd <N> ─────────────────────────────────────────────────────────
 
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  printHelp();
+  process.exit(0);
+}
+
 const prdFlag = process.argv.indexOf('--prd');
 if (prdFlag === -1 || !process.argv[prdFlag + 1]) {
   fail('Usage: npx tsx .sandcastle/dispatch-waves.mts --prd <issue-number>');
 }
 const prdNumber = parseInt(process.argv[prdFlag + 1], 10);
 if (isNaN(prdNumber)) fail('--prd must be a number.');
+
+const forwardedArgs: string[] = [];
+for (let i = 2; i < process.argv.length; i++) {
+  const arg = process.argv[i];
+  if (arg === '--prd') {
+    i += 1;
+    continue;
+  }
+  if (arg === '--plan') {
+    continue;
+  }
+  forwardedArgs.push(arg);
+}
 
 // ─── Fetch all AFK slices for this PRD ────────────────────────────────────────
 
@@ -214,7 +253,13 @@ for (let i = 0; i < waves.length; i++) {
   // slice into the local feature branch.
   const dispatch = spawnSync(
     'npx',
-    ['tsx', '.sandcastle/main.mts', '--prd', String(prdNumber)],
+    [
+      'tsx',
+      '.sandcastle/main.mts',
+      '--prd',
+      String(prdNumber),
+      ...forwardedArgs,
+    ],
     { encoding: 'utf8', stdio: 'inherit', windowsHide: true, shell: true },
   );
   if (dispatch.status !== 0) {

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,10 +1,13 @@
-import { run, claudeCode } from '@ai-hero/sandcastle';
+import dotenv from 'dotenv';
+import { run, claudeCode, cursor, copilot } from '@ai-hero/sandcastle';
 import { docker } from '@ai-hero/sandcastle/sandboxes/docker';
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REPO = 'mnaimfaizy/myorganizer';
+
+dotenv.config({ path: join(process.cwd(), '.sandcastle', '.env') });
 
 // ─── Integration model (local-only) ───────────────────────────────────────────
 // GitHub coupling is deliberately minimal: we READ the PRD + slice issues and
@@ -103,12 +106,56 @@ function gitRefExists(ref: string): boolean {
 
 // ─── Parse --prd <N> ─────────────────────────────────────────────────────────
 
-const prdFlag = process.argv.indexOf('--prd');
-if (prdFlag === -1 || !process.argv[prdFlag + 1]) {
-  fail('Usage: yarn dispatch-agents --prd <issue-number>');
+function getArgValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const withEquals = process.argv.find((arg) => arg.startsWith(prefix));
+  if (withEquals) return withEquals.slice(prefix.length);
+
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) return undefined;
+
+  const value = process.argv[index + 1];
+  return value && !value.startsWith('--') ? value : undefined;
 }
-const prdNumber = parseInt(process.argv[prdFlag + 1], 10);
+
+function printHelp(): void {
+  console.log(`
+Usage:
+  yarn dispatch-agents --prd <issue-number> [--agent claude|cursor|copilot] [--model <model>]
+
+Flags:
+  --prd <issue-number>   PRD issue number to dispatch
+  --agent <name>         Agent provider to use (default: SANDCASTLE_AGENT or claude)
+  --model <model>        Override the model for this run (default: env/provider routing)
+  --help                 Show this help text
+
+Environment:
+  .sandcastle/.env is loaded automatically.
+  SANDCASTLE_AGENT
+  SANDCASTLE_MODEL
+  SANDCASTLE_CLAUDE_MODEL
+  SANDCASTLE_CURSOR_MODEL
+  SANDCASTLE_COPILOT_MODEL
+`);
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  printHelp();
+  process.exit(0);
+}
+
+const prdValue = getArgValue('prd');
+if (!prdValue) {
+  fail(
+    'Usage: yarn dispatch-agents --prd <issue-number> [--agent claude|cursor|copilot] [--model <model>]',
+  );
+}
+
+const prdNumber = parseInt(prdValue, 10);
 if (isNaN(prdNumber)) fail('--prd must be a number.');
+
+const agentFlag = getArgValue('agent');
+const modelFlag = getArgValue('model');
 
 // ─── Fetch PRD issue ──────────────────────────────────────────────────────────
 
@@ -235,11 +282,47 @@ console.log(`Dispatching ${slices.length} slice(s) one by one...\n`);
 
 // ─── Model routing ────────────────────────────────────────────────────────────
 
+type AgentKind = 'claude' | 'cursor' | 'copilot';
+
 function modelFor(issue: Issue): string {
   const labels = issue.labels.map((l) => l.name);
   if (labels.includes('complexity:high')) return 'claude-opus-4-5';
   if (labels.includes('complexity:medium')) return 'claude-sonnet-4-6';
   return 'claude-haiku-4-5';
+}
+
+function resolveAgentKind(): AgentKind {
+  const raw = (agentFlag ?? process.env.SANDCASTLE_AGENT ?? 'claude').trim();
+  if (raw === 'claude' || raw === 'cursor' || raw === 'copilot') {
+    return raw;
+  }
+
+  fail(`Unknown agent "${raw}". Available: claude, cursor, copilot.`);
+}
+
+function resolveModel(issue: Issue, agentKind: AgentKind): string {
+  const explicitModel = modelFlag ?? process.env.SANDCASTLE_MODEL;
+  if (explicitModel) return explicitModel;
+
+  switch (agentKind) {
+    case 'claude':
+      return process.env.SANDCASTLE_CLAUDE_MODEL ?? modelFor(issue);
+    case 'cursor':
+      return process.env.SANDCASTLE_CURSOR_MODEL ?? 'composer-2';
+    case 'copilot':
+      return process.env.SANDCASTLE_COPILOT_MODEL ?? 'claude-sonnet-4.5';
+  }
+}
+
+function buildAgent(agentKind: AgentKind, model: string) {
+  switch (agentKind) {
+    case 'claude':
+      return claudeCode(model);
+    case 'cursor':
+      return cursor(model);
+    case 'copilot':
+      return copilot(model);
+  }
 }
 
 function sliceBranchFor(issue: Issue): string {
@@ -515,9 +598,11 @@ type SliceResult = {
 
 const results: SliceResult[] = [];
 const crashed: Array<{ issue: Issue; error: string }> = [];
+const agentKind = resolveAgentKind();
 
 for (const issue of slices) {
-  const model = modelFor(issue);
+  const model = resolveModel(issue, agentKind);
+  const agent = buildAgent(agentKind, model);
   const sliceBranch = sliceBranchFor(issue);
 
   ghSilent([
@@ -531,7 +616,9 @@ for (const issue of slices) {
   ]);
 
   try {
-    console.log(`\n  → #${issue.number} on ${sliceBranch} (${model})`);
+    console.log(
+      `\n  → #${issue.number} on ${sliceBranch} (${agentKind}:${model})`,
+    );
 
     // Fresh slice branch + worktree off the CURRENT local feature head, so this
     // slice (processed one by one) builds on every previously-integrated slice.
@@ -568,7 +655,7 @@ for (const issue of slices) {
     }
 
     const result = await run({
-      agent: claudeCode(model),
+      agent,
       sandbox: docker({
         env: {
           NX_DAEMON: 'false',

--- a/docs/sandcastle/RUNBOOK.md
+++ b/docs/sandcastle/RUNBOOK.md
@@ -27,8 +27,11 @@ pipeline.
 2. **Docker:** a running Docker engine the dispatch shell can reach (`docker info` works).
 3. **Auth:** `gh auth status` green and `git config user.name/.email` set, for the dispatch host.
 4. **Secrets:** `cp .sandcastle/.env.example .sandcastle/.env` and set `ANTHROPIC_API_KEY`
-   (`GH_TOKEN` optional; otherwise the host's `gh` session is used).
-5. The `sandcastle:myorganizer` image builds automatically on first run if missing.
+   (`GH_TOKEN` optional; otherwise the host's `gh` session is used). The launcher loads
+   `.sandcastle/.env` itself.
+5. The `sandcastle:myorganizer` image builds automatically on first run if missing. It
+   already bakes in Claude Code, Cursor, and GitHub Copilot CLI so the `--agent` flag only
+   switches which provider Sandcastle launches.
 
 The dispatch host does **not** need native build tools — compilation happens in-container.
 
@@ -66,7 +69,15 @@ Windows-native dispatch (from PowerShell, repo on `D:\`) works but is ~29 min/in
 ```bash
 corepack yarn dispatch-agents --prd <issue-number>   # all ready AFK slices, one by one
 corepack yarn dispatch-waves  --prd <issue-number>   # dependency-ordered across waves
+corepack yarn dispatch-agents --prd <issue-number> --agent cursor
+corepack yarn dispatch-agents --prd <issue-number> --agent copilot --model claude-sonnet-4.5
 ```
+
+Provider switching is optional: the default agent can live in `.sandcastle/.env` as
+`SANDCASTLE_AGENT=claude|cursor|copilot`. Per-provider model defaults can also live there
+(`SANDCASTLE_CLAUDE_MODEL`, `SANDCASTLE_CURSOR_MODEL`, `SANDCASTLE_COPILOT_MODEL`), and
+`--model` always overrides them for a single run. Claude keeps the existing complexity-based
+model routing when no override is set.
 
 **Integration is local-only** (see `docs/adr/0010`). The feature branch `feat/<slug>` is created
 from `origin/main` **locally and is never pushed**. Slices run **one by one**: each branches off


### PR DESCRIPTION
## Summary
- Add runtime switching between Claude, Cursor, and Copilot for Sandcastle runs
- Load provider defaults from .sandcastle/.env and support --agent / --model flags
- Update the Sandcastle Docker image to include all three CLIs
- Document the new flow in the Sandcastle runbook

## Verification
- git diff --check
- npx tsc --noEmit for .sandcastle/main.mts and .sandcastle/dispatch-waves.mts
- docker build -f .sandcastle/Dockerfile