### PR TITLE
test(tasks): thin TasksPageClient behavior tests via workflow seam

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,8 +1,8 @@
-import dotenv from 'dotenv';
-import { run, claudeCode, cursor, copilot } from '@ai-hero/sandcastle';
+import { claudeCode, copilot, cursor, run } from '@ai-hero/sandcastle';
 import { docker } from '@ai-hero/sandcastle/sandboxes/docker';
+import dotenv from 'dotenv';
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REPO = 'mnaimfaizy/myorganizer';
@@ -524,11 +524,68 @@ function integrateSlice(issue: Issue, sliceBranch: string): boolean {
     );
     return false;
   }
+
+  const findCheckedOutWorktreeForBranch = (branch: string): string | null => {
+    const wt = spawnSync('git', ['worktree', 'list', '--porcelain'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    if (wt.status !== 0 || !wt.stdout.trim()) return null;
+
+    let worktreePath: string | null = null;
+    for (const line of wt.stdout.split('\n')) {
+      if (!line.trim()) {
+        worktreePath = null;
+        continue;
+      }
+      if (line.startsWith('worktree ')) {
+        worktreePath = line.slice('worktree '.length).trim();
+        continue;
+      }
+      if (
+        line === `branch refs/heads/${branch}` &&
+        typeof worktreePath === 'string'
+      ) {
+        return worktreePath;
+      }
+    }
+    return null;
+  };
+
+  const mergeInCheckedOutWorktree = (): boolean => {
+    const worktreePath = findCheckedOutWorktreeForBranch(featureBranch);
+    if (!worktreePath) return false;
+
+    const ffMerge = spawnSync(
+      'git',
+      ['-C', worktreePath, 'merge', '--ff-only', sliceBranch],
+      {
+        encoding: 'utf8',
+        windowsHide: true,
+      },
+    );
+
+    if (ffMerge.status !== 0) {
+      console.error(
+        `  [#${issue.number}] integrate: failed to fast-forward ${featureBranch} in checked-out worktree ${worktreePath}.\n${ffMerge.stderr}`,
+      );
+      return false;
+    }
+
+    console.log(
+      `  [#${issue.number}] integrated into local ${featureBranch} (fast-forward in checked-out worktree).`,
+    );
+    return true;
+  };
+
   const ff = spawnSync('git', ['branch', '-f', featureBranch, sliceBranch], {
     encoding: 'utf8',
     windowsHide: true,
   });
   if (ff.status !== 0) {
+    if (ff.stderr.includes('cannot force update the branch')) {
+      return mergeInCheckedOutWorktree();
+    }
     console.error(
       `  [#${issue.number}] integrate: failed to advance ${featureBranch}.\n${ff.stderr}`,
     );

--- a/libs/web/pages/tasks/src/components/TasksPageClient.test.tsx
+++ b/libs/web/pages/tasks/src/components/TasksPageClient.test.tsx
@@ -1,21 +1,9 @@
-import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { Task } from '@myorganizer/core';
-import {
-  loadDecryptedData,
-  migrateFromTodos,
-  normalizeTasks,
-  saveEncryptedData,
-} from '@myorganizer/web-vault';
-import { useToast } from '@myorganizer/web-ui';
-import { TasksPageClient } from './TasksPageClient';
+/** Mocking rule: place jest.mock calls before any imports */
+/* eslint-disable import/first -- jest.mock must precede application imports */
 
-jest.mock('@myorganizer/core', () => ({
-  ...jest.requireActual('@myorganizer/core'),
-  randomId: jest.fn(() => 'mock-task-id'),
+jest.mock('@myorganizer/web-ui', () => ({
+  useToast: jest.fn(),
 }));
-
-jest.mock('@myorganizer/web-vault');
 
 jest.mock('@myorganizer/web-vault-ui', () => ({
   VaultGate: ({
@@ -25,9 +13,7 @@ jest.mock('@myorganizer/web-vault-ui', () => ({
   }) => children({ masterKeyBytes: new Uint8Array(32) }) as React.ReactElement,
 }));
 
-jest.mock('@myorganizer/web-ui', () => ({
-  useToast: jest.fn(),
-}));
+jest.mock('../workflow');
 
 jest.mock('./task-form', () => ({
   TaskForm: ({
@@ -157,243 +143,153 @@ jest.mock('./task-delete-dialog', () => ({
     ) : null,
 }));
 
-const mockLoadDecryptedData = loadDecryptedData as jest.Mock;
-const mockSaveEncryptedData = saveEncryptedData as jest.Mock;
-const mockNormalizeTasks = normalizeTasks as jest.Mock;
-const mockMigrateFromTodos = migrateFromTodos as jest.Mock;
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Task } from '@myorganizer/core';
+import { useToast } from '@myorganizer/web-ui';
+import { TasksPageClient } from './TasksPageClient';
+import { useTasksWorkflow } from '../workflow';
+
 const mockUseToast = useToast as jest.Mock;
+const mockUseTasksWorkflow = useTasksWorkflow as jest.Mock;
+
 const mockToast = jest.fn();
+
+function makeWorkflowState(
+  overrides?: Partial<ReturnType<typeof useTasksWorkflow>>,
+) {
+  return {
+    tasks: [] as Task[],
+    loading: false,
+    loadError: null,
+    addTask: jest.fn(),
+    updateTask: jest.fn(),
+    deleteTask: jest.fn(),
+    archiveTask: jest.fn(),
+    unarchiveTask: jest.fn(),
+    ...overrides,
+  };
+}
 
 describe('TasksPageClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseToast.mockReturnValue({ toast: mockToast });
-    mockLoadDecryptedData.mockResolvedValue([
-      {
-        id: 't1',
-        title: 'Task 1',
-        priority: 'medium',
-        status: 'pending',
-        archived: false,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      } as Task,
-    ]);
-    mockSaveEncryptedData.mockResolvedValue(undefined);
-    mockNormalizeTasks.mockImplementation((raw) => ({
-      value: Array.isArray(raw) ? raw : [],
-      changed: false,
-    }));
-    mockMigrateFromTodos.mockImplementation((todos) =>
-      Array.isArray(todos)
-        ? todos.map((t: { id: string; todo: string }) => ({
-            id: t.id,
-            title: t.todo,
-            priority: 'medium' as const,
-            status: 'pending' as const,
-            archived: false,
-            createdAt: '2024-01-01T00:00:00.000Z',
-          }))
-        : [],
-    );
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState());
   });
 
-  it('should load tasks from vault on mount and call loadDecryptedData with type tasks', async () => {
+  it('renders page with task list section', () => {
+    render(<TasksPageClient />);
+    expect(screen.getByText('Create task')).toBeInTheDocument();
+    expect(screen.getByText('Task List')).toBeInTheDocument();
+  });
+
+  it('renders tasks from workflow', () => {
     const tasks: Task[] = [
       {
         id: 't1',
         title: 'Task One',
-        priority: 'medium',
+        priority: 'high',
         status: 'pending',
         archived: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       },
-    ];
-    mockLoadDecryptedData.mockResolvedValue(tasks);
-    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
-
-    render(<TasksPageClient />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Task One')).toBeInTheDocument();
-    });
-
-    expect(mockLoadDecryptedData).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'tasks', defaultValue: null }),
-    );
-  });
-
-  it('should auto-migrate from todos when tasks blob is null and todos exist', async () => {
-    mockLoadDecryptedData.mockImplementation(
-      (opts: { type: string; defaultValue: unknown }) => {
-        if (opts.type === 'tasks') return Promise.resolve(null);
-        if (opts.type === 'todos')
-          return Promise.resolve([{ id: 'todo1', todo: 'Migrate me' }]);
-        return Promise.resolve(opts.defaultValue);
-      },
-    );
-    const migratedTasks: Task[] = [
       {
-        id: 'todo1',
-        title: 'Migrate me',
+        id: 't2',
+        title: 'Task Two',
         priority: 'medium',
         status: 'pending',
         archived: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
-    mockMigrateFromTodos.mockReturnValue(migratedTasks);
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks }));
 
     render(<TasksPageClient />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Migrate me')).toBeInTheDocument();
-    });
-
-    expect(mockLoadDecryptedData).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'todos', defaultValue: [] }),
-    );
-    expect(mockMigrateFromTodos).toHaveBeenCalled();
-    expect(mockSaveEncryptedData).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'tasks', value: migratedTasks }),
-    );
+    expect(screen.getByText('Task One')).toBeInTheDocument();
+    expect(screen.getByText('Task Two')).toBeInTheDocument();
   });
 
-  it('should not save when tasks blob is null and todos are empty', async () => {
-    mockLoadDecryptedData.mockImplementation(
-      (opts: { type: string; defaultValue: unknown }) => {
-        if (opts.type === 'tasks') return Promise.resolve(null);
-        if (opts.type === 'todos') return Promise.resolve([]);
-        return Promise.resolve(opts.defaultValue);
-      },
-    );
-
+  it('calls useTasksWorkflow with masterKeyBytes from VaultGate', () => {
     render(<TasksPageClient />);
 
-    await waitFor(() => {
-      expect(mockLoadDecryptedData).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'todos' }),
-      );
-    });
-
-    expect(mockSaveEncryptedData).not.toHaveBeenCalled();
+    expect(mockUseTasksWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        masterKeyBytes: expect.any(Uint8Array),
+      }),
+    );
   });
 
-  it('should show destructive toast on load failure', async () => {
-    mockLoadDecryptedData.mockRejectedValue(new Error('Decryption failed'));
+  it('shows load error toast when workflow.loadError is set', async () => {
+    const loadError = { code: 'load_failed' as const, message: 'Vault error' };
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ loadError }));
 
     render(<TasksPageClient />);
 
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: 'destructive',
           title: 'Failed to load tasks',
           description: 'Could not decrypt saved data.',
+          variant: 'destructive',
         }),
       );
     });
   });
 
-  it('should re-save when normalization reports changed=true', async () => {
-    const rawTasks = [
-      { id: 't1', title: 'Task One', priority: 'high', createdAt: '...' },
-    ];
-    const normalizedTasks: Task[] = [
-      {
-        id: 't1',
-        title: 'Task One',
-        priority: 'high',
-        status: 'pending',
-        archived: false,
-        createdAt: '...',
-      },
-    ];
-    mockLoadDecryptedData.mockResolvedValue(rawTasks);
-    mockNormalizeTasks.mockReturnValue({
-      value: normalizedTasks,
-      changed: true,
+  it('calls addTask on form submit and shows success toast', async () => {
+    const mockAddTask = jest.fn().mockResolvedValue({
+      ok: true,
+      kind: 'created',
     });
+    mockUseTasksWorkflow.mockReturnValue(
+      makeWorkflowState({ addTask: mockAddTask }),
+    );
 
     render(<TasksPageClient />);
-
-    await waitFor(() => {
-      expect(mockSaveEncryptedData).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'tasks', value: normalizedTasks }),
-      );
-    });
-  });
-
-  it('should render tasks sorted by priority: high before medium before low', async () => {
-    const tasks: Task[] = [
-      {
-        id: 'low',
-        title: 'Low Priority',
-        priority: 'low',
-        status: 'pending',
-        archived: false,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      },
-      {
-        id: 'high',
-        title: 'High Priority',
-        priority: 'high',
-        status: 'pending',
-        archived: false,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      },
-      {
-        id: 'medium',
-        title: 'Medium Priority',
-        priority: 'medium',
-        status: 'pending',
-        archived: false,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      },
-    ];
-    mockLoadDecryptedData.mockResolvedValue(tasks);
-    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
-
-    render(<TasksPageClient />);
-
-    await waitFor(() => {
-      const titles = screen
-        .getAllByRole('heading', { level: 3 })
-        .map((el) => el.textContent);
-      expect(titles).toEqual([
-        'High Priority',
-        'Medium Priority',
-        'Low Priority',
-      ]);
-    });
-  });
-
-  it('should save vault and show task in list after form submit', async () => {
-    mockLoadDecryptedData.mockResolvedValue([]);
-    mockNormalizeTasks.mockReturnValue({ value: [], changed: false });
-
-    render(<TasksPageClient />);
-
-    await waitFor(() => {
-      expect(mockLoadDecryptedData).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'tasks' }),
-      );
-    });
 
     fireEvent.click(screen.getByTestId('add-task-btn'));
 
     await waitFor(() => {
-      expect(mockSaveEncryptedData).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'tasks' }),
-      );
+      expect(mockAddTask).toHaveBeenCalled();
     });
+
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({ title: 'Task created' }),
+        expect.objectContaining({
+          title: 'Task created',
+          description: 'Your task has been saved (encrypted).',
+        }),
       );
     });
   });
 
-  it('should remove task and save vault after delete', async () => {
+  it('shows save_failed toast when addTask mutation fails', async () => {
+    const mockAddTask = jest.fn().mockResolvedValue({
+      ok: false,
+      error: { code: 'save_failed' as const, message: 'Save error' },
+    });
+    mockUseTasksWorkflow.mockReturnValue(
+      makeWorkflowState({ addTask: mockAddTask }),
+    );
+
+    render(<TasksPageClient />);
+
+    fireEvent.click(screen.getByTestId('add-task-btn'));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to save',
+          description: 'Save error',
+          variant: 'destructive',
+        }),
+      );
+    });
+  });
+
+  it('opens delete dialog when delete button clicked', async () => {
     const task: Task = {
       id: 't1',
       title: 'Task to delete',
@@ -402,14 +298,38 @@ describe('TasksPageClient', () => {
       archived: false,
       createdAt: '2024-01-01T00:00:00.000Z',
     };
-    mockLoadDecryptedData.mockResolvedValue([task]);
-    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks: [task] }));
 
     render(<TasksPageClient />);
 
+    fireEvent.click(screen.getByTestId('delete-t1'));
+
     await waitFor(() => {
-      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('deleting-task-title')).toHaveTextContent(
+        'Task to delete',
+      );
     });
+  });
+
+  it('calls deleteTask on delete confirmation and shows success toast', async () => {
+    const task: Task = {
+      id: 't1',
+      title: 'Task to delete',
+      priority: 'medium',
+      status: 'pending',
+      archived: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    const mockDeleteTask = jest.fn().mockResolvedValue({
+      ok: true,
+      kind: 'deleted',
+    });
+    mockUseTasksWorkflow.mockReturnValue(
+      makeWorkflowState({ tasks: [task], deleteTask: mockDeleteTask }),
+    );
+
+    render(<TasksPageClient />);
 
     fireEvent.click(screen.getByTestId('delete-t1'));
 
@@ -420,18 +340,46 @@ describe('TasksPageClient', () => {
     fireEvent.click(screen.getByTestId('confirm-delete-btn'));
 
     await waitFor(() => {
-      expect(mockSaveEncryptedData).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'tasks', value: [] }),
-      );
+      expect(mockDeleteTask).toHaveBeenCalledWith('t1');
     });
+
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({ title: 'Task deleted' }),
+        expect.objectContaining({
+          title: 'Task deleted',
+          description: 'Your task has been deleted.',
+        }),
       );
     });
   });
 
-  it('should open edit dialog and save edit with updatedAt', async () => {
+  it('closes delete dialog on cancel', async () => {
+    const task: Task = {
+      id: 't1',
+      title: 'Task to delete',
+      priority: 'medium',
+      status: 'pending',
+      archived: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks: [task] }));
+
+    render(<TasksPageClient />);
+
+    fireEvent.click(screen.getByTestId('delete-t1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-delete-btn'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('opens edit dialog when edit button clicked', async () => {
     const task: Task = {
       id: 't1',
       title: 'Task to edit',
@@ -440,14 +388,9 @@ describe('TasksPageClient', () => {
       archived: false,
       createdAt: '2024-01-01T00:00:00.000Z',
     };
-    mockLoadDecryptedData.mockResolvedValue([task]);
-    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks: [task] }));
 
     render(<TasksPageClient />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
-    });
 
     fireEvent.click(screen.getByTestId('edit-t1'));
 
@@ -457,33 +400,9 @@ describe('TasksPageClient', () => {
         'Task to edit',
       );
     });
-
-    fireEvent.click(screen.getByTestId('save-edit-btn'));
-
-    await waitFor(() => {
-      expect(mockSaveEncryptedData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'tasks',
-          value: expect.arrayContaining([
-            expect.objectContaining({
-              id: 't1',
-              title: 'Updated Title',
-              priority: 'low',
-              status: 'done',
-              updatedAt: expect.any(String),
-            }),
-          ]),
-        }),
-      );
-    });
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({ title: 'Task updated' }),
-      );
-    });
   });
 
-  it('should close edit dialog when close button clicked', async () => {
+  it('calls updateTask on edit save and shows success toast', async () => {
     const task: Task = {
       id: 't1',
       title: 'Task to edit',
@@ -492,14 +411,54 @@ describe('TasksPageClient', () => {
       archived: false,
       createdAt: '2024-01-01T00:00:00.000Z',
     };
-    mockLoadDecryptedData.mockResolvedValue([task]);
-    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
+    const mockUpdateTask = jest.fn().mockResolvedValue({
+      ok: true,
+      kind: 'updated',
+    });
+    mockUseTasksWorkflow.mockReturnValue(
+      makeWorkflowState({ tasks: [task], updateTask: mockUpdateTask }),
+    );
 
     render(<TasksPageClient />);
 
+    fireEvent.click(screen.getByTestId('edit-t1'));
+
     await waitFor(() => {
-      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-dialog')).toBeInTheDocument();
     });
+
+    fireEvent.click(screen.getByTestId('save-edit-btn'));
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith('t1', {
+        title: 'Updated Title',
+        priority: 'low',
+        status: 'done',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Task updated',
+          description: 'Changes saved (encrypted).',
+        }),
+      );
+    });
+  });
+
+  it('closes edit dialog on close button click', async () => {
+    const task: Task = {
+      id: 't1',
+      title: 'Task to edit',
+      priority: 'high',
+      status: 'pending',
+      archived: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks: [task] }));
+
+    render(<TasksPageClient />);
 
     fireEvent.click(screen.getByTestId('edit-t1'));
 
@@ -514,7 +473,7 @@ describe('TasksPageClient', () => {
     });
   });
 
-  it('should archive task with archived:true and updatedAt', async () => {
+  it('calls archiveTask and shows success toast', async () => {
     const task: Task = {
       id: 't1',
       title: 'Task to archive',
@@ -523,39 +482,33 @@ describe('TasksPageClient', () => {
       archived: false,
       createdAt: '2024-01-01T00:00:00.000Z',
     };
-    mockLoadDecryptedData.mockResolvedValue([task]);
-    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
+    const mockArchiveTask = jest.fn().mockResolvedValue({
+      ok: true,
+      kind: 'archived',
+    });
+    mockUseTasksWorkflow.mockReturnValue(
+      makeWorkflowState({ tasks: [task], archiveTask: mockArchiveTask }),
+    );
 
     render(<TasksPageClient />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
-    });
 
     fireEvent.click(screen.getByTestId('archive-t1'));
 
     await waitFor(() => {
-      expect(mockSaveEncryptedData).toHaveBeenCalledWith(
+      expect(mockArchiveTask).toHaveBeenCalledWith('t1');
+    });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'tasks',
-          value: expect.arrayContaining([
-            expect.objectContaining({
-              id: 't1',
-              archived: true,
-              updatedAt: expect.any(String),
-            }),
-          ]),
+          title: 'Task archived',
+          description: 'Task moved to archive.',
         }),
       );
     });
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({ title: 'Task archived' }),
-      );
-    });
   });
 
-  it('should hide archived tasks by default', async () => {
+  it('hides archived tasks by default', () => {
     const tasks: Task[] = [
       {
         id: 't1',
@@ -574,19 +527,15 @@ describe('TasksPageClient', () => {
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
-    mockLoadDecryptedData.mockResolvedValue(tasks);
-    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks }));
 
     render(<TasksPageClient />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Active task')).toBeInTheDocument();
-    });
-
+    expect(screen.getByText('Active task')).toBeInTheDocument();
     expect(screen.queryByText('Archived task')).not.toBeInTheDocument();
   });
 
-  it('should show archived tasks when "Show Archived" button clicked', async () => {
+  it('shows archived tasks when Show Archived button clicked', async () => {
     const tasks: Task[] = [
       {
         id: 't1',
@@ -605,26 +554,18 @@ describe('TasksPageClient', () => {
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
-    mockLoadDecryptedData.mockResolvedValue(tasks);
-    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks }));
 
     render(<TasksPageClient />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Active task')).toBeInTheDocument();
-    });
-
-    const showArchivedBtn = screen.getByRole('button', {
-      name: 'Show Archived',
-    });
-    fireEvent.click(showArchivedBtn);
+    fireEvent.click(screen.getByRole('button', { name: 'Show Archived' }));
 
     await waitFor(() => {
       expect(screen.getByText('Archived task')).toBeInTheDocument();
     });
   });
 
-  it('should filter tasks by context: "Personal" button shows only personal tasks', async () => {
+  it('filters to personal context only when Personal button clicked', async () => {
     const tasks: Task[] = [
       {
         id: 't1',
@@ -645,18 +586,11 @@ describe('TasksPageClient', () => {
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
-    mockLoadDecryptedData.mockResolvedValue(tasks);
-    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks }));
 
     render(<TasksPageClient />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Personal task')).toBeInTheDocument();
-      expect(screen.getByText('Work task')).toBeInTheDocument();
-    });
-
-    const personalBtn = screen.getByRole('button', { name: 'Personal' });
-    fireEvent.click(personalBtn);
+    fireEvent.click(screen.getByRole('button', { name: 'Personal' }));
 
     await waitFor(() => {
       expect(screen.getByText('Personal task')).toBeInTheDocument();
@@ -664,7 +598,7 @@ describe('TasksPageClient', () => {
     });
   });
 
-  it('should filter tasks by context: "Work" button shows only work tasks', async () => {
+  it('filters to work context only when Work button clicked', async () => {
     const tasks: Task[] = [
       {
         id: 't1',
@@ -685,18 +619,11 @@ describe('TasksPageClient', () => {
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
-    mockLoadDecryptedData.mockResolvedValue(tasks);
-    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks }));
 
     render(<TasksPageClient />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Personal task')).toBeInTheDocument();
-      expect(screen.getByText('Work task')).toBeInTheDocument();
-    });
-
-    const workBtn = screen.getByRole('button', { name: 'Work' });
-    fireEvent.click(workBtn);
+    fireEvent.click(screen.getByRole('button', { name: 'Work' }));
 
     await waitFor(() => {
       expect(screen.queryByText('Personal task')).not.toBeInTheDocument();
@@ -704,7 +631,7 @@ describe('TasksPageClient', () => {
     });
   });
 
-  it('should show all non-archived tasks when "All" filter button clicked', async () => {
+  it('shows all tasks when All filter button clicked after context filter', async () => {
     const tasks: Task[] = [
       {
         id: 't1',
@@ -725,25 +652,17 @@ describe('TasksPageClient', () => {
         createdAt: '2024-01-01T00:00:00.000Z',
       },
     ];
-    mockLoadDecryptedData.mockResolvedValue(tasks);
-    mockNormalizeTasks.mockReturnValue({ value: tasks, changed: false });
+    mockUseTasksWorkflow.mockReturnValue(makeWorkflowState({ tasks }));
 
     render(<TasksPageClient />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Personal task')).toBeInTheDocument();
-      expect(screen.getByText('Work task')).toBeInTheDocument();
-    });
-
-    const personalBtn = screen.getByRole('button', { name: 'Personal' });
-    fireEvent.click(personalBtn);
+    fireEvent.click(screen.getByRole('button', { name: 'Personal' }));
 
     await waitFor(() => {
       expect(screen.queryByText('Work task')).not.toBeInTheDocument();
     });
 
-    const allBtn = screen.getByRole('button', { name: 'All' });
-    fireEvent.click(allBtn);
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
 
     await waitFor(() => {
       expect(screen.getByText('Personal task')).toBeInTheDocument();
@@ -751,7 +670,7 @@ describe('TasksPageClient', () => {
     });
   });
 
-  it('should show destructive toast on save failure', async () => {
+  it('shows save_failed toast when updateTask mutation fails', async () => {
     const task: Task = {
       id: 't1',
       title: 'Task to edit',
@@ -760,15 +679,15 @@ describe('TasksPageClient', () => {
       archived: false,
       createdAt: '2024-01-01T00:00:00.000Z',
     };
-    mockLoadDecryptedData.mockResolvedValue([task]);
-    mockNormalizeTasks.mockReturnValue({ value: [task], changed: false });
-    mockSaveEncryptedData.mockRejectedValueOnce(new Error('Save failed'));
+    const mockUpdateTask = jest.fn().mockResolvedValue({
+      ok: false,
+      error: { code: 'save_failed' as const, message: 'Network error' },
+    });
+    mockUseTasksWorkflow.mockReturnValue(
+      makeWorkflowState({ tasks: [task], updateTask: mockUpdateTask }),
+    );
 
     render(<TasksPageClient />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('task-t1')).toBeInTheDocument();
-    });
 
     fireEvent.click(screen.getByTestId('edit-t1'));
 
@@ -777,6 +696,38 @@ describe('TasksPageClient', () => {
     });
 
     fireEvent.click(screen.getByTestId('save-edit-btn'));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to save',
+          description: 'Network error',
+          variant: 'destructive',
+        }),
+      );
+    });
+  });
+
+  it('shows save_failed toast when archiveTask mutation fails', async () => {
+    const task: Task = {
+      id: 't1',
+      title: 'Task to archive',
+      priority: 'medium',
+      status: 'pending',
+      archived: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    const mockArchiveTask = jest.fn().mockResolvedValue({
+      ok: false,
+      error: { code: 'save_failed' as const, message: 'Save failed' },
+    });
+    mockUseTasksWorkflow.mockReturnValue(
+      makeWorkflowState({ tasks: [task], archiveTask: mockArchiveTask }),
+    );
+
+    render(<TasksPageClient />);
+
+    fireEvent.click(screen.getByTestId('archive-t1'));
 
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(

--- a/libs/web/pages/tasks/src/components/TasksPageClient.tsx
+++ b/libs/web/pages/tasks/src/components/TasksPageClient.tsx
@@ -1,42 +1,23 @@
 'use client';
 
-import type { Task, TaskPriority } from '@myorganizer/core';
-import { randomId } from '@myorganizer/core';
+import type { Task } from '@myorganizer/core';
 import { useToast } from '@myorganizer/web-ui';
-import {
-  loadDecryptedData,
-  migrateFromTodos,
-  normalizeTasks,
-  saveEncryptedData,
-} from '@myorganizer/web-vault';
 import { VaultGate } from '@myorganizer/web-vault-ui';
 import { useCallback, useEffect, useState } from 'react';
 
+import { useTasksWorkflow } from '../workflow';
 import { TaskDeleteDialog } from './task-delete-dialog';
 import { TaskEditDialog } from './task-edit-dialog';
 import { TaskForm } from './task-form';
 import TaskItem from './task-item';
 
-const PRIORITY_ORDER: Record<TaskPriority, number> = {
-  high: 0,
-  medium: 1,
-  low: 2,
-};
-
-function sortTasks(tasks: Task[]): Task[] {
-  return [...tasks].sort((a, b) => {
-    const pa = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority];
-    if (pa !== 0) return pa;
-    const da = a.dueDate ? new Date(a.dueDate).getTime() : Infinity;
-    const db = b.dueDate ? new Date(b.dueDate).getTime() : Infinity;
-    if (da !== db) return da - db;
-    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-  });
+interface TasksInnerProps {
+  masterKeyBytes: Uint8Array;
 }
 
-function TasksInner(props: { masterKeyBytes: Uint8Array }) {
+function TasksInner({ masterKeyBytes }: TasksInnerProps) {
   const { toast } = useToast();
-  const [tasks, setTasks] = useState<Task[]>([]);
+  const workflow = useTasksWorkflow({ masterKeyBytes });
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [deletingTask, setDeletingTask] = useState<Task | null>(null);
   const [showArchived, setShowArchived] = useState(false);
@@ -45,193 +26,130 @@ function TasksInner(props: { masterKeyBytes: Uint8Array }) {
   >('all');
 
   useEffect(() => {
-    loadDecryptedData<unknown>({
-      masterKeyBytes: props.masterKeyBytes,
-      type: 'tasks',
-      defaultValue: null,
-    })
-      .then(async (raw) => {
-        if (raw === null) {
-          const todos = await loadDecryptedData<unknown>({
-            masterKeyBytes: props.masterKeyBytes,
-            type: 'todos',
-            defaultValue: [],
-          });
-
-          if (Array.isArray(todos) && todos.length > 0) {
-            const migrated = migrateFromTodos(todos);
-            await saveEncryptedData({
-              masterKeyBytes: props.masterKeyBytes,
-              type: 'tasks',
-              value: migrated,
-            });
-            setTasks(sortTasks(migrated));
-          } else {
-            setTasks([]);
-          }
-        } else {
-          const normalized = normalizeTasks(raw);
-          if (normalized.changed) {
-            await saveEncryptedData({
-              masterKeyBytes: props.masterKeyBytes,
-              type: 'tasks',
-              value: normalized.value,
-            });
-          }
-          setTasks(sortTasks(normalized.value));
-        }
-      })
-      .catch(() => {
-        toast({
-          title: 'Failed to load tasks',
-          description: 'Could not decrypt saved data.',
-          variant: 'destructive',
-        });
+    if (workflow.loadError) {
+      toast({
+        title: 'Failed to load tasks',
+        description: 'Could not decrypt saved data.',
+        variant: 'destructive',
       });
-  }, [props.masterKeyBytes, toast]);
+    }
+  }, [workflow.loadError, toast]);
 
-  const persist = useCallback(
-    async (next: Task[]) => {
-      const sorted = sortTasks(next);
-      setTasks(sorted);
-      try {
-        await saveEncryptedData({
-          masterKeyBytes: props.masterKeyBytes,
-          type: 'tasks',
-          value: sorted,
+  const handleAddTask = useCallback(
+    async (formData: Parameters<typeof workflow.addTask>[0]) => {
+      const result = await workflow.addTask(formData);
+      if (result.ok && result.kind === 'created') {
+        toast({
+          title: 'Task created',
+          description: 'Your task has been saved (encrypted).',
         });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : String(e);
+      } else if (!result.ok && result.error.code === 'save_failed') {
         toast({
           title: 'Failed to save',
-          description: message,
+          description: result.error.message,
           variant: 'destructive',
         });
       }
     },
-    [props.masterKeyBytes, toast],
-  );
-
-  const handleAddTask = useCallback(
-    async (formData: {
-      title: string;
-      description?: string;
-      priority: TaskPriority;
-      status: Task['status'];
-      context?: Task['context'];
-      dueDate?: string;
-    }) => {
-      const newTask: Task = {
-        id: randomId(),
-        title: formData.title,
-        description: formData.description,
-        priority: formData.priority,
-        status: formData.status,
-        context: formData.context,
-        dueDate: formData.dueDate,
-        archived: false,
-        createdAt: new Date().toISOString(),
-      };
-      await persist([newTask, ...tasks]);
-      toast({
-        title: 'Task created',
-        description: 'Your task has been saved (encrypted).',
-      });
-    },
-    [persist, tasks, toast],
+    [workflow, toast],
   );
 
   const handleRequestDelete = useCallback(
     (id: string) => {
-      const task = tasks.find((t) => t.id === id);
+      const task = workflow.tasks.find((t) => t.id === id);
       if (task) setDeletingTask(task);
     },
-    [tasks],
+    [workflow.tasks],
   );
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deletingTask) return;
-    const next = tasks.filter((t) => t.id !== deletingTask.id);
-    await persist(next);
-    toast({
-      title: 'Task deleted',
-      description: 'Your task has been deleted.',
-    });
+    const result = await workflow.deleteTask(deletingTask.id);
+    if (result.ok && result.kind === 'deleted') {
+      toast({
+        title: 'Task deleted',
+        description: 'Your task has been deleted.',
+      });
+    } else if (!result.ok && result.error.code === 'save_failed') {
+      toast({
+        title: 'Failed to save',
+        description: result.error.message,
+        variant: 'destructive',
+      });
+    }
     setDeletingTask(null);
-  }, [deletingTask, tasks, persist, toast]);
+  }, [deletingTask, workflow, toast]);
 
   const handleRequestEdit = useCallback(
     (id: string) => {
-      const task = tasks.find((t) => t.id === id);
+      const task = workflow.tasks.find((t) => t.id === id);
       if (task) setEditingTask(task);
     },
-    [tasks],
+    [workflow.tasks],
   );
 
   const handleSaveEdit = useCallback(
     async (
       taskId: string,
-      values: {
-        title: string;
-        description?: string;
-        priority: Task['priority'];
-        status: Task['status'];
-        context?: Task['context'];
-        dueDate?: string;
-      },
+      values: Parameters<typeof workflow.updateTask>[1],
     ) => {
-      const next = tasks.map((t) =>
-        t.id === taskId
-          ? {
-              ...t,
-              ...values,
-              updatedAt: new Date().toISOString(),
-            }
-          : t,
-      );
-      await persist(next);
-      toast({
-        title: 'Task updated',
-        description: 'Changes saved (encrypted).',
-      });
+      const result = await workflow.updateTask(taskId, values);
+      if (result.ok && result.kind === 'updated') {
+        toast({
+          title: 'Task updated',
+          description: 'Changes saved (encrypted).',
+        });
+      } else if (!result.ok && result.error.code === 'save_failed') {
+        toast({
+          title: 'Failed to save',
+          description: result.error.message,
+          variant: 'destructive',
+        });
+      }
       setEditingTask(null);
     },
-    [tasks, persist, toast],
+    [workflow, toast],
   );
 
   const handleArchiveTask = useCallback(
     async (id: string) => {
-      const next = tasks.map((t) =>
-        t.id === id
-          ? { ...t, archived: true, updatedAt: new Date().toISOString() }
-          : t,
-      );
-      await persist(next);
-      toast({
-        title: 'Task archived',
-        description: 'Task moved to archive.',
-      });
+      const result = await workflow.archiveTask(id);
+      if (result.ok && result.kind === 'archived') {
+        toast({
+          title: 'Task archived',
+          description: 'Task moved to archive.',
+        });
+      } else if (!result.ok && result.error.code === 'save_failed') {
+        toast({
+          title: 'Failed to save',
+          description: result.error.message,
+          variant: 'destructive',
+        });
+      }
     },
-    [tasks, persist, toast],
+    [workflow, toast],
   );
 
   const handleUnarchiveTask = useCallback(
     async (id: string) => {
-      const next = tasks.map((t) =>
-        t.id === id
-          ? { ...t, archived: false, updatedAt: new Date().toISOString() }
-          : t,
-      );
-      await persist(next);
-      toast({
-        title: 'Task restored',
-        description: 'Task moved back to active.',
-      });
+      const result = await workflow.unarchiveTask(id);
+      if (result.ok && result.kind === 'unarchived') {
+        toast({
+          title: 'Task restored',
+          description: 'Task moved back to active.',
+        });
+      } else if (!result.ok && result.error.code === 'save_failed') {
+        toast({
+          title: 'Failed to save',
+          description: result.error.message,
+          variant: 'destructive',
+        });
+      }
     },
-    [tasks, persist, toast],
+    [workflow, toast],
   );
 
-  const displayedTasks = tasks.filter((t) => {
+  const displayedTasks = workflow.tasks.filter((t) => {
     if (!showArchived && t.archived) return false;
     if (contextFilter !== 'all' && t.context !== contextFilter) return false;
     return true;

--- a/libs/web/pages/tasks/src/workflow/index.ts
+++ b/libs/web/pages/tasks/src/workflow/index.ts
@@ -1,0 +1,27 @@
+export {
+  createProductionTasksVaultAdapter,
+  InMemoryTasksVaultAdapter,
+  type TasksVaultAdapter,
+} from './tasks-vault-adapter';
+export { sortTasks } from './task-sorting';
+export type {
+  TaskFormInput,
+  TaskUpdateInput,
+  TaskWorkflowError,
+  TaskWorkflowErrorCode,
+  TaskWorkflowMutationKind,
+  TaskWorkflowMutationResult,
+} from './task-workflow-types';
+export {
+  addTaskToWorkflow,
+  archiveTaskInWorkflow,
+  deleteTaskFromWorkflow,
+  loadTasksFromVault,
+  unarchiveTaskInWorkflow,
+  updateTaskInWorkflow,
+} from './task-workflow';
+export {
+  useTasksWorkflow,
+  type UseTasksWorkflowOptions,
+  type UseTasksWorkflowResult,
+} from './useTasksWorkflow';

--- a/libs/web/pages/tasks/src/workflow/task-sorting.ts
+++ b/libs/web/pages/tasks/src/workflow/task-sorting.ts
@@ -1,0 +1,18 @@
+import type { Task, TaskPriority } from '@myorganizer/core';
+
+const PRIORITY_ORDER: Record<TaskPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+export function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    const pa = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority];
+    if (pa !== 0) return pa;
+    const da = a.dueDate ? new Date(a.dueDate).getTime() : Infinity;
+    const db = b.dueDate ? new Date(b.dueDate).getTime() : Infinity;
+    if (da !== db) return da - db;
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  });
+}

--- a/libs/web/pages/tasks/src/workflow/task-workflow-types.ts
+++ b/libs/web/pages/tasks/src/workflow/task-workflow-types.ts
@@ -1,0 +1,37 @@
+import type { Task, TaskPriority } from '@myorganizer/core';
+
+export type TaskWorkflowErrorCode = 'load_failed' | 'save_failed';
+
+export interface TaskWorkflowError {
+  code: TaskWorkflowErrorCode;
+  message: string;
+}
+
+export type TaskWorkflowMutationKind =
+  | 'created'
+  | 'updated'
+  | 'deleted'
+  | 'archived'
+  | 'unarchived';
+
+export type TaskWorkflowMutationResult =
+  | { ok: true; kind: TaskWorkflowMutationKind }
+  | { ok: false; error: TaskWorkflowError };
+
+export interface TaskFormInput {
+  title: string;
+  description?: string;
+  priority: TaskPriority;
+  status: Task['status'];
+  context?: Task['context'];
+  dueDate?: string;
+}
+
+export interface TaskUpdateInput {
+  title: string;
+  description?: string;
+  priority: Task['priority'];
+  status: Task['status'];
+  context?: Task['context'];
+  dueDate?: string;
+}

--- a/libs/web/pages/tasks/src/workflow/task-workflow.test.ts
+++ b/libs/web/pages/tasks/src/workflow/task-workflow.test.ts
@@ -1,0 +1,352 @@
+/** Mocking rule: place jest.mock calls before any imports */
+/* eslint-disable import/first -- jest.mock must precede application imports */
+
+jest.mock('@myorganizer/core', () => ({
+  ...jest.requireActual('@myorganizer/core'),
+  randomId: jest.fn(),
+}));
+
+import type { Task, TaskPriority } from '@myorganizer/core';
+import { randomId } from '@myorganizer/core';
+
+import {
+  addTaskToWorkflow,
+  archiveTaskInWorkflow,
+  deleteTaskFromWorkflow,
+  loadTasksFromVault,
+  unarchiveTaskInWorkflow,
+  updateTaskInWorkflow,
+} from './task-workflow';
+import { InMemoryTasksVaultAdapter } from './tasks-vault-adapter';
+
+const FIXED_NOW = '2024-06-15T12:00:00.000Z';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    title: 'Test task',
+    status: 'pending',
+    priority: 'medium',
+    archived: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+class ThrowOnLoadVaultAdapter extends InMemoryTasksVaultAdapter {
+  async loadTasks(): Promise<Task[] | null> {
+    throw new Error('decrypt failed');
+  }
+}
+
+class ThrowOnSaveVaultAdapter extends InMemoryTasksVaultAdapter {
+  async saveTasks(_tasks: Task[]): Promise<void> {
+    throw new Error('disk full');
+  }
+}
+
+describe('task-workflow', () => {
+  let idCounter = 0;
+
+  beforeEach(() => {
+    idCounter = 0;
+    (randomId as jest.Mock).mockReset();
+    (randomId as jest.Mock).mockImplementation(
+      () => `generated-id-${++idCounter}`,
+    );
+    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('loadTasksFromVault', () => {
+    it('returns empty tasks when adapter has no tasks or todos', async () => {
+      const adapter = new InMemoryTasksVaultAdapter();
+
+      const result = await loadTasksFromVault(adapter);
+
+      expect(result).toEqual({ tasks: [], loadError: null });
+      expect(adapter.getSavedTasks()).toBeNull();
+    });
+
+    it('returns sorted tasks when tasks are already stored', async () => {
+      const unsorted = [
+        makeTask({
+          id: 'low',
+          priority: 'low',
+          createdAt: '2024-01-03T00:00:00.000Z',
+        }),
+        makeTask({
+          id: 'high',
+          priority: 'high',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        }),
+      ];
+      const adapter = new InMemoryTasksVaultAdapter({ tasks: unsorted });
+
+      const result = await loadTasksFromVault(adapter);
+
+      expect(result.loadError).toBeNull();
+      expect(result.tasks.map((t) => t.id)).toEqual(['high', 'low']);
+    });
+
+    it('migrates legacy todos and persists migrated tasks', async () => {
+      const adapter = new InMemoryTasksVaultAdapter({
+        tasks: null,
+        todos: [{ id: 'legacy-1', todo: 'Buy milk' }, 'Walk dog'],
+      });
+
+      const result = await loadTasksFromVault(adapter);
+
+      expect(result.loadError).toBeNull();
+      expect(result.tasks).toHaveLength(2);
+      expect(result.tasks.map((t) => t.title).sort()).toEqual([
+        'Buy milk',
+        'Walk dog',
+      ]);
+      expect(result.tasks.find((t) => t.title === 'Buy milk')?.id).toBe(
+        'legacy-1',
+      );
+      expect(result.tasks.find((t) => t.title === 'Walk dog')?.id).toBe(
+        'generated-id-1',
+      );
+      expect(adapter.getSavedTasks()).toHaveLength(2);
+    });
+
+    it('normalizes invalid task fields and re-saves when changed', async () => {
+      const adapter = new InMemoryTasksVaultAdapter({
+        tasks: [
+          {
+            id: 'task-1',
+            title: 'Bad priority',
+            status: 'pending',
+            priority: 'urgent' as TaskPriority,
+            archived: false,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const result = await loadTasksFromVault(adapter);
+
+      expect(result.loadError).toBeNull();
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0].priority).toBe('medium');
+      expect(adapter.getSavedTasks()?.[0].priority).toBe('medium');
+    });
+
+    it('returns load_failed when adapter throws on load', async () => {
+      const adapter = new ThrowOnLoadVaultAdapter();
+
+      const result = await loadTasksFromVault(adapter);
+
+      expect(result).toEqual({
+        tasks: [],
+        loadError: {
+          code: 'load_failed',
+          message: 'Could not decrypt saved data.',
+        },
+      });
+    });
+
+    it('sorts by priority, due date, then createdAt', async () => {
+      const tasks = [
+        makeTask({
+          id: 'low-no-due',
+          priority: 'low',
+          createdAt: '2024-01-03T00:00:00.000Z',
+        }),
+        makeTask({
+          id: 'high-late',
+          priority: 'high',
+          dueDate: '2024-02-01T00:00:00.000Z',
+          createdAt: '2024-01-02T00:00:00.000Z',
+        }),
+        makeTask({
+          id: 'high-early',
+          priority: 'high',
+          dueDate: '2024-01-01T00:00:00.000Z',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        }),
+        makeTask({
+          id: 'medium',
+          priority: 'medium',
+          dueDate: '2024-01-15T00:00:00.000Z',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        }),
+      ];
+      const adapter = new InMemoryTasksVaultAdapter({ tasks });
+
+      const result = await loadTasksFromVault(adapter);
+
+      expect(result.tasks.map((t) => t.id)).toEqual([
+        'high-early',
+        'high-late',
+        'medium',
+        'low-no-due',
+      ]);
+    });
+  });
+
+  describe('addTaskToWorkflow', () => {
+    it('prepends a new task, sorts, persists, and returns created result', async () => {
+      const existing = makeTask({
+        id: 'existing-1',
+        priority: 'low',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      });
+      const adapter = new InMemoryTasksVaultAdapter({ tasks: [existing] });
+
+      const { tasks, result } = await addTaskToWorkflow(adapter, [existing], {
+        title: 'New task',
+        priority: 'high',
+        status: 'pending',
+      });
+
+      expect(result).toEqual({ ok: true, kind: 'created' });
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0]).toMatchObject({
+        id: 'generated-id-1',
+        title: 'New task',
+        priority: 'high',
+        status: 'pending',
+        archived: false,
+        createdAt: FIXED_NOW,
+      });
+      expect(adapter.getSavedTasks()).toEqual(tasks);
+    });
+
+    it('returns save_failed but still returns updated tasks optimistically', async () => {
+      const adapter = new ThrowOnSaveVaultAdapter();
+
+      const { tasks, result } = await addTaskToWorkflow(adapter, [], {
+        title: 'Unsaved task',
+        priority: 'medium',
+        status: 'pending',
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error: { code: 'save_failed', message: 'disk full' },
+      });
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].title).toBe('Unsaved task');
+      expect(adapter.getSavedTasks()).toBeNull();
+    });
+  });
+
+  describe('updateTaskInWorkflow', () => {
+    it('updates the matching task, sets updatedAt, persists, and returns updated result', async () => {
+      const task = makeTask({ id: 'task-1', title: 'Original' });
+      const adapter = new InMemoryTasksVaultAdapter({ tasks: [task] });
+
+      const { tasks, result } = await updateTaskInWorkflow(
+        adapter,
+        [task],
+        'task-1',
+        {
+          title: 'Updated title',
+          priority: 'high',
+          status: 'in_progress',
+        },
+      );
+
+      expect(result).toEqual({ ok: true, kind: 'updated' });
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]).toMatchObject({
+        id: 'task-1',
+        title: 'Updated title',
+        priority: 'high',
+        status: 'in_progress',
+        updatedAt: FIXED_NOW,
+      });
+      expect(adapter.getSavedTasks()).toEqual(tasks);
+    });
+
+    it('returns save_failed but still returns updated tasks optimistically', async () => {
+      const task = makeTask({ id: 'task-1', title: 'Original' });
+      const adapter = new ThrowOnSaveVaultAdapter({ tasks: [task] });
+
+      const { tasks, result } = await updateTaskInWorkflow(
+        adapter,
+        [task],
+        'task-1',
+        {
+          title: 'Updated title',
+          priority: 'high',
+          status: 'in_progress',
+        },
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: { code: 'save_failed', message: 'disk full' },
+      });
+      expect(tasks[0].title).toBe('Updated title');
+      expect(adapter.getSavedTasks()).toEqual([task]);
+    });
+  });
+
+  describe('deleteTaskFromWorkflow', () => {
+    it('removes the task, persists, and returns deleted result', async () => {
+      const keep = makeTask({ id: 'keep', title: 'Keep me' });
+      const remove = makeTask({ id: 'remove', title: 'Remove me' });
+      const adapter = new InMemoryTasksVaultAdapter({ tasks: [keep, remove] });
+
+      const { tasks, result } = await deleteTaskFromWorkflow(
+        adapter,
+        [keep, remove],
+        'remove',
+      );
+
+      expect(result).toEqual({ ok: true, kind: 'deleted' });
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].id).toBe('keep');
+      expect(adapter.getSavedTasks()).toEqual(tasks);
+    });
+  });
+
+  describe('archiveTaskInWorkflow', () => {
+    it('marks the task archived, sets updatedAt, persists, and returns archived result', async () => {
+      const task = makeTask({ id: 'task-1', archived: false });
+      const adapter = new InMemoryTasksVaultAdapter({ tasks: [task] });
+
+      const { tasks, result } = await archiveTaskInWorkflow(
+        adapter,
+        [task],
+        'task-1',
+      );
+
+      expect(result).toEqual({ ok: true, kind: 'archived' });
+      expect(tasks[0]).toMatchObject({
+        id: 'task-1',
+        archived: true,
+        updatedAt: FIXED_NOW,
+      });
+      expect(adapter.getSavedTasks()).toEqual(tasks);
+    });
+  });
+
+  describe('unarchiveTaskInWorkflow', () => {
+    it('clears archived flag, sets updatedAt, persists, and returns unarchived result', async () => {
+      const task = makeTask({ id: 'task-1', archived: true });
+      const adapter = new InMemoryTasksVaultAdapter({ tasks: [task] });
+
+      const { tasks, result } = await unarchiveTaskInWorkflow(
+        adapter,
+        [task],
+        'task-1',
+      );
+
+      expect(result).toEqual({ ok: true, kind: 'unarchived' });
+      expect(tasks[0]).toMatchObject({
+        id: 'task-1',
+        archived: false,
+        updatedAt: FIXED_NOW,
+      });
+      expect(adapter.getSavedTasks()).toEqual(tasks);
+    });
+  });
+});

--- a/libs/web/pages/tasks/src/workflow/task-workflow.ts
+++ b/libs/web/pages/tasks/src/workflow/task-workflow.ts
@@ -1,0 +1,176 @@
+import type { Task } from '@myorganizer/core';
+import { randomId } from '@myorganizer/core';
+import { migrateFromTodos, normalizeTasks } from '@myorganizer/web-vault';
+
+import { sortTasks } from './task-sorting';
+import type {
+  TaskFormInput,
+  TaskUpdateInput,
+  TaskWorkflowError,
+  TaskWorkflowMutationResult,
+} from './task-workflow-types';
+import type { TasksVaultAdapter } from './tasks-vault-adapter';
+
+function saveFailedError(message: string): TaskWorkflowError {
+  return { code: 'save_failed', message };
+}
+
+function loadFailedError(): TaskWorkflowError {
+  return {
+    code: 'load_failed',
+    message: 'Could not decrypt saved data.',
+  };
+}
+
+export async function loadTasksFromVault(
+  adapter: TasksVaultAdapter,
+): Promise<{ tasks: Task[]; loadError: TaskWorkflowError | null }> {
+  try {
+    const raw = await adapter.loadTasks();
+
+    if (raw === null) {
+      const todos = await adapter.loadTodos();
+
+      if (Array.isArray(todos) && todos.length > 0) {
+        const migrated = migrateFromTodos(todos);
+        await adapter.saveTasks(migrated);
+        return { tasks: sortTasks(migrated), loadError: null };
+      }
+
+      return { tasks: [], loadError: null };
+    }
+
+    const normalized = normalizeTasks(raw);
+    if (normalized.changed) {
+      await adapter.saveTasks(normalized.value);
+    }
+    return { tasks: sortTasks(normalized.value), loadError: null };
+  } catch {
+    return { tasks: [], loadError: loadFailedError() };
+  }
+}
+
+async function persistTasks(
+  adapter: TasksVaultAdapter,
+  next: Task[],
+): Promise<{ tasks: Task[]; error: TaskWorkflowError | null }> {
+  const sorted = sortTasks(next);
+  try {
+    await adapter.saveTasks(sorted);
+    return { tasks: sorted, error: null };
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { tasks: sorted, error: saveFailedError(message) };
+  }
+}
+
+export async function addTaskToWorkflow(
+  adapter: TasksVaultAdapter,
+  tasks: Task[],
+  formData: TaskFormInput,
+): Promise<{ tasks: Task[]; result: TaskWorkflowMutationResult }> {
+  const newTask: Task = {
+    id: randomId(),
+    title: formData.title,
+    description: formData.description,
+    priority: formData.priority,
+    status: formData.status,
+    context: formData.context,
+    dueDate: formData.dueDate,
+    archived: false,
+    createdAt: new Date().toISOString(),
+  };
+
+  const persisted = await persistTasks(adapter, [newTask, ...tasks]);
+  if (persisted.error) {
+    return {
+      tasks: persisted.tasks,
+      result: { ok: false, error: persisted.error },
+    };
+  }
+  return { tasks: persisted.tasks, result: { ok: true, kind: 'created' } };
+}
+
+export async function updateTaskInWorkflow(
+  adapter: TasksVaultAdapter,
+  tasks: Task[],
+  taskId: string,
+  values: TaskUpdateInput,
+): Promise<{ tasks: Task[]; result: TaskWorkflowMutationResult }> {
+  const next = tasks.map((t) =>
+    t.id === taskId
+      ? {
+          ...t,
+          ...values,
+          updatedAt: new Date().toISOString(),
+        }
+      : t,
+  );
+
+  const persisted = await persistTasks(adapter, next);
+  if (persisted.error) {
+    return {
+      tasks: persisted.tasks,
+      result: { ok: false, error: persisted.error },
+    };
+  }
+  return { tasks: persisted.tasks, result: { ok: true, kind: 'updated' } };
+}
+
+export async function deleteTaskFromWorkflow(
+  adapter: TasksVaultAdapter,
+  tasks: Task[],
+  taskId: string,
+): Promise<{ tasks: Task[]; result: TaskWorkflowMutationResult }> {
+  const next = tasks.filter((t) => t.id !== taskId);
+  const persisted = await persistTasks(adapter, next);
+  if (persisted.error) {
+    return {
+      tasks: persisted.tasks,
+      result: { ok: false, error: persisted.error },
+    };
+  }
+  return { tasks: persisted.tasks, result: { ok: true, kind: 'deleted' } };
+}
+
+export async function archiveTaskInWorkflow(
+  adapter: TasksVaultAdapter,
+  tasks: Task[],
+  taskId: string,
+): Promise<{ tasks: Task[]; result: TaskWorkflowMutationResult }> {
+  const next = tasks.map((t) =>
+    t.id === taskId
+      ? { ...t, archived: true, updatedAt: new Date().toISOString() }
+      : t,
+  );
+
+  const persisted = await persistTasks(adapter, next);
+  if (persisted.error) {
+    return {
+      tasks: persisted.tasks,
+      result: { ok: false, error: persisted.error },
+    };
+  }
+  return { tasks: persisted.tasks, result: { ok: true, kind: 'archived' } };
+}
+
+export async function unarchiveTaskInWorkflow(
+  adapter: TasksVaultAdapter,
+  tasks: Task[],
+  taskId: string,
+): Promise<{ tasks: Task[]; result: TaskWorkflowMutationResult }> {
+  const next = tasks.map((t) =>
+    t.id === taskId
+      ? { ...t, archived: false, updatedAt: new Date().toISOString() }
+      : t,
+  );
+
+  const persisted = await persistTasks(adapter, next);
+  if (persisted.error) {
+    return {
+      tasks: persisted.tasks,
+      result: { ok: false, error: persisted.error },
+    };
+  }
+  return { tasks: persisted.tasks, result: { ok: true, kind: 'unarchived' } };
+}

--- a/libs/web/pages/tasks/src/workflow/tasks-vault-adapter.ts
+++ b/libs/web/pages/tasks/src/workflow/tasks-vault-adapter.ts
@@ -1,0 +1,66 @@
+import type { Task } from '@myorganizer/core';
+import { loadDecryptedData, saveEncryptedData } from '@myorganizer/web-vault';
+
+export interface TasksVaultAdapter {
+  loadTasks(): Promise<Task[] | null>;
+  loadTodos(): Promise<unknown>;
+  saveTasks(tasks: Task[]): Promise<void>;
+}
+
+export function createProductionTasksVaultAdapter(
+  masterKeyBytes: Uint8Array,
+): TasksVaultAdapter {
+  return {
+    async loadTasks() {
+      return loadDecryptedData<Task[] | null>({
+        masterKeyBytes,
+        type: 'tasks',
+        defaultValue: null,
+      });
+    },
+    async loadTodos() {
+      return loadDecryptedData<unknown>({
+        masterKeyBytes,
+        type: 'todos',
+        defaultValue: [],
+      });
+    },
+    async saveTasks(tasks) {
+      await saveEncryptedData({
+        masterKeyBytes,
+        type: 'tasks',
+        value: tasks,
+      });
+    },
+  };
+}
+
+export class InMemoryTasksVaultAdapter implements TasksVaultAdapter {
+  private tasks: Task[] | null = null;
+  private todos: unknown = [];
+
+  constructor(initial?: { tasks?: Task[] | null; todos?: unknown }) {
+    if (initial?.tasks !== undefined) {
+      this.tasks = initial.tasks;
+    }
+    if (initial?.todos !== undefined) {
+      this.todos = initial.todos;
+    }
+  }
+
+  async loadTasks(): Promise<Task[] | null> {
+    return this.tasks;
+  }
+
+  async loadTodos(): Promise<unknown> {
+    return this.todos;
+  }
+
+  async saveTasks(tasks: Task[]): Promise<void> {
+    this.tasks = tasks;
+  }
+
+  getSavedTasks(): Task[] | null {
+    return this.tasks;
+  }
+}

--- a/libs/web/pages/tasks/src/workflow/useTasksWorkflow.ts
+++ b/libs/web/pages/tasks/src/workflow/useTasksWorkflow.ts
@@ -1,0 +1,150 @@
+'use client';
+
+import type { Task } from '@myorganizer/core';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  addTaskToWorkflow,
+  archiveTaskInWorkflow,
+  deleteTaskFromWorkflow,
+  loadTasksFromVault,
+  unarchiveTaskInWorkflow,
+  updateTaskInWorkflow,
+} from './task-workflow';
+import type {
+  TaskFormInput,
+  TaskUpdateInput,
+  TaskWorkflowError,
+  TaskWorkflowMutationResult,
+} from './task-workflow-types';
+import {
+  createProductionTasksVaultAdapter,
+  type TasksVaultAdapter,
+} from './tasks-vault-adapter';
+
+export interface UseTasksWorkflowOptions {
+  masterKeyBytes: Uint8Array;
+  adapter?: TasksVaultAdapter;
+}
+
+export interface UseTasksWorkflowResult {
+  tasks: Task[];
+  loading: boolean;
+  loadError: TaskWorkflowError | null;
+  addTask: (formData: TaskFormInput) => Promise<TaskWorkflowMutationResult>;
+  updateTask: (
+    taskId: string,
+    values: TaskUpdateInput,
+  ) => Promise<TaskWorkflowMutationResult>;
+  deleteTask: (taskId: string) => Promise<TaskWorkflowMutationResult>;
+  archiveTask: (taskId: string) => Promise<TaskWorkflowMutationResult>;
+  unarchiveTask: (taskId: string) => Promise<TaskWorkflowMutationResult>;
+}
+
+export function useTasksWorkflow({
+  masterKeyBytes,
+  adapter,
+}: UseTasksWorkflowOptions): UseTasksWorkflowResult {
+  const vaultAdapter = useMemo(
+    () => adapter ?? createProductionTasksVaultAdapter(masterKeyBytes),
+    [adapter, masterKeyBytes],
+  );
+
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<TaskWorkflowError | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadTasksFromVault(vaultAdapter).then(
+      ({ tasks: loaded, loadError: error }) => {
+        if (cancelled) return;
+        setTasks(loaded);
+        setLoadError(error);
+        setLoading(false);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [vaultAdapter]);
+
+  const addTask = useCallback(
+    async (formData: TaskFormInput) => {
+      const { tasks: next, result } = await addTaskToWorkflow(
+        vaultAdapter,
+        tasks,
+        formData,
+      );
+      setTasks(next);
+      return result;
+    },
+    [tasks, vaultAdapter],
+  );
+
+  const updateTask = useCallback(
+    async (taskId: string, values: TaskUpdateInput) => {
+      const { tasks: next, result } = await updateTaskInWorkflow(
+        vaultAdapter,
+        tasks,
+        taskId,
+        values,
+      );
+      setTasks(next);
+      return result;
+    },
+    [tasks, vaultAdapter],
+  );
+
+  const deleteTask = useCallback(
+    async (taskId: string) => {
+      const { tasks: next, result } = await deleteTaskFromWorkflow(
+        vaultAdapter,
+        tasks,
+        taskId,
+      );
+      setTasks(next);
+      return result;
+    },
+    [tasks, vaultAdapter],
+  );
+
+  const archiveTask = useCallback(
+    async (taskId: string) => {
+      const { tasks: next, result } = await archiveTaskInWorkflow(
+        vaultAdapter,
+        tasks,
+        taskId,
+      );
+      setTasks(next);
+      return result;
+    },
+    [tasks, vaultAdapter],
+  );
+
+  const unarchiveTask = useCallback(
+    async (taskId: string) => {
+      const { tasks: next, result } = await unarchiveTaskInWorkflow(
+        vaultAdapter,
+        tasks,
+        taskId,
+      );
+      setTasks(next);
+      return result;
+    },
+    [tasks, vaultAdapter],
+  );
+
+  return {
+    tasks,
+    loading,
+    loadError,
+    addTask,
+    updateTask,
+    deleteTask,
+    archiveTask,
+    unarchiveTask,
+  };
+}


### PR DESCRIPTION
## Why
Thin TasksPageClient behavior tests via workflow seam. Follow-up commits refine the branch before merging `feat/deepen-task-workflow-module` into `main`.

## Changes
- Extract useTasksWorkflow with vault adapter seam, rewire TasksPageClient as
- a thin orchestrator, and replace vault-coupled tests with focused UI coverage
- for rendering, filters, dialog wiring, and toast mapping.
- Cover load, legacy todo migration, normalization, sorting, and optimistic
- mutations through the InMemoryTasksVaultAdapter seam for Issue #176.
- Add helpers to find a worktree for a branch and fast-forward merge there.
- Attempt checked-out worktree merge when * feat/deepen-task-workflow-module
- main
- slice/176-deepen-task-workflow-module-extract-work
- slice/177-deepen-task-workflow-module-rewire-tasks
- slice/178-deepen-task-workflow-module-update-thin- cannot force-update.
- Minor import reordering.

## Validation
- Generated from 3 commit(s) on `feat/deepen-task-workflow-module`.
- Compared against base branch `main`.
