### PR TITLE
refactor(backend): extract platform-specific login response logic to PlatformTokenHandler

### DIFF
--- a/apps/backend/src/controllers/AuthController.ts
+++ b/apps/backend/src/controllers/AuthController.ts
@@ -18,6 +18,7 @@ import {
 import { Body, ValidateBody } from '../decorators/request-body-validator';
 import apiTokens from '../helpers/ApiTokens';
 import filterUser from '../helpers/filterUser';
+import PlatformTokenHandler from '../helpers/PlatformTokenHandler';
 import { decodeToken } from '../helpers/jwtHelper';
 import { ValidateErrorJSON } from '../interfaces';
 import { RegisterUserResponse } from '../models/Auth';
@@ -57,23 +58,18 @@ export class AuthController extends Controller {
   }> {
     void requestBody;
     const requestUser = req.user as UserInterface;
-    const { token, refreshToken } = apiTokens.createTokens(requestUser);
-    if (token instanceof Error) {
+
+    try {
+      const response = PlatformTokenHandler.buildLoginResponse(
+        requestUser,
+        requestBody.client_type,
+      );
+      this.setStatus(200);
+      return response;
+    } catch {
       this.setStatus(500);
       throw new Error('Failed to create access token');
     }
-    const user = filterUser(requestUser);
-    const isMobile = requestBody.client_type === 'mobile';
-
-    this.setStatus(200);
-    return {
-      token,
-      expires_in: 600_000,
-      user,
-      ...(isMobile && !(refreshToken instanceof Error)
-        ? { refresh_token: refreshToken }
-        : {}),
-    };
   }
 
   @Post('/logout/{userId}')

--- a/apps/backend/src/controllers/VaultBackupController.int.test.ts
+++ b/apps/backend/src/controllers/VaultBackupController.int.test.ts
@@ -6,20 +6,43 @@ import { ValidateError } from 'tsoa';
 
 jest.setTimeout(120_000);
 
+jest.mock('../helpers/PlatformTokenHandler', () => ({
+  __esModule: true,
+  PlatformTokenHandler: {
+    buildLoginResponse: jest.fn(),
+  },
+  default: {
+    buildLoginResponse: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/passport', () => ({
+  __esModule: true,
+  default: {
+    authenticate: () => (_req: any, _res: any, next: any) => next(),
+  },
+}));
+
 jest.mock('../middleware/authentication', () => {
   return {
     expressAuthentication: async (req: any) => {
       const authHeader = req?.headers?.authorization;
       if (!authHeader) {
-        const err: any = new Error('No token provided');
+        const err = new Error('Unauthorized') as Error & { status?: number };
         err.status = 401;
         throw err;
       }
 
-      const userId = authHeader.startsWith('Bearer ')
+      const token = authHeader.startsWith('Bearer ')
         ? authHeader.slice('Bearer '.length)
-        : 'user-1';
-      req.user = { id: userId || 'user-1' };
+        : authHeader;
+
+      if (token === 'no-id') {
+        req.user = {};
+        return req.user;
+      }
+
+      req.user = { id: token || 'user-1' };
       return req.user;
     },
   };
@@ -41,6 +64,27 @@ jest.mock('../services/VaultBackupService', () => {
     ],
   };
 });
+
+jest.mock('../services/VaultService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/UserService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+// Prevent module-level createPrismaClient() calls in YouTube services from
+// attempting a real DB connection during VaultBackup integration tests.
+jest.mock('../services/YouTubeNotificationService', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../services/YouTubeSyncService', () => ({
+  __esModule: true,
+  default: {},
+}));
 
 function makeApp() {
   jest.resetModules();
@@ -90,10 +134,53 @@ describe('VaultBackupController (HTTP integration)', () => {
     jest.clearAllMocks();
   });
 
-  test('requires auth for POST /vault/backups', async () => {
-    const app = makeApp();
-    const res = await request(app).post('/vault/backups').send(validBody);
-    expect(res.status).toBe(401);
+  describe('auth requirements', () => {
+    test('requires auth for POST /vault/backups', async () => {
+      const app = makeApp();
+      const svc = require('../services/VaultBackupService').default;
+
+      const res = await request(app).post('/vault/backups').send(validBody);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(svc.recordEvent).not.toHaveBeenCalled();
+    });
+
+    test('requires auth for GET /vault/backups/latest', async () => {
+      const app = makeApp();
+      const svc = require('../services/VaultBackupService').default;
+
+      const res = await request(app).get('/vault/backups/latest');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(svc.getLatest).not.toHaveBeenCalled();
+    });
+
+    test('requires auth for GET /vault/backups', async () => {
+      const app = makeApp();
+      const svc = require('../services/VaultBackupService').default;
+
+      const res = await request(app).get('/vault/backups');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(svc.listHistory).not.toHaveBeenCalled();
+    });
+
+    test('returns 401 with Unauthorized when authenticated user has no id', async () => {
+      const app = makeApp();
+      const svc = require('../services/VaultBackupService').default;
+
+      const res = await request(app)
+        .post('/vault/backups')
+        .set('Authorization', 'Bearer no-id')
+        .send(validBody);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(svc.recordEvent).not.toHaveBeenCalled();
+    });
   });
 
   test('returns 201 when recording a successful backup', async () => {

--- a/apps/backend/src/controllers/VaultBackupController.ts
+++ b/apps/backend/src/controllers/VaultBackupController.ts
@@ -10,6 +10,7 @@ import {
   Security,
   Tags,
 } from 'tsoa';
+import { requireUserId } from '../guards/AuthGuard';
 import vaultBackupService, {
   VaultBackupRecordDto,
 } from '../services/VaultBackupService';
@@ -19,7 +20,6 @@ import {
   VaultBackupSource,
   VaultBackupStatus,
 } from '../services/vaultBackupConstants';
-import { UserInterface } from '../types';
 import { ErrorResponse } from './ErrorResponse';
 
 export interface RecordVaultBackupRequest {
@@ -47,21 +47,12 @@ type ListVaultBackupsResponse = VaultBackupHistoryPage | ErrorResponse;
 @Route('/vault/backups')
 @Security('jwt')
 export class VaultBackupController extends Controller {
-  private getUserId(req: ExRequest): string {
-    const user = req.user as UserInterface;
-    return user?.id;
-  }
-
   @Post()
   public async recordBackup(
     @Request() req: ExRequest,
     @Body() body: RecordVaultBackupRequest,
   ): Promise<RecordVaultBackupResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     const result = await vaultBackupService.recordEvent(userId, body);
     this.setStatus(result.status);
@@ -74,11 +65,7 @@ export class VaultBackupController extends Controller {
     @Query() status?: VaultBackupStatus,
     @Query() source?: VaultBackupSource,
   ): Promise<GetLatestVaultBackupResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     const result = await vaultBackupService.getLatest(userId, status, source);
     this.setStatus(result.status);
@@ -92,11 +79,7 @@ export class VaultBackupController extends Controller {
     @Query() limit?: number,
     @Query() source?: VaultBackupSource,
   ): Promise<ListVaultBackupsResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     const result = await vaultBackupService.listHistory(userId, {
       cursor,

--- a/apps/backend/src/controllers/VaultController.int.test.ts
+++ b/apps/backend/src/controllers/VaultController.int.test.ts
@@ -6,14 +6,40 @@ import { ValidateError } from 'tsoa';
 
 jest.setTimeout(30_000);
 
+jest.mock('../helpers/PlatformTokenHandler', () => ({
+  __esModule: true,
+  PlatformTokenHandler: {
+    buildLoginResponse: jest.fn(),
+  },
+  default: {
+    buildLoginResponse: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/passport', () => ({
+  __esModule: true,
+  default: {
+    authenticate: () => (_req: any, _res: any, next: any) => next(),
+  },
+}));
+
 jest.mock('../middleware/authentication', () => {
   return {
     expressAuthentication: async (req: any) => {
       const authHeader = req?.headers?.authorization;
       if (!authHeader) {
-        const err: any = new Error('No token provided');
+        const err = new Error('Unauthorized') as Error & { status?: number };
         err.status = 401;
         throw err;
+      }
+
+      const token = authHeader.startsWith('Bearer ')
+        ? authHeader.slice('Bearer '.length)
+        : authHeader;
+
+      if (token === 'no-id') {
+        req.user = {};
+        return req.user;
       }
 
       req.user = { id: 'user-1' };
@@ -35,6 +61,16 @@ jest.mock('../services/VaultService', () => {
     },
   };
 });
+
+jest.mock('../services/VaultBackupService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/UserService', () => ({
+  __esModule: true,
+  default: {},
+}));
 
 // Prevent module-level createPrismaClient() calls in YouTube services from
 // attempting a real DB connection during Vault integration tests.
@@ -113,12 +149,89 @@ describe('VaultController (HTTP integration)', () => {
     jest.clearAllMocks();
   });
 
-  test('requires auth for GET /vault', async () => {
-    const app = makeApp();
+  describe('auth requirements', () => {
+    test('requires auth for GET /vault', async () => {
+      const app = makeApp();
+      const vaultService = require('../services/VaultService').default;
 
-    const res = await request(app).get('/vault');
+      const res = await request(app).get('/vault');
 
-    expect(res.status).toBe(401);
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(vaultService.getVaultMeta).not.toHaveBeenCalled();
+    });
+
+    test('requires auth for PUT /vault', async () => {
+      const app = makeApp();
+      const vaultService = require('../services/VaultService').default;
+
+      const res = await request(app).put('/vault').send({ meta });
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(vaultService.putVaultMeta).not.toHaveBeenCalled();
+    });
+
+    test('requires auth for GET /vault/blob/:type', async () => {
+      const app = makeApp();
+      const vaultService = require('../services/VaultService').default;
+
+      const res = await request(app).get('/vault/blob/addresses');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(vaultService.getBlob).not.toHaveBeenCalled();
+    });
+
+    test('requires auth for PUT /vault/blob/:type', async () => {
+      const app = makeApp();
+      const vaultService = require('../services/VaultService').default;
+
+      const res = await request(app)
+        .put('/vault/blob/addresses')
+        .send({ type: 'addresses', blob });
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(vaultService.putBlob).not.toHaveBeenCalled();
+    });
+
+    test('requires auth for POST /vault/export', async () => {
+      const app = makeApp();
+      const vaultService = require('../services/VaultService').default;
+
+      const res = await request(app).post('/vault/export');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(vaultService.exportVault).not.toHaveBeenCalled();
+    });
+
+    test('requires auth for POST /vault/import', async () => {
+      const app = makeApp();
+      const vaultService = require('../services/VaultService').default;
+
+      const res = await request(app)
+        .post('/vault/import')
+        .send({ version: 1, meta, blobs: {} });
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(vaultService.importVault).not.toHaveBeenCalled();
+    });
+
+    test('returns 401 with Unauthorized when authenticated user has no id', async () => {
+      const app = makeApp();
+      const vaultService = require('../services/VaultService').default;
+
+      const res = await request(app)
+        .get('/vault')
+        .set('Authorization', 'Bearer no-id');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(vaultService.getVaultMeta).not.toHaveBeenCalled();
+    });
   });
 
   test('returns 404 on missing vault meta', async () => {

--- a/apps/backend/src/controllers/VaultController.ts
+++ b/apps/backend/src/controllers/VaultController.ts
@@ -12,13 +12,13 @@ import {
   Security,
   Tags,
 } from 'tsoa';
+import { requireUserId } from '../guards/AuthGuard';
 import vaultService, {
   EncryptedBlobV1,
   VaultBlobType,
   VaultExportV1,
   VaultMetaV1,
 } from '../services/VaultService';
-import { UserInterface } from '../types';
 import { ErrorResponse } from './ErrorResponse';
 
 type GetVaultMetaResponse =
@@ -50,20 +50,11 @@ type ImportVaultResponse = { ok: true } | ErrorResponse;
 @Route('/vault')
 @Security('jwt')
 export class VaultController extends Controller {
-  private getUserId(req: ExRequest): string {
-    const user = req.user as UserInterface;
-    return user?.id;
-  }
-
   @Get()
   public async getVaultMeta(
     @Request() req: ExRequest,
   ): Promise<GetVaultMetaResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     const result = await vaultService.getVaultMeta(userId);
     this.setStatus(result.status);
@@ -76,11 +67,7 @@ export class VaultController extends Controller {
     @Body() requestBody: { meta: VaultMetaV1 },
     @Header('if-match') ifMatch?: string,
   ): Promise<PutVaultMetaResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     const result = await vaultService.putVaultMeta(
       userId,
@@ -96,11 +83,7 @@ export class VaultController extends Controller {
     @Request() req: ExRequest,
     @Path() type: VaultBlobType,
   ): Promise<GetVaultBlobResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     const result = await vaultService.getBlob(userId, type);
     this.setStatus(result.status);
@@ -114,11 +97,7 @@ export class VaultController extends Controller {
     @Body() requestBody: { type: VaultBlobType; blob: EncryptedBlobV1 },
     @Header('if-match') ifMatch?: string,
   ): Promise<PutVaultBlobResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     if (requestBody?.type && requestBody.type !== type) {
       this.setStatus(422);
@@ -139,11 +118,7 @@ export class VaultController extends Controller {
   public async exportVault(
     @Request() req: ExRequest,
   ): Promise<ExportVaultResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     const result = await vaultService.exportVault(userId);
     this.setStatus(result.status);
@@ -155,11 +130,7 @@ export class VaultController extends Controller {
     @Request() req: ExRequest,
     @Body() requestBody: VaultExportV1,
   ): Promise<ImportVaultResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
 
     const result = await vaultService.importVault(userId, requestBody);
     this.setStatus(result.status);

--- a/apps/backend/src/controllers/YouTubeController.int.test.ts
+++ b/apps/backend/src/controllers/YouTubeController.int.test.ts
@@ -1,0 +1,243 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals';
+import bodyParser from 'body-parser';
+import express from 'express';
+import request from 'supertest';
+import { ValidateError } from 'tsoa';
+
+jest.setTimeout(30_000);
+
+jest.mock('../helpers/PlatformTokenHandler', () => ({
+  __esModule: true,
+  PlatformTokenHandler: {
+    buildLoginResponse: jest.fn(),
+  },
+  default: {
+    buildLoginResponse: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/passport', () => ({
+  __esModule: true,
+  default: {
+    authenticate: () => (_req: any, _res: any, next: any) => next(),
+  },
+}));
+
+const CRON_SECRET = 'test-youtube-cron-secret';
+
+jest.mock('../middleware/authentication', () => {
+  return {
+    expressAuthentication: async (req: any, securityName: string) => {
+      if (securityName === 'cron-secret') {
+        const secret = req.headers['x-cron-secret'];
+        const expectedSecret = process.env.YOUTUBE_CRON_SECRET;
+
+        if (!expectedSecret || secret !== expectedSecret) {
+          const err = new Error('Unauthorized') as Error & { status?: number };
+          err.status = 401;
+          throw err;
+        }
+
+        return;
+      }
+
+      const authHeader = req?.headers?.authorization;
+      if (!authHeader) {
+        const err = new Error('Unauthorized') as Error & { status?: number };
+        err.status = 401;
+        throw err;
+      }
+
+      req.user = { id: 'user-1' };
+      return req.user;
+    },
+  };
+});
+
+jest.mock('../services/VaultService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/VaultBackupService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/UserService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/YouTubeSyncService', () => ({
+  __esModule: true,
+  default: {
+    getAuthUrl: jest.fn(),
+  },
+}));
+
+jest.mock('../services/YouTubeNotificationService', () => ({
+  __esModule: true,
+  default: {
+    syncAndNotifyAll: jest.fn(),
+  },
+}));
+
+function makeApp() {
+  jest.resetModules();
+
+  const { RegisterRoutes } = require('../routes/routes');
+
+  const app = express();
+  app.use(bodyParser.json({ limit: '2mb' }));
+  RegisterRoutes(app);
+
+  app.use(function tsoaErrorHandler(
+    err: unknown,
+    _req: any,
+    res: any,
+    next: any,
+  ) {
+    if (err instanceof ValidateError) {
+      return res.status(422).json({
+        message: 'Validation Failed',
+        details: err?.fields,
+      });
+    }
+
+    const anyErr = err as { status?: number; message?: string };
+    if (
+      anyErr &&
+      typeof anyErr === 'object' &&
+      typeof anyErr.status === 'number'
+    ) {
+      return res.status(anyErr.status).json({ message: anyErr.message });
+    }
+
+    if (err instanceof Error) {
+      return res.status(500).json({ message: 'Internal Server Error' });
+    }
+
+    return next(err);
+  });
+
+  return app;
+}
+
+describe('YouTubeController (HTTP integration)', () => {
+  const originalCronSecret = process.env.YOUTUBE_CRON_SECRET;
+
+  beforeEach(() => {
+    process.env.YOUTUBE_CRON_SECRET = CRON_SECRET;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalCronSecret === undefined) {
+      delete process.env.YOUTUBE_CRON_SECRET;
+    } else {
+      process.env.YOUTUBE_CRON_SECRET = originalCronSecret;
+    }
+  });
+
+  test('requires auth for GET /youtube/auth-url', async () => {
+    const app = makeApp();
+    const youtubeSyncService =
+      require('../services/YouTubeSyncService').default;
+
+    const res = await request(app).get('/youtube/auth-url');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ message: 'Unauthorized' });
+    expect(youtubeSyncService.getAuthUrl).not.toHaveBeenCalled();
+  });
+
+  test('returns auth URL for authenticated GET /youtube/auth-url', async () => {
+    const app = makeApp();
+    const youtubeSyncService =
+      require('../services/YouTubeSyncService').default;
+
+    youtubeSyncService.getAuthUrl.mockReturnValue(
+      'https://accounts.google.com/o/oauth2/auth?state=user-1',
+    );
+
+    const res = await request(app)
+      .get('/youtube/auth-url')
+      .set('Authorization', 'Bearer test');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      url: 'https://accounts.google.com/o/oauth2/auth?state=user-1',
+    });
+    expect(youtubeSyncService.getAuthUrl).toHaveBeenCalledWith('user-1');
+  });
+
+  test('requires X-Cron-Secret for POST /youtube/cron/sync-and-notify', async () => {
+    const app = makeApp();
+    const youTubeNotificationService =
+      require('../services/YouTubeNotificationService').default;
+
+    const res = await request(app).post('/youtube/cron/sync-and-notify');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ message: 'Unauthorized' });
+    expect(youTubeNotificationService.syncAndNotifyAll).not.toHaveBeenCalled();
+  });
+
+  test('rejects wrong X-Cron-Secret for POST /youtube/cron/sync-and-notify', async () => {
+    const app = makeApp();
+    const youTubeNotificationService =
+      require('../services/YouTubeNotificationService').default;
+
+    const res = await request(app)
+      .post('/youtube/cron/sync-and-notify')
+      .set('X-Cron-Secret', 'wrong-secret');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ message: 'Unauthorized' });
+    expect(youTubeNotificationService.syncAndNotifyAll).not.toHaveBeenCalled();
+  });
+
+  test('runs cron sync-and-notify with valid X-Cron-Secret', async () => {
+    const app = makeApp();
+    const youTubeNotificationService =
+      require('../services/YouTubeNotificationService').default;
+
+    youTubeNotificationService.syncAndNotifyAll.mockResolvedValue({
+      usersSynced: 3,
+      notificationsSent: 2,
+    });
+
+    const res = await request(app)
+      .post('/youtube/cron/sync-and-notify')
+      .set('X-Cron-Secret', CRON_SECRET);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ usersSynced: 3, notificationsSent: 2 });
+    expect(youTubeNotificationService.syncAndNotifyAll).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  test('returns identical 401 body shape for JWT and cron-secret auth failures', async () => {
+    const app = makeApp();
+
+    const jwtRes = await request(app).get('/youtube/auth-url');
+    const cronRes = await request(app).post('/youtube/cron/sync-and-notify');
+
+    expect(jwtRes.status).toBe(401);
+    expect(cronRes.status).toBe(401);
+    expect(jwtRes.body).toEqual({ message: 'Unauthorized' });
+    expect(cronRes.body).toEqual({ message: 'Unauthorized' });
+    expect(Object.keys(jwtRes.body).sort()).toEqual(
+      Object.keys(cronRes.body).sort(),
+    );
+  });
+});

--- a/apps/backend/src/controllers/YouTubeController.ts
+++ b/apps/backend/src/controllers/YouTubeController.ts
@@ -14,11 +14,11 @@ import {
   Security,
   Tags,
 } from 'tsoa';
+import { requireUserId } from '../guards/AuthGuard';
 import youTubeNotificationService from '../services/YouTubeNotificationService';
 import youtubeSyncService, {
   YouTubeVideoWithChannel,
 } from '../services/YouTubeSyncService';
-import { UserInterface } from '../types';
 
 type YouTubeErrorResponse = { message: string };
 
@@ -89,11 +89,6 @@ interface CronResultResponse {
 @Tags('YouTube')
 @Route('/youtube')
 export class YouTubeController extends Controller {
-  private getUserId(req: ExRequest): string {
-    const user = req.user as UserInterface;
-    return user?.id;
-  }
-
   /**
    * Returns the Google OAuth consent URL for linking YouTube.
    */
@@ -102,11 +97,7 @@ export class YouTubeController extends Controller {
   public async getAuthUrl(
     @Request() req: ExRequest,
   ): Promise<AuthUrlResponse | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     const url = youtubeSyncService.getAuthUrl(userId);
     return { url };
   }
@@ -120,11 +111,7 @@ export class YouTubeController extends Controller {
     @Request() req: ExRequest,
     @Body() body: { code: string },
   ): Promise<{ ok: boolean; message: string }> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { ok: false, message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     const result = await youtubeSyncService.handleOAuthCallback(
       userId,
       body.code,
@@ -143,11 +130,7 @@ export class YouTubeController extends Controller {
   public async getConnectionStatus(
     @Request() req: ExRequest,
   ): Promise<StatusResponse | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     try {
       return await youtubeSyncService.getStatus(userId);
     } catch {
@@ -164,11 +147,7 @@ export class YouTubeController extends Controller {
   public async disconnect(
     @Request() req: ExRequest,
   ): Promise<{ ok: boolean; message: string }> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { ok: false, message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     return youtubeSyncService.disconnect(userId);
   }
 
@@ -180,11 +159,7 @@ export class YouTubeController extends Controller {
   public async getSubscriptions(
     @Request() req: ExRequest,
   ): Promise<SubscriptionResponse[] | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     const subs = await youtubeSyncService.getSubscriptions(userId);
     return subs.map((s) => ({
       id: s.id,
@@ -205,11 +180,7 @@ export class YouTubeController extends Controller {
   public async syncSubscriptions(
     @Request() req: ExRequest,
   ): Promise<{ synced: number; videosSynced: number } | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     const subs = await youtubeSyncService.syncSubscriptions(userId);
     const videosSynced = await youtubeSyncService.syncVideosForUser(userId);
     return { synced: subs.length, videosSynced };
@@ -225,11 +196,7 @@ export class YouTubeController extends Controller {
     @Path() subscriptionId: string,
     @Body() body: { enabled: boolean },
   ): Promise<{ ok: boolean } | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     await youtubeSyncService.toggleSubscription(
       userId,
       subscriptionId,
@@ -255,11 +222,7 @@ export class YouTubeController extends Controller {
     @Query() limit?: number,
     @Query() channelId?: string,
   ): Promise<VideosPageResponse | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     const result = await youtubeSyncService.getVideos(userId, {
       sort,
       search,
@@ -289,11 +252,7 @@ export class YouTubeController extends Controller {
   public async getVideosCarousel(
     @Request() req: ExRequest,
   ): Promise<ChannelCarouselResponse[] | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     const grouped = await youtubeSyncService.getVideosGroupedByChannel(userId);
     return grouped.map((g) => ({
       channelId: g.channelId,
@@ -318,11 +277,7 @@ export class YouTubeController extends Controller {
   public async getNotificationSettings(
     @Request() req: ExRequest,
   ): Promise<NotificationSettingsResponse | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     const settings = await youtubeSyncService.getNotificationSettings(userId);
     return {
       intervalDays: settings.intervalDays,
@@ -340,11 +295,7 @@ export class YouTubeController extends Controller {
     @Request() req: ExRequest,
     @Body() body: NotificationSettingsBody,
   ): Promise<NotificationSettingsResponse | YouTubeErrorResponse> {
-    const userId = this.getUserId(req);
-    if (!userId) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
+    const userId = requireUserId(req);
     const updated = await youtubeSyncService.updateNotificationSettings(
       userId,
       body,
@@ -361,17 +312,10 @@ export class YouTubeController extends Controller {
    * Authenticated via X-Cron-Secret header instead of JWT.
    */
   @Post('/cron/sync-and-notify')
-  public async cronSyncAndNotify(
-    @Request() req: ExRequest,
-  ): Promise<CronResultResponse | YouTubeErrorResponse> {
-    const secret = req.headers['x-cron-secret'];
-    const expectedSecret = process.env.YOUTUBE_CRON_SECRET;
-
-    if (!expectedSecret || secret !== expectedSecret) {
-      this.setStatus(401);
-      return { message: 'Unauthorized' };
-    }
-
+  @Security('cron-secret')
+  public async cronSyncAndNotify(): Promise<
+    CronResultResponse | YouTubeErrorResponse
+  > {
     const result = await youTubeNotificationService.syncAndNotifyAll();
     return result;
   }

--- a/apps/backend/src/guards/AuthGuard.test.ts
+++ b/apps/backend/src/guards/AuthGuard.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from '@jest/globals';
+import type * as express from 'express';
+
+import {
+  getAuthenticatedUser,
+  requireUserId,
+  UnauthorizedError,
+} from './AuthGuard';
+import type { UserInterface } from '../types';
+
+function makeReq(overrides: Partial<express.Request> = {}): express.Request {
+  return {
+    headers: {},
+    body: {},
+    ...overrides,
+  } as express.Request;
+}
+
+function makeUser(overrides: Partial<UserInterface> = {}): UserInterface {
+  return {
+    id: 'user-1',
+    name: 'Test User',
+    email: 'test@example.com',
+    password: 'hashed',
+    password_reset_token: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  };
+}
+
+describe('UnauthorizedError', () => {
+  test('has status 401, name, and default message', () => {
+    const error = new UnauthorizedError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(UnauthorizedError);
+    expect(error.status).toBe(401);
+    expect(error.name).toBe('UnauthorizedError');
+    expect(error.message).toBe('Unauthorized');
+  });
+});
+
+describe('getAuthenticatedUser', () => {
+  test('returns req.user when set', () => {
+    const user = makeUser();
+    const req = makeReq();
+    (req as express.Request & { user?: UserInterface }).user = user;
+
+    expect(getAuthenticatedUser(req)).toBe(user);
+  });
+
+  test('throws UnauthorizedError when req.user is undefined', () => {
+    const req = makeReq();
+
+    expect(() => getAuthenticatedUser(req)).toThrow(UnauthorizedError);
+    expect(() => getAuthenticatedUser(req)).toThrow(
+      expect.objectContaining({ status: 401, message: 'Unauthorized' }),
+    );
+  });
+
+  test('throws UnauthorizedError when req.user is null', () => {
+    const req = makeReq();
+    (req as express.Request & { user?: UserInterface | null }).user = null;
+
+    expect(() => getAuthenticatedUser(req)).toThrow(UnauthorizedError);
+    expect(() => getAuthenticatedUser(req)).toThrow(
+      expect.objectContaining({ status: 401, message: 'Unauthorized' }),
+    );
+  });
+});
+
+describe('requireUserId', () => {
+  test('returns user.id when req.user has a valid id', () => {
+    const user = makeUser({ id: 'user-42' });
+    const req = makeReq();
+    (req as express.Request & { user?: UserInterface }).user = user;
+
+    expect(requireUserId(req)).toBe('user-42');
+  });
+
+  test('throws UnauthorizedError when req.user is undefined', () => {
+    const req = makeReq();
+
+    expect(() => requireUserId(req)).toThrow(UnauthorizedError);
+    expect(() => requireUserId(req)).toThrow(
+      expect.objectContaining({ status: 401, message: 'Unauthorized' }),
+    );
+  });
+
+  test('throws UnauthorizedError when user.id is an empty string', () => {
+    const user = makeUser({ id: '' });
+    const req = makeReq();
+    (req as express.Request & { user?: UserInterface }).user = user;
+
+    expect(() => requireUserId(req)).toThrow(UnauthorizedError);
+    expect(() => requireUserId(req)).toThrow(
+      expect.objectContaining({ status: 401, message: 'Unauthorized' }),
+    );
+  });
+
+  test('throws UnauthorizedError when user.id is undefined', () => {
+    const user = makeUser({ id: undefined as unknown as string });
+    const req = makeReq();
+    (req as express.Request & { user?: UserInterface }).user = user;
+
+    expect(() => requireUserId(req)).toThrow(UnauthorizedError);
+    expect(() => requireUserId(req)).toThrow(
+      expect.objectContaining({ status: 401, message: 'Unauthorized' }),
+    );
+  });
+});

--- a/apps/backend/src/guards/AuthGuard.ts
+++ b/apps/backend/src/guards/AuthGuard.ts
@@ -1,0 +1,27 @@
+import { Request as ExRequest } from 'express';
+import { UserInterface } from '../types';
+
+export class UnauthorizedError extends Error {
+  status = 401;
+
+  constructor(message = 'Unauthorized') {
+    super(message);
+    this.name = 'UnauthorizedError';
+  }
+}
+
+export function getAuthenticatedUser(req: ExRequest): UserInterface {
+  const user = req.user as UserInterface | undefined;
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+  return user;
+}
+
+export function requireUserId(req: ExRequest): string {
+  const user = getAuthenticatedUser(req);
+  if (!user.id) {
+    throw new UnauthorizedError();
+  }
+  return user.id;
+}

--- a/apps/backend/src/helpers/PlatformTokenHandler.spec.ts
+++ b/apps/backend/src/helpers/PlatformTokenHandler.spec.ts
@@ -1,0 +1,133 @@
+import { PlatformTokenHandler } from './PlatformTokenHandler';
+import apiTokens from './ApiTokens';
+import filterUser from './filterUser';
+import type { User } from '../models/User';
+import type { FilteredUserInterface } from '../types';
+
+// Redirect @myorganizer/auth to refresh-client-contract only so ts-jest does not
+// compile libs/auth/src/lib/auth.ts (unrelated TS errors under backend tsconfig).
+jest.mock('@myorganizer/auth', () =>
+  jest.requireActual('../../../../libs/auth/src/lib/refresh-client-contract'),
+);
+
+jest.mock('./ApiTokens', () => ({
+  __esModule: true,
+  default: {
+    createTokens: jest.fn(),
+  },
+}));
+
+jest.mock('./filterUser', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockCreateTokens = jest.mocked(apiTokens.createTokens);
+const mockFilterUser = jest.mocked(filterUser);
+
+describe('PlatformTokenHandler', () => {
+  const mockUser: User = {
+    id: 'user-1',
+    name: 'Test User',
+    email: 'test@example.com',
+  };
+
+  const filteredUser: FilteredUserInterface = {
+    id: 'user-1',
+    name: 'Test User',
+    email: 'test@example.com',
+    firstName: 'Test',
+    lastName: 'User',
+  };
+
+  beforeEach(() => {
+    mockCreateTokens.mockReset();
+    mockFilterUser.mockReset();
+    mockFilterUser.mockReturnValue(filteredUser);
+  });
+
+  describe('buildLoginResponse', () => {
+    it('includes refresh_token in the body for mobile clients when refresh token succeeds', () => {
+      mockCreateTokens.mockReturnValue({
+        token: 'access-token',
+        refreshToken: 'refresh-token',
+      });
+
+      const response = PlatformTokenHandler.buildLoginResponse(
+        mockUser,
+        'mobile',
+      );
+
+      expect(mockCreateTokens).toHaveBeenCalledWith(mockUser);
+      expect(mockFilterUser).toHaveBeenCalledWith(mockUser);
+      expect(response).toEqual({
+        token: 'access-token',
+        expires_in: 600_000,
+        user: filteredUser,
+        refresh_token: 'refresh-token',
+      });
+    });
+
+    it('omits refresh_token in the body for web clients', () => {
+      mockCreateTokens.mockReturnValue({
+        token: 'access-token',
+        refreshToken: 'refresh-token',
+      });
+
+      const response = PlatformTokenHandler.buildLoginResponse(mockUser, 'web');
+
+      expect(response).toEqual({
+        token: 'access-token',
+        expires_in: 600_000,
+        user: filteredUser,
+      });
+      expect(response).not.toHaveProperty('refresh_token');
+    });
+
+    it('defaults to web behavior when clientType is omitted', () => {
+      mockCreateTokens.mockReturnValue({
+        token: 'access-token',
+        refreshToken: 'refresh-token',
+      });
+
+      const response = PlatformTokenHandler.buildLoginResponse(mockUser);
+
+      expect(response).toEqual({
+        token: 'access-token',
+        expires_in: 600_000,
+        user: filteredUser,
+      });
+      expect(response).not.toHaveProperty('refresh_token');
+    });
+
+    it('throws when access token creation fails', () => {
+      mockCreateTokens.mockReturnValue({
+        token: new Error('jwt sign failed'),
+        refreshToken: 'refresh-token',
+      });
+
+      expect(() =>
+        PlatformTokenHandler.buildLoginResponse(mockUser, 'mobile'),
+      ).toThrow('Failed to create access token');
+    });
+
+    it('omits refresh_token for mobile when refresh token creation fails', () => {
+      mockCreateTokens.mockReturnValue({
+        token: 'access-token',
+        refreshToken: new Error('refresh sign failed'),
+      });
+
+      const response = PlatformTokenHandler.buildLoginResponse(
+        mockUser,
+        'mobile',
+      );
+
+      expect(response).toEqual({
+        token: 'access-token',
+        expires_in: 600_000,
+        user: filteredUser,
+      });
+      expect(response).not.toHaveProperty('refresh_token');
+    });
+  });
+});

--- a/apps/backend/src/helpers/PlatformTokenHandler.ts
+++ b/apps/backend/src/helpers/PlatformTokenHandler.ts
@@ -1,0 +1,50 @@
+import {
+  resolveAuthClientType,
+  shouldIncludeRefreshTokenInLoginBody,
+} from '@myorganizer/auth';
+import { User } from '../models/User';
+import { FilteredUserInterface, UserInterface } from '../types';
+import apiTokens from './ApiTokens';
+import filterUser from './filterUser';
+
+const ACCESS_TOKEN_EXPIRES_IN_MS = 600_000;
+
+export type LoginResponseBody = {
+  token: string;
+  expires_in: number;
+  user: FilteredUserInterface;
+  refresh_token?: string;
+};
+
+export class PlatformTokenHandler {
+  static buildLoginResponse(
+    user: User,
+    clientType?: string,
+  ): LoginResponseBody {
+    const { token, refreshToken } = apiTokens.createTokens(user);
+
+    if (token instanceof Error) {
+      throw new Error('Failed to create access token');
+    }
+
+    const filteredUser = filterUser(user as UserInterface);
+    const authClientType = resolveAuthClientType(clientType);
+
+    const response: LoginResponseBody = {
+      token,
+      expires_in: ACCESS_TOKEN_EXPIRES_IN_MS,
+      user: filteredUser,
+    };
+
+    if (
+      shouldIncludeRefreshTokenInLoginBody(authClientType) &&
+      !(refreshToken instanceof Error)
+    ) {
+      response.refresh_token = refreshToken;
+    }
+
+    return response;
+  }
+}
+
+export default PlatformTokenHandler;

--- a/apps/backend/src/main.test.ts
+++ b/apps/backend/src/main.test.ts
@@ -6,30 +6,31 @@ import { createCorsOptions } from './config/http';
 import { RegisterRoutes } from './routes/routes';
 import usersRouter from './routes/user';
 
-const app = express();
+let app: express.Application;
 
 beforeAll(() => {
   process.env.CORS_ORIGINS =
     'https://myorganizerapi.mnfprofile.com,http://localhost:3000';
   process.env.ROUTER_PREFIX = '/api/v1';
+
+  app = express();
+
+  const corsOptions = createCorsOptions();
+  app.use(cors(corsOptions));
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(bodyParser.json());
+
+  const prefix = process.env.ROUTER_PREFIX || '/api/v1';
+  const api = express.Router();
+  api.use('/user', usersRouter);
+  RegisterRoutes(api);
+  app.use(prefix, api);
 });
 
 afterAll(() => {
   delete process.env.CORS_ORIGINS;
   delete process.env.ROUTER_PREFIX;
 });
-
-const corsOptions = createCorsOptions();
-
-app.use(cors(corsOptions));
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
-
-const prefix = process.env.ROUTER_PREFIX || '/api/v1';
-const api = express.Router();
-api.use('/user', usersRouter);
-RegisterRoutes(api);
-app.use(prefix, api);
 
 describe('Main Application', () => {
   it('should have CORS enabled for specific origins', async () => {

--- a/apps/backend/src/middleware/authentication.test.ts
+++ b/apps/backend/src/middleware/authentication.test.ts
@@ -32,6 +32,7 @@ describe('expressAuthentication (tsoa jwt)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.ACCESS_JWT_SECRET = 'secret';
+    delete process.env.YOUTUBE_CRON_SECRET;
   });
 
   test('rejects when no token provided', async () => {
@@ -39,12 +40,12 @@ describe('expressAuthentication (tsoa jwt)', () => {
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'status',
-      401
+      401,
     );
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'message',
-      'No token provided'
+      'Unauthorized',
     );
   });
 
@@ -53,12 +54,12 @@ describe('expressAuthentication (tsoa jwt)', () => {
 
     await expect(expressAuthentication(req, 'api_key')).rejects.toHaveProperty(
       'status',
-      401
+      401,
     );
 
     await expect(expressAuthentication(req, 'api_key')).rejects.toHaveProperty(
       'message',
-      'Unsupported security scheme'
+      'Unsupported security scheme',
     );
   });
 
@@ -92,12 +93,12 @@ describe('expressAuthentication (tsoa jwt)', () => {
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'status',
-      401
+      401,
     );
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'message',
-      'No token provided'
+      'Unauthorized',
     );
   });
 
@@ -108,12 +109,12 @@ describe('expressAuthentication (tsoa jwt)', () => {
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'status',
-      401
+      401,
     );
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'message',
-      'Invalid token'
+      'Unauthorized',
     );
   });
 
@@ -124,12 +125,12 @@ describe('expressAuthentication (tsoa jwt)', () => {
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'status',
-      401
+      401,
     );
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'message',
-      'Invalid token'
+      'Unauthorized',
     );
   });
 
@@ -141,12 +142,60 @@ describe('expressAuthentication (tsoa jwt)', () => {
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'status',
-      401
+      401,
     );
 
     await expect(expressAuthentication(req, 'jwt')).rejects.toHaveProperty(
       'message',
-      'User not found'
+      'Unauthorized',
     );
+  });
+});
+
+describe('expressAuthentication (tsoa cron-secret)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.YOUTUBE_CRON_SECRET = 'cron-secret-value';
+  });
+
+  test('accepts matching X-Cron-Secret header', async () => {
+    const req = makeReq({ headers: { 'x-cron-secret': 'cron-secret-value' } });
+
+    await expect(
+      expressAuthentication(req, 'cron-secret'),
+    ).resolves.toBeUndefined();
+  });
+
+  test('rejects missing header', async () => {
+    const req = makeReq();
+
+    await expect(
+      expressAuthentication(req, 'cron-secret'),
+    ).rejects.toHaveProperty('status', 401);
+
+    await expect(
+      expressAuthentication(req, 'cron-secret'),
+    ).rejects.toHaveProperty('message', 'Unauthorized');
+  });
+
+  test('rejects wrong secret', async () => {
+    const req = makeReq({ headers: { 'x-cron-secret': 'wrong' } });
+
+    await expect(
+      expressAuthentication(req, 'cron-secret'),
+    ).rejects.toHaveProperty('status', 401);
+
+    await expect(
+      expressAuthentication(req, 'cron-secret'),
+    ).rejects.toHaveProperty('message', 'Unauthorized');
+  });
+
+  test('rejects when YOUTUBE_CRON_SECRET env is unset', async () => {
+    delete process.env.YOUTUBE_CRON_SECRET;
+    const req = makeReq({ headers: { 'x-cron-secret': 'cron-secret-value' } });
+
+    await expect(
+      expressAuthentication(req, 'cron-secret'),
+    ).rejects.toHaveProperty('status', 401);
   });
 });

--- a/apps/backend/src/middleware/authentication.ts
+++ b/apps/backend/src/middleware/authentication.ts
@@ -3,7 +3,7 @@ import { JwtPayload } from 'jsonwebtoken';
 import { decodeToken } from '../helpers/jwtHelper';
 import userService from '../services/UserService';
 
-function unauthorized(message: string) {
+function unauthorized(message = 'Unauthorized') {
   const err = new Error(message) as Error & { status?: number };
   err.status = 401;
   return err;
@@ -17,11 +17,26 @@ function getBearerToken(request: express.Request): string | undefined {
   return match?.[1];
 }
 
+function authenticateCronSecret(request: express.Request): Promise<void> {
+  const secret = request.headers['x-cron-secret'];
+  const expectedSecret = process.env.YOUTUBE_CRON_SECRET;
+
+  if (!expectedSecret || secret !== expectedSecret) {
+    return Promise.reject(unauthorized());
+  }
+
+  return Promise.resolve();
+}
+
 export function expressAuthentication(
   request: express.Request,
   securityName: string,
-  scopes?: string[]
+  scopes?: string[],
 ): Promise<any> {
+  if (securityName === 'cron-secret') {
+    return authenticateCronSecret(request);
+  }
+
   if (securityName !== 'jwt') {
     return Promise.reject(unauthorized('Unsupported security scheme'));
   }
@@ -40,23 +55,23 @@ export function expressAuthentication(
 
     const token = tokenFromHeader ?? tokenFromBody;
     if (!token) {
-      throw unauthorized('No token provided');
+      throw unauthorized();
     }
 
     const decoded = decodeToken(token, process.env.ACCESS_JWT_SECRET as string);
 
     if (!decoded || decoded instanceof Error) {
-      throw unauthorized('Invalid token');
+      throw unauthorized();
     }
 
     const payload = decoded as JwtPayload;
     if (!payload.userId) {
-      throw unauthorized('Invalid token');
+      throw unauthorized();
     }
 
     const user = await userService.getById(payload.userId);
     if (!user) {
-      throw unauthorized('User not found');
+      throw unauthorized();
     }
 
     // Ensure downstream authZ can consistently rely on request.user.
@@ -78,6 +93,6 @@ export function expressAuthentication(
       throw err;
     }
 
-    throw unauthorized('Unauthorized');
+    throw unauthorized();
   });
 }

--- a/apps/backend/src/routes/routes.ts
+++ b/apps/backend/src/routes/routes.ts
@@ -744,9 +744,9 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsYouTubeController_cronSyncAndNotify: Record<string, TsoaRoute.ParameterSchema> = {
-                req: {"in":"request","name":"req","required":true,"dataType":"object"},
         };
         app.post('/youtube/cron/sync-and-notify',
+            authenticateMiddleware([{"cron-secret":[]}]),
             ...(fetchMiddlewares<RequestHandler>(YouTubeController)),
             ...(fetchMiddlewares<RequestHandler>(YouTubeController.prototype.cronSyncAndNotify)),
 

--- a/apps/backend/src/swagger/swagger.json
+++ b/apps/backend/src/swagger/swagger.json
@@ -1,2416 +1,2201 @@
 {
-	"openapi": "3.0.0",
-	"components": {
-		"examples": {},
-		"headers": {},
-		"parameters": {},
-		"requestBodies": {},
-		"responses": {},
-		"schemas": {
-			"AuthUrlResponse": {
-				"properties": {
-					"url": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"url"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"YouTubeErrorResponse": {
-				"properties": {
-					"message": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"message"
-				],
-				"type": "object"
-			},
-			"StatusResponse": {
-				"properties": {
-					"connected": {
-						"type": "boolean"
-					},
-					"status": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"connected",
-					"status"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"SubscriptionResponse": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"channelId": {
-						"type": "string"
-					},
-					"channelTitle": {
-						"type": "string"
-					},
-					"channelThumbnail": {
-						"type": "string",
-						"nullable": true
-					},
-					"uploadsPlaylistId": {
-						"type": "string"
-					},
-					"enabled": {
-						"type": "boolean"
-					},
-					"lastSyncedAt": {
-						"type": "string",
-						"nullable": true
-					}
-				},
-				"required": [
-					"id",
-					"channelId",
-					"channelTitle",
-					"channelThumbnail",
-					"uploadsPlaylistId",
-					"enabled",
-					"lastSyncedAt"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"VideoResponse": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"videoId": {
-						"type": "string"
-					},
-					"channelId": {
-						"type": "string"
-					},
-					"title": {
-						"type": "string"
-					},
-					"thumbnail": {
-						"type": "string",
-						"nullable": true
-					},
-					"publishedAt": {
-						"type": "string"
-					},
-					"channelTitle": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id",
-					"videoId",
-					"channelId",
-					"title",
-					"thumbnail",
-					"publishedAt"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"VideosPageResponse": {
-				"properties": {
-					"videos": {
-						"items": {
-							"$ref": "#/components/schemas/VideoResponse"
-						},
-						"type": "array"
-					},
-					"total": {
-						"type": "number",
-						"format": "double"
-					},
-					"page": {
-						"type": "number",
-						"format": "double"
-					},
-					"limit": {
-						"type": "number",
-						"format": "double"
-					},
-					"totalPages": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"videos",
-					"total",
-					"page",
-					"limit",
-					"totalPages"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ChannelCarouselResponse": {
-				"properties": {
-					"channelId": {
-						"type": "string"
-					},
-					"channelTitle": {
-						"type": "string"
-					},
-					"channelThumbnail": {
-						"type": "string",
-						"nullable": true
-					},
-					"videos": {
-						"items": {
-							"$ref": "#/components/schemas/VideoResponse"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"channelId",
-					"channelTitle",
-					"channelThumbnail",
-					"videos"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"NotificationSettingsResponse": {
-				"properties": {
-					"intervalDays": {
-						"type": "number",
-						"format": "double"
-					},
-					"enabled": {
-						"type": "boolean"
-					},
-					"lastNotifiedAt": {
-						"type": "string",
-						"nullable": true
-					}
-				},
-				"required": [
-					"intervalDays",
-					"enabled",
-					"lastNotifiedAt"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"NotificationSettingsBody": {
-				"properties": {
-					"intervalDays": {
-						"type": "number",
-						"format": "double"
-					},
-					"enabled": {
-						"type": "boolean"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CronResultResponse": {
-				"properties": {
-					"usersSynced": {
-						"type": "number",
-						"format": "double"
-					},
-					"notificationsSent": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"usersSynced",
-					"notificationsSent"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Record_string.unknown_": {
-				"properties": {},
-				"additionalProperties": {},
-				"type": "object",
-				"description": "Construct a type with a set of properties K of type T"
-			},
-			"VaultMetaV1": {
-				"properties": {
-					"version": {
-						"type": "number",
-						"format": "double"
-					},
-					"kdf_name": {
-						"type": "string"
-					},
-					"kdf_salt": {
-						"type": "string"
-					},
-					"kdf_params": {
-						"$ref": "#/components/schemas/Record_string.unknown_"
-					},
-					"wrapped_mk_passphrase": {},
-					"wrapped_mk_recovery": {}
-				},
-				"required": [
-					"version",
-					"kdf_name",
-					"kdf_salt",
-					"kdf_params",
-					"wrapped_mk_passphrase",
-					"wrapped_mk_recovery"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"ErrorResponse": {
-				"properties": {
-					"message": {
-						"type": "string"
-					},
-					"details": {}
-				},
-				"required": [
-					"message"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"GetVaultMetaResponse": {
-				"anyOf": [
-					{
-						"properties": {
-							"etag": {
-								"type": "string"
-							},
-							"updatedAt": {
-								"type": "string"
-							},
-							"meta": {
-								"$ref": "#/components/schemas/VaultMetaV1"
-							}
-						},
-						"required": [
-							"etag",
-							"updatedAt",
-							"meta"
-						],
-						"type": "object"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"PutVaultMetaResponse": {
-				"anyOf": [
-					{
-						"properties": {
-							"updatedAt": {
-								"type": "string"
-							},
-							"etag": {
-								"type": "string"
-							},
-							"ok": {
-								"type": "boolean",
-								"enum": [
-									true
-								],
-								"nullable": false
-							}
-						},
-						"required": [
-							"updatedAt",
-							"etag",
-							"ok"
-						],
-						"type": "object"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"VaultBlobType": {
-				"type": "string",
-				"enum": [
-					"addresses",
-					"groceries",
-					"mobileNumbers",
-					"subscriptions",
-					"tasks",
-					"todos"
-				]
-			},
-			"EncryptedBlobV1": {
-				"properties": {
-					"version": {
-						"type": "number",
-						"format": "double"
-					},
-					"iv": {
-						"type": "string"
-					},
-					"ciphertext": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"version",
-					"iv",
-					"ciphertext"
-				],
-				"type": "object",
-				"additionalProperties": {}
-			},
-			"GetVaultBlobResponse": {
-				"anyOf": [
-					{
-						"properties": {
-							"etag": {
-								"type": "string"
-							},
-							"updatedAt": {
-								"type": "string"
-							},
-							"blob": {
-								"$ref": "#/components/schemas/EncryptedBlobV1"
-							},
-							"type": {
-								"$ref": "#/components/schemas/VaultBlobType"
-							}
-						},
-						"required": [
-							"etag",
-							"updatedAt",
-							"blob",
-							"type"
-						],
-						"type": "object"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"PutVaultBlobResponse": {
-				"anyOf": [
-					{
-						"properties": {
-							"updatedAt": {
-								"type": "string"
-							},
-							"etag": {
-								"type": "string"
-							},
-							"ok": {
-								"type": "boolean",
-								"enum": [
-									true
-								],
-								"nullable": false
-							}
-						},
-						"required": [
-							"updatedAt",
-							"etag",
-							"ok"
-						],
-						"type": "object"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"Partial_Record_VaultBlobType.EncryptedBlobV1__": {
-				"properties": {
-					"addresses": {
-						"$ref": "#/components/schemas/EncryptedBlobV1"
-					},
-					"groceries": {
-						"$ref": "#/components/schemas/EncryptedBlobV1"
-					},
-					"mobileNumbers": {
-						"$ref": "#/components/schemas/EncryptedBlobV1"
-					},
-					"subscriptions": {
-						"$ref": "#/components/schemas/EncryptedBlobV1"
-					},
-					"tasks": {
-						"$ref": "#/components/schemas/EncryptedBlobV1"
-					},
-					"todos": {
-						"$ref": "#/components/schemas/EncryptedBlobV1"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"VaultExportV1": {
-				"properties": {
-					"exportVersion": {
-						"type": "number",
-						"enum": [
-							1
-						],
-						"nullable": false
-					},
-					"exportedAt": {
-						"type": "string"
-					},
-					"meta": {
-						"$ref": "#/components/schemas/VaultMetaV1"
-					},
-					"blobs": {
-						"$ref": "#/components/schemas/Partial_Record_VaultBlobType.EncryptedBlobV1__"
-					}
-				},
-				"required": [
-					"exportVersion",
-					"exportedAt",
-					"meta",
-					"blobs"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ExportVaultResponse": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/VaultExportV1"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"ImportVaultResponse": {
-				"anyOf": [
-					{
-						"properties": {
-							"ok": {
-								"type": "boolean",
-								"enum": [
-									true
-								],
-								"nullable": false
-							}
-						},
-						"required": [
-							"ok"
-						],
-						"type": "object"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"VaultBackupEvent": {
-				"type": "string",
-				"enum": [
-					"export",
-					"import"
-				]
-			},
-			"VaultBackupSource": {
-				"type": "string",
-				"enum": [
-					"local-file",
-					"google-drive"
-				]
-			},
-			"VaultBackupStatus": {
-				"type": "string",
-				"enum": [
-					"success",
-					"failed"
-				]
-			},
-			"VaultBackupBlobType": {
-				"type": "string",
-				"enum": [
-					"addresses",
-					"groceries",
-					"mobileNumbers",
-					"subscriptions",
-					"todos"
-				]
-			},
-			"VaultBackupRecordDto": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"userId": {
-						"type": "string"
-					},
-					"event": {
-						"$ref": "#/components/schemas/VaultBackupEvent"
-					},
-					"source": {
-						"$ref": "#/components/schemas/VaultBackupSource"
-					},
-					"status": {
-						"$ref": "#/components/schemas/VaultBackupStatus"
-					},
-					"errorCode": {
-						"type": "string",
-						"nullable": true
-					},
-					"schemaVersion": {
-						"type": "number",
-						"format": "double"
-					},
-					"blobTypes": {
-						"items": {
-							"$ref": "#/components/schemas/VaultBackupBlobType"
-						},
-						"type": "array"
-					},
-					"sizeBytes": {
-						"type": "number",
-						"format": "double"
-					},
-					"createdAt": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id",
-					"userId",
-					"event",
-					"source",
-					"status",
-					"errorCode",
-					"schemaVersion",
-					"blobTypes",
-					"sizeBytes",
-					"createdAt"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RecordVaultBackupResponse": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/VaultBackupRecordDto"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"RecordVaultBackupRequest": {
-				"properties": {
-					"event": {
-						"$ref": "#/components/schemas/VaultBackupEvent"
-					},
-					"source": {
-						"$ref": "#/components/schemas/VaultBackupSource"
-					},
-					"status": {
-						"$ref": "#/components/schemas/VaultBackupStatus"
-					},
-					"errorCode": {
-						"type": "string",
-						"nullable": true
-					},
-					"schemaVersion": {
-						"type": "number",
-						"format": "double"
-					},
-					"blobTypes": {
-						"items": {
-							"$ref": "#/components/schemas/VaultBackupBlobType"
-						},
-						"type": "array"
-					},
-					"sizeBytes": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"event",
-					"source",
-					"status",
-					"schemaVersion",
-					"blobTypes",
-					"sizeBytes"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"GetLatestVaultBackupResponse": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/VaultBackupRecordDto"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"VaultBackupHistoryPage": {
-				"properties": {
-					"items": {
-						"items": {
-							"$ref": "#/components/schemas/VaultBackupRecordDto"
-						},
-						"type": "array"
-					},
-					"nextCursor": {
-						"type": "string",
-						"nullable": true
-					}
-				},
-				"required": [
-					"items",
-					"nextCursor"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ListVaultBackupsResponse": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/VaultBackupHistoryPage"
-					},
-					{
-						"$ref": "#/components/schemas/ErrorResponse"
-					}
-				]
-			},
-			"User": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"first_name": {
-						"type": "string"
-					},
-					"last_name": {
-						"type": "string"
-					},
-					"phone": {
-						"type": "string"
-					},
-					"email": {
-						"type": "string"
-					},
-					"password": {
-						"type": "string"
-					},
-					"reset_password_token": {
-						"type": "string"
-					},
-					"email_verification_timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"blacklisted_tokens": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"id",
-					"email"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"FilteredUserInterface": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"email": {
-						"type": "string"
-					},
-					"firstName": {
-						"type": "string"
-					},
-					"lastName": {
-						"type": "string"
-					},
-					"phone": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id",
-					"name",
-					"email",
-					"firstName",
-					"lastName"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ValidateErrorJSON": {
-				"properties": {
-					"message": {
-						"type": "string",
-						"enum": [
-							"Validation failed"
-						],
-						"nullable": false
-					},
-					"details": {
-						"properties": {},
-						"additionalProperties": {},
-						"type": "object"
-					}
-				},
-				"required": [
-					"message",
-					"details"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"UserCreationBody": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"firstName": {
-						"type": "string"
-					},
-					"lastName": {
-						"type": "string"
-					},
-					"phone": {
-						"type": "string"
-					},
-					"email": {
-						"type": "string"
-					},
-					"password": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"firstName",
-					"lastName",
-					"email",
-					"password"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"UserLoginBody": {
-				"properties": {
-					"email": {
-						"type": "string"
-					},
-					"password": {
-						"type": "string"
-					},
-					"client_type": {
-						"type": "string",
-						"enum": [
-							"mobile",
-							"web"
-						]
-					}
-				},
-				"required": [
-					"email",
-					"password"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RegisterUserResponse": {
-				"properties": {
-					"message": {
-						"type": "string"
-					},
-					"user": {
-						"$ref": "#/components/schemas/FilteredUserInterface"
-					}
-				},
-				"required": [
-					"message"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResetPasswordByEmailBody": {
-				"properties": {
-					"email": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"email"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ConfirmResetPasswordBody": {
-				"properties": {
-					"token": {
-						"type": "string"
-					},
-					"password": {
-						"type": "string"
-					},
-					"confirm_password": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"token",
-					"password",
-					"confirm_password"
-				],
-				"type": "object",
-				"additionalProperties": false
-			}
-		},
-		"securitySchemes": {
-			"OAuth2PasswordSecurity": {
-				"type": "oauth2",
-				"description": "OAuth2 Password Grant",
-				"flows": {
-					"password": {
-						"tokenUrl": "http://localhost:3000/api/v1/auth/login",
-						"scopes": {}
-					}
-				}
-			},
-			"jwt": {
-				"type": "http",
-				"scheme": "bearer",
-				"bearerFormat": "JWT",
-				"description": "JWT Access Token only"
-			}
-		}
-	},
-	"info": {
-		"title": "@myorganizer/source",
-		"version": "0.2.0",
-		"license": {
-			"name": "MIT"
-		},
-		"contact": {}
-	},
-	"paths": {
-		"/youtube/auth-url": {
-			"get": {
-				"operationId": "GetAuthUrl",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/AuthUrlResponse"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Returns the Google OAuth consent URL for linking YouTube.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			}
-		},
-		"/youtube/callback": {
-			"post": {
-				"operationId": "HandleCallback",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										},
-										"ok": {
-											"type": "boolean"
-										}
-									},
-									"required": [
-										"message",
-										"ok"
-									],
-									"type": "object"
-								}
-							}
-						}
-					}
-				},
-				"description": "OAuth callback — exchanges the authorization code for tokens.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"code": {
-										"type": "string"
-									}
-								},
-								"required": [
-									"code"
-								],
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/youtube/status": {
-			"get": {
-				"operationId": "GetConnectionStatus",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/StatusResponse"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Returns the user's YouTube integration status.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			}
-		},
-		"/youtube/disconnect": {
-			"delete": {
-				"operationId": "Disconnect",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										},
-										"ok": {
-											"type": "boolean"
-										}
-									},
-									"required": [
-										"message",
-										"ok"
-									],
-									"type": "object"
-								}
-							}
-						}
-					}
-				},
-				"description": "Disconnects the user's YouTube account after revoking the token.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			}
-		},
-		"/youtube/subscriptions": {
-			"get": {
-				"operationId": "GetSubscriptions",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"items": {
-												"$ref": "#/components/schemas/SubscriptionResponse"
-											},
-											"type": "array"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Returns the user's synced YouTube channel subscriptions.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			}
-		},
-		"/youtube/subscriptions/sync": {
-			"put": {
-				"operationId": "SyncSubscriptions",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"properties": {
-												"videosSynced": {
-													"type": "number",
-													"format": "double"
-												},
-												"synced": {
-													"type": "number",
-													"format": "double"
-												}
-											},
-											"required": [
-												"videosSynced",
-												"synced"
-											],
-											"type": "object"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Fetches fresh subscriptions from YouTube and syncs to DB.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			}
-		},
-		"/youtube/subscriptions/{subscriptionId}": {
-			"patch": {
-				"operationId": "ToggleSubscription",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"properties": {
-												"ok": {
-													"type": "boolean"
-												}
-											},
-											"required": [
-												"ok"
-											],
-											"type": "object"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Toggles a subscription's enabled state.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "subscriptionId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"enabled": {
-										"type": "boolean"
-									}
-								},
-								"required": [
-									"enabled"
-								],
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/youtube/videos": {
-			"get": {
-				"operationId": "GetVideos",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/VideosPageResponse"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Returns cached videos with sorting, searching, and pagination.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"description": "Sort order: latest | oldest | az",
-						"in": "query",
-						"name": "sort",
-						"required": false,
-						"schema": {
-							"type": "string",
-							"enum": [
-								"latest",
-								"oldest",
-								"az"
-							]
-						}
-					},
-					{
-						"description": "Filter by video title",
-						"in": "query",
-						"name": "search",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Page number (1-based)",
-						"in": "query",
-						"name": "page",
-						"required": false,
-						"schema": {
-							"format": "double",
-							"type": "number"
-						}
-					},
-					{
-						"description": "Items per page",
-						"in": "query",
-						"name": "limit",
-						"required": false,
-						"schema": {
-							"format": "double",
-							"type": "number"
-						}
-					},
-					{
-						"in": "query",
-						"name": "channelId",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/youtube/videos/carousel": {
-			"get": {
-				"operationId": "GetVideosCarousel",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"items": {
-												"$ref": "#/components/schemas/ChannelCarouselResponse"
-											},
-											"type": "array"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Returns videos grouped by channel for the carousel view.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			}
-		},
-		"/youtube/notification-settings": {
-			"get": {
-				"operationId": "GetNotificationSettings",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/NotificationSettingsResponse"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Returns the user's YouTube notification preferences.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			},
-			"patch": {
-				"operationId": "UpdateNotificationSettings",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/NotificationSettingsResponse"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Updates the user's YouTube notification preferences.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/NotificationSettingsBody"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/youtube/cron/sync-and-notify": {
-			"post": {
-				"operationId": "CronSyncAndNotify",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/CronResultResponse"
-										},
-										{
-											"$ref": "#/components/schemas/YouTubeErrorResponse"
-										}
-									]
-								}
-							}
-						}
-					}
-				},
-				"description": "Cron-only endpoint: syncs all users' videos and sends due notifications.\nAuthenticated via X-Cron-Secret header instead of JWT.",
-				"tags": [
-					"YouTube"
-				],
-				"security": [],
-				"parameters": []
-			}
-		},
-		"/vault": {
-			"get": {
-				"operationId": "GetVaultMeta",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/GetVaultMetaResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Vault"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			},
-			"put": {
-				"operationId": "PutVaultMeta",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/PutVaultMetaResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Vault"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"in": "header",
-						"name": "if-match",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"meta": {
-										"$ref": "#/components/schemas/VaultMetaV1"
-									}
-								},
-								"required": [
-									"meta"
-								],
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/vault/blob/{type}": {
-			"get": {
-				"operationId": "GetVaultBlob",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/GetVaultBlobResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Vault"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/VaultBlobType"
-						}
-					}
-				]
-			},
-			"put": {
-				"operationId": "PutVaultBlob",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/PutVaultBlobResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Vault"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/VaultBlobType"
-						}
-					},
-					{
-						"in": "header",
-						"name": "if-match",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"blob": {
-										"$ref": "#/components/schemas/EncryptedBlobV1"
-									},
-									"type": {
-										"$ref": "#/components/schemas/VaultBlobType"
-									}
-								},
-								"required": [
-									"blob",
-									"type"
-								],
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/vault/export": {
-			"post": {
-				"operationId": "ExportVault",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ExportVaultResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Vault"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			}
-		},
-		"/vault/import": {
-			"post": {
-				"operationId": "ImportVault",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ImportVaultResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Vault"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/VaultExportV1"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/vault/backups": {
-			"post": {
-				"operationId": "RecordBackup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/RecordVaultBackupResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"VaultBackups"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/RecordVaultBackupRequest"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "ListBackups",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ListVaultBackupsResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"VaultBackups"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "cursor",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "limit",
-						"required": false,
-						"schema": {
-							"format": "double",
-							"type": "number"
-						}
-					},
-					{
-						"in": "query",
-						"name": "source",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/VaultBackupSource"
-						}
-					}
-				]
-			}
-		},
-		"/vault/backups/latest": {
-			"get": {
-				"operationId": "GetLatestBackup",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/GetLatestVaultBackupResponse"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"VaultBackups"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/VaultBackupStatus"
-						}
-					},
-					{
-						"in": "query",
-						"name": "source",
-						"required": false,
-						"schema": {
-							"$ref": "#/components/schemas/VaultBackupSource"
-						}
-					}
-				]
-			}
-		},
-		"/user": {
-			"get": {
-				"operationId": "GetAllUsers",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/User"
-									},
-									"type": "array"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Users Management"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": []
-			},
-			"post": {
-				"operationId": "CreateUser",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/FilteredUserInterface"
-								}
-							}
-						}
-					},
-					"201": {
-						"description": "Created"
-					},
-					"422": {
-						"description": "Validation Failed",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidateErrorJSON"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Users Management"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UserCreationBody"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/user/{userId}": {
-			"get": {
-				"operationId": "GetUserById",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"allOf": [
-										{
-											"$ref": "#/components/schemas/User"
-										}
-									],
-									"nullable": true
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Users Management"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "userId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/auth/login": {
-			"post": {
-				"operationId": "Login",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"refresh_token": {
-											"type": "string"
-										},
-										"user": {
-											"$ref": "#/components/schemas/FilteredUserInterface"
-										},
-										"expires_in": {
-											"type": "number",
-											"format": "double"
-										},
-										"token": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"user",
-										"expires_in",
-										"token"
-									],
-									"type": "object"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized"
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UserLoginBody"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/auth/logout/{userId}": {
-			"post": {
-				"operationId": "Logout",
-				"responses": {
-					"200": {
-						"description": "Logged out successfully",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"message"
-									],
-									"type": "object"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized"
-					},
-					"500": {
-						"description": "Failed to logout"
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "userId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/auth/refresh": {
-			"post": {
-				"operationId": "RefreshToken",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"user": {
-											"$ref": "#/components/schemas/FilteredUserInterface"
-										},
-										"expires_in": {
-											"type": "number",
-											"format": "double"
-										},
-										"token": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"user",
-										"expires_in",
-										"token"
-									],
-									"type": "object"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"message"
-									],
-									"type": "object"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"message"
-									],
-									"type": "object"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Failed",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidateErrorJSON"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": false,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"refresh_token": {
-										"type": "string"
-									}
-								},
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/auth/register": {
-			"post": {
-				"operationId": "RegisterUser",
-				"responses": {
-					"201": {
-						"description": "Created",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/RegisterUserResponse"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Failed",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidateErrorJSON"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UserCreationBody"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/auth/verify/email": {
-			"patch": {
-				"operationId": "VerifyEmail",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/FilteredUserInterface"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Failed",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidateErrorJSON"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"token": {
-										"type": "string"
-									}
-								},
-								"required": [
-									"token"
-								],
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/auth/verify/resend": {
-			"post": {
-				"operationId": "ResendVerificationEmailByEmail",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										},
-										"status": {
-											"type": "number",
-											"format": "double"
-										}
-									},
-									"required": [
-										"message",
-										"status"
-									],
-									"type": "object"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"email": {
-										"type": "string"
-									}
-								},
-								"required": [
-									"email"
-								],
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/auth/verify/resend/{userId}": {
-			"post": {
-				"operationId": "ResendVerificationEmail",
-				"responses": {
-					"204": {
-						"description": "No content"
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [
-					{
-						"jwt": []
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "userId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/auth/password/reset": {
-			"post": {
-				"operationId": "ResetPassword",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										},
-										"status": {
-											"type": "number",
-											"format": "double"
-										}
-									},
-									"required": [
-										"message",
-										"status"
-									],
-									"type": "object"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/ResetPasswordByEmailBody"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/auth/password/reset/confirm": {
-			"patch": {
-				"operationId": "ConfirmResetPassword",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										},
-										"status": {
-											"type": "number",
-											"format": "double"
-										}
-									},
-									"required": [
-										"message",
-										"status"
-									],
-									"type": "object"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Authentication"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/ConfirmResetPasswordBody"
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"servers": [
-		{
-			"url": "http://localhost:3000/api/v1/",
-			"description": "Local server"
-		}
-	]
+  "openapi": "3.0.0",
+  "components": {
+    "examples": {},
+    "headers": {},
+    "parameters": {},
+    "requestBodies": {},
+    "responses": {},
+    "schemas": {
+      "AuthUrlResponse": {
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["url"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "YouTubeErrorResponse": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["message"],
+        "type": "object"
+      },
+      "StatusResponse": {
+        "properties": {
+          "connected": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": ["connected", "status"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "SubscriptionResponse": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string"
+          },
+          "channelTitle": {
+            "type": "string"
+          },
+          "channelThumbnail": {
+            "type": "string",
+            "nullable": true
+          },
+          "uploadsPlaylistId": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "lastSyncedAt": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "channelId",
+          "channelTitle",
+          "channelThumbnail",
+          "uploadsPlaylistId",
+          "enabled",
+          "lastSyncedAt"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "VideoResponse": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "videoId": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string",
+            "nullable": true
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "channelTitle": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "videoId",
+          "channelId",
+          "title",
+          "thumbnail",
+          "publishedAt"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "VideosPageResponse": {
+        "properties": {
+          "videos": {
+            "items": {
+              "$ref": "#/components/schemas/VideoResponse"
+            },
+            "type": "array"
+          },
+          "total": {
+            "type": "number",
+            "format": "double"
+          },
+          "page": {
+            "type": "number",
+            "format": "double"
+          },
+          "limit": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalPages": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": ["videos", "total", "page", "limit", "totalPages"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ChannelCarouselResponse": {
+        "properties": {
+          "channelId": {
+            "type": "string"
+          },
+          "channelTitle": {
+            "type": "string"
+          },
+          "channelThumbnail": {
+            "type": "string",
+            "nullable": true
+          },
+          "videos": {
+            "items": {
+              "$ref": "#/components/schemas/VideoResponse"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["channelId", "channelTitle", "channelThumbnail", "videos"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "NotificationSettingsResponse": {
+        "properties": {
+          "intervalDays": {
+            "type": "number",
+            "format": "double"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "lastNotifiedAt": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": ["intervalDays", "enabled", "lastNotifiedAt"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "NotificationSettingsBody": {
+        "properties": {
+          "intervalDays": {
+            "type": "number",
+            "format": "double"
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CronResultResponse": {
+        "properties": {
+          "usersSynced": {
+            "type": "number",
+            "format": "double"
+          },
+          "notificationsSent": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": ["usersSynced", "notificationsSent"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Record_string.unknown_": {
+        "properties": {},
+        "additionalProperties": {},
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "VaultMetaV1": {
+        "properties": {
+          "version": {
+            "type": "number",
+            "format": "double"
+          },
+          "kdf_name": {
+            "type": "string"
+          },
+          "kdf_salt": {
+            "type": "string"
+          },
+          "kdf_params": {
+            "$ref": "#/components/schemas/Record_string.unknown_"
+          },
+          "wrapped_mk_passphrase": {},
+          "wrapped_mk_recovery": {}
+        },
+        "required": [
+          "version",
+          "kdf_name",
+          "kdf_salt",
+          "kdf_params",
+          "wrapped_mk_passphrase",
+          "wrapped_mk_recovery"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ErrorResponse": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "details": {}
+        },
+        "required": ["message"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "GetVaultMetaResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "etag": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "meta": {
+                "$ref": "#/components/schemas/VaultMetaV1"
+              }
+            },
+            "required": ["etag", "updatedAt", "meta"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "PutVaultMetaResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "updatedAt": {
+                "type": "string"
+              },
+              "etag": {
+                "type": "string"
+              },
+              "ok": {
+                "type": "boolean",
+                "enum": [true],
+                "nullable": false
+              }
+            },
+            "required": ["updatedAt", "etag", "ok"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "VaultBlobType": {
+        "type": "string",
+        "enum": [
+          "addresses",
+          "groceries",
+          "mobileNumbers",
+          "subscriptions",
+          "tasks",
+          "todos"
+        ]
+      },
+      "EncryptedBlobV1": {
+        "properties": {
+          "version": {
+            "type": "number",
+            "format": "double"
+          },
+          "iv": {
+            "type": "string"
+          },
+          "ciphertext": {
+            "type": "string"
+          }
+        },
+        "required": ["version", "iv", "ciphertext"],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "GetVaultBlobResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "etag": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "blob": {
+                "$ref": "#/components/schemas/EncryptedBlobV1"
+              },
+              "type": {
+                "$ref": "#/components/schemas/VaultBlobType"
+              }
+            },
+            "required": ["etag", "updatedAt", "blob", "type"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "PutVaultBlobResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "updatedAt": {
+                "type": "string"
+              },
+              "etag": {
+                "type": "string"
+              },
+              "ok": {
+                "type": "boolean",
+                "enum": [true],
+                "nullable": false
+              }
+            },
+            "required": ["updatedAt", "etag", "ok"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "Partial_Record_VaultBlobType.EncryptedBlobV1__": {
+        "properties": {
+          "addresses": {
+            "$ref": "#/components/schemas/EncryptedBlobV1"
+          },
+          "groceries": {
+            "$ref": "#/components/schemas/EncryptedBlobV1"
+          },
+          "mobileNumbers": {
+            "$ref": "#/components/schemas/EncryptedBlobV1"
+          },
+          "subscriptions": {
+            "$ref": "#/components/schemas/EncryptedBlobV1"
+          },
+          "tasks": {
+            "$ref": "#/components/schemas/EncryptedBlobV1"
+          },
+          "todos": {
+            "$ref": "#/components/schemas/EncryptedBlobV1"
+          }
+        },
+        "type": "object",
+        "description": "Make all properties in T optional"
+      },
+      "VaultExportV1": {
+        "properties": {
+          "exportVersion": {
+            "type": "number",
+            "enum": [1],
+            "nullable": false
+          },
+          "exportedAt": {
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/VaultMetaV1"
+          },
+          "blobs": {
+            "$ref": "#/components/schemas/Partial_Record_VaultBlobType.EncryptedBlobV1__"
+          }
+        },
+        "required": ["exportVersion", "exportedAt", "meta", "blobs"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ExportVaultResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/VaultExportV1"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "ImportVaultResponse": {
+        "anyOf": [
+          {
+            "properties": {
+              "ok": {
+                "type": "boolean",
+                "enum": [true],
+                "nullable": false
+              }
+            },
+            "required": ["ok"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "VaultBackupEvent": {
+        "type": "string",
+        "enum": ["export", "import"]
+      },
+      "VaultBackupSource": {
+        "type": "string",
+        "enum": ["local-file", "google-drive"]
+      },
+      "VaultBackupStatus": {
+        "type": "string",
+        "enum": ["success", "failed"]
+      },
+      "VaultBackupBlobType": {
+        "type": "string",
+        "enum": [
+          "addresses",
+          "groceries",
+          "mobileNumbers",
+          "subscriptions",
+          "todos"
+        ]
+      },
+      "VaultBackupRecordDto": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "event": {
+            "$ref": "#/components/schemas/VaultBackupEvent"
+          },
+          "source": {
+            "$ref": "#/components/schemas/VaultBackupSource"
+          },
+          "status": {
+            "$ref": "#/components/schemas/VaultBackupStatus"
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "schemaVersion": {
+            "type": "number",
+            "format": "double"
+          },
+          "blobTypes": {
+            "items": {
+              "$ref": "#/components/schemas/VaultBackupBlobType"
+            },
+            "type": "array"
+          },
+          "sizeBytes": {
+            "type": "number",
+            "format": "double"
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "event",
+          "source",
+          "status",
+          "errorCode",
+          "schemaVersion",
+          "blobTypes",
+          "sizeBytes",
+          "createdAt"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RecordVaultBackupResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/VaultBackupRecordDto"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "RecordVaultBackupRequest": {
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/VaultBackupEvent"
+          },
+          "source": {
+            "$ref": "#/components/schemas/VaultBackupSource"
+          },
+          "status": {
+            "$ref": "#/components/schemas/VaultBackupStatus"
+          },
+          "errorCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "schemaVersion": {
+            "type": "number",
+            "format": "double"
+          },
+          "blobTypes": {
+            "items": {
+              "$ref": "#/components/schemas/VaultBackupBlobType"
+            },
+            "type": "array"
+          },
+          "sizeBytes": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "event",
+          "source",
+          "status",
+          "schemaVersion",
+          "blobTypes",
+          "sizeBytes"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "GetLatestVaultBackupResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/VaultBackupRecordDto"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "VaultBackupHistoryPage": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/VaultBackupRecordDto"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": ["items", "nextCursor"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ListVaultBackupsResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/VaultBackupHistoryPage"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ]
+      },
+      "User": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "reset_password_token": {
+            "type": "string"
+          },
+          "email_verification_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "blacklisted_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["id", "email"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "FilteredUserInterface": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "name", "email", "firstName", "lastName"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ValidateErrorJSON": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "enum": ["Validation failed"],
+            "nullable": false
+          },
+          "details": {
+            "properties": {},
+            "additionalProperties": {},
+            "type": "object"
+          }
+        },
+        "required": ["message", "details"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "UserCreationBody": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        },
+        "required": ["firstName", "lastName", "email", "password"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "UserLoginBody": {
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "client_type": {
+            "type": "string",
+            "enum": ["mobile", "web"]
+          }
+        },
+        "required": ["email", "password"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterUserResponse": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/FilteredUserInterface"
+          }
+        },
+        "required": ["message"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ResetPasswordByEmailBody": {
+        "properties": {
+          "email": {
+            "type": "string"
+          }
+        },
+        "required": ["email"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ConfirmResetPasswordBody": {
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "confirm_password": {
+            "type": "string"
+          }
+        },
+        "required": ["token", "password", "confirm_password"],
+        "type": "object",
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordSecurity": {
+        "type": "oauth2",
+        "description": "OAuth2 Password Grant",
+        "flows": {
+          "password": {
+            "tokenUrl": "http://localhost:3000/api/v1/auth/login",
+            "scopes": {}
+          }
+        }
+      },
+      "jwt": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "JWT Access Token only"
+      },
+      "cron-secret": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Cron-Secret",
+        "description": "Shared secret for cron-triggered endpoints"
+      }
+    }
+  },
+  "info": {
+    "title": "@myorganizer/source",
+    "version": "0.2.0",
+    "license": {
+      "name": "MIT"
+    },
+    "contact": {}
+  },
+  "paths": {
+    "/youtube/auth-url": {
+      "get": {
+        "operationId": "GetAuthUrl",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AuthUrlResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns the Google OAuth consent URL for linking YouTube.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/youtube/callback": {
+      "post": {
+        "operationId": "HandleCallback",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["message", "ok"],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "description": "OAuth callback — exchanges the authorization code for tokens.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  }
+                },
+                "required": ["code"],
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/youtube/status": {
+      "get": {
+        "operationId": "GetConnectionStatus",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/StatusResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns the user's YouTube integration status.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/youtube/disconnect": {
+      "delete": {
+        "operationId": "Disconnect",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["message", "ok"],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "description": "Disconnects the user's YouTube account after revoking the token.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/youtube/subscriptions": {
+      "get": {
+        "operationId": "GetSubscriptions",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "$ref": "#/components/schemas/SubscriptionResponse"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns the user's synced YouTube channel subscriptions.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/youtube/subscriptions/sync": {
+      "put": {
+        "operationId": "SyncSubscriptions",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "videosSynced": {
+                          "type": "number",
+                          "format": "double"
+                        },
+                        "synced": {
+                          "type": "number",
+                          "format": "double"
+                        }
+                      },
+                      "required": ["videosSynced", "synced"],
+                      "type": "object"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Fetches fresh subscriptions from YouTube and syncs to DB.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/youtube/subscriptions/{subscriptionId}": {
+      "patch": {
+        "operationId": "ToggleSubscription",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "ok": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"],
+                      "type": "object"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Toggles a subscription's enabled state.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "subscriptionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["enabled"],
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/youtube/videos": {
+      "get": {
+        "operationId": "GetVideos",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/VideosPageResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns cached videos with sorting, searching, and pagination.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "description": "Sort order: latest | oldest | az",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["latest", "oldest", "az"]
+            }
+          },
+          {
+            "description": "Filter by video title",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number (1-based)",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Items per page",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "channelId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/youtube/videos/carousel": {
+      "get": {
+        "operationId": "GetVideosCarousel",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "$ref": "#/components/schemas/ChannelCarouselResponse"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns videos grouped by channel for the carousel view.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/youtube/notification-settings": {
+      "get": {
+        "operationId": "GetNotificationSettings",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/NotificationSettingsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns the user's YouTube notification preferences.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      },
+      "patch": {
+        "operationId": "UpdateNotificationSettings",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/NotificationSettingsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Updates the user's YouTube notification preferences.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationSettingsBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/youtube/cron/sync-and-notify": {
+      "post": {
+        "operationId": "CronSyncAndNotify",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/CronResultResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/YouTubeErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Cron-only endpoint: syncs all users' videos and sends due notifications.\nAuthenticated via X-Cron-Secret header instead of JWT.",
+        "tags": ["YouTube"],
+        "security": [
+          {
+            "cron-secret": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/vault": {
+      "get": {
+        "operationId": "GetVaultMeta",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetVaultMetaResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      },
+      "put": {
+        "operationId": "PutVaultMeta",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutVaultMetaResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "if-match",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "meta": {
+                    "$ref": "#/components/schemas/VaultMetaV1"
+                  }
+                },
+                "required": ["meta"],
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vault/blob/{type}": {
+      "get": {
+        "operationId": "GetVaultBlob",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetVaultBlobResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VaultBlobType"
+            }
+          }
+        ]
+      },
+      "put": {
+        "operationId": "PutVaultBlob",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutVaultBlobResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VaultBlobType"
+            }
+          },
+          {
+            "in": "header",
+            "name": "if-match",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "blob": {
+                    "$ref": "#/components/schemas/EncryptedBlobV1"
+                  },
+                  "type": {
+                    "$ref": "#/components/schemas/VaultBlobType"
+                  }
+                },
+                "required": ["blob", "type"],
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vault/export": {
+      "post": {
+        "operationId": "ExportVault",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportVaultResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      }
+    },
+    "/vault/import": {
+      "post": {
+        "operationId": "ImportVault",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportVaultResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Vault"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VaultExportV1"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vault/backups": {
+      "post": {
+        "operationId": "RecordBackup",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordVaultBackupResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["VaultBackups"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecordVaultBackupRequest"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "ListBackups",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListVaultBackupsResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["VaultBackups"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/VaultBackupSource"
+            }
+          }
+        ]
+      }
+    },
+    "/vault/backups/latest": {
+      "get": {
+        "operationId": "GetLatestBackup",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetLatestVaultBackupResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["VaultBackups"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/VaultBackupStatus"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/VaultBackupSource"
+            }
+          }
+        ]
+      }
+    },
+    "/user": {
+      "get": {
+        "operationId": "GetAllUsers",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Users Management"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": []
+      },
+      "post": {
+        "operationId": "CreateUser",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilteredUserInterface"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "422": {
+            "description": "Validation Failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidateErrorJSON"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Users Management"],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreationBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/{userId}": {
+      "get": {
+        "operationId": "GetUserById",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  ],
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Users Management"],
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "operationId": "Login",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "refresh_token": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/FilteredUserInterface"
+                    },
+                    "expires_in": {
+                      "type": "number",
+                      "format": "double"
+                    },
+                    "token": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["user", "expires_in", "token"],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserLoginBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout/{userId}": {
+      "post": {
+        "operationId": "Logout",
+        "responses": {
+          "200": {
+            "description": "Logged out successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Failed to logout"
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/auth/refresh": {
+      "post": {
+        "operationId": "RefreshToken",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/FilteredUserInterface"
+                    },
+                    "expires_in": {
+                      "type": "number",
+                      "format": "double"
+                    },
+                    "token": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["user", "expires_in", "token"],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidateErrorJSON"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "refresh_token": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "operationId": "RegisterUser",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterUserResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidateErrorJSON"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreationBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/verify/email": {
+      "patch": {
+        "operationId": "VerifyEmail",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilteredUserInterface"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidateErrorJSON"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  }
+                },
+                "required": ["token"],
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/verify/resend": {
+      "post": {
+        "operationId": "ResendVerificationEmailByEmail",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "number",
+                      "format": "double"
+                    }
+                  },
+                  "required": ["message", "status"],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": ["email"],
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/verify/resend/{userId}": {
+      "post": {
+        "operationId": "ResendVerificationEmail",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/auth/password/reset": {
+      "post": {
+        "operationId": "ResetPassword",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "number",
+                      "format": "double"
+                    }
+                  },
+                  "required": ["message", "status"],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResetPasswordByEmailBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/password/reset/confirm": {
+      "patch": {
+        "operationId": "ConfirmResetPassword",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "number",
+                      "format": "double"
+                    }
+                  },
+                  "required": ["message", "status"],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Authentication"],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmResetPasswordBody"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000/api/v1/",
+      "description": "Local server"
+    }
+  ]
 }

--- a/apps/backend/src/swagger/swagger.yaml
+++ b/apps/backend/src/swagger/swagger.yaml
@@ -620,6 +620,11 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: JWT Access Token only
+    cron-secret:
+      type: apiKey
+      in: header
+      name: X-Cron-Secret
+      description: Shared secret for cron-triggered endpoints
 info:
   title: "@myorganizer/source"
   version: 0.2.0
@@ -940,7 +945,8 @@ paths:
         Authenticated via X-Cron-Secret header instead of JWT.
       tags:
         - YouTube
-      security: []
+      security:
+        - cron-secret: []
       parameters: []
   /vault:
     get:

--- a/apps/backend/tsconfig.app.json
+++ b/apps/backend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "types": ["node", "express", "passport"],
     "composite": false,
-    "lib": ["es2021"]
+    "lib": ["es2021", "dom"]
   },
   "include": [
     "src/**/*.ts",

--- a/apps/backend/tsoa.json
+++ b/apps/backend/tsoa.json
@@ -25,6 +25,12 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "description": "JWT Access Token only"
+      },
+      "cron-secret": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Cron-Secret",
+        "description": "Shared secret for cron-triggered endpoints"
       }
     }
   },

--- a/libs/api-specs/src/api-specs.openapi.yaml
+++ b/libs/api-specs/src/api-specs.openapi.yaml
@@ -620,6 +620,11 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: JWT Access Token only
+    cron-secret:
+      type: apiKey
+      in: header
+      name: X-Cron-Secret
+      description: Shared secret for cron-triggered endpoints
 info:
   title: "@myorganizer/source"
   version: 0.2.0
@@ -940,7 +945,8 @@ paths:
         Authenticated via X-Cron-Secret header instead of JWT.
       tags:
         - YouTube
-      security: []
+      security:
+        - cron-secret: []
       parameters: []
   /vault:
     get:

--- a/libs/auth/src/lib/auth.ts
+++ b/libs/auth/src/lib/auth.ts
@@ -9,7 +9,7 @@ import {
 import type { AuthSessionStorageAdapter } from './auth-session-storage-adapter';
 import { createBrowserAuthSessionStorageAdapter } from './auth-session-storage-adapter';
 import { createAuthSessionTransportAdapter } from './auth-session-transport-adapter';
-import type { AuthUser } from './auth-session-types';
+import type { AuthOperationResult, AuthUser } from './auth-session-types';
 
 export type { AuthUser } from './auth-session-types';
 export type ResetPasswordResponse = {
@@ -62,34 +62,33 @@ export function getAuthApi(): AuthenticationApi {
   return defaultTransport.getAuthApi();
 }
 
+function unwrapAuthResult<T>(result: AuthOperationResult<T>): T {
+  if ('error' in result) {
+    throw new Error(result.error.message);
+  }
+
+  return result.value;
+}
+
 export async function login(args: {
   email: string;
   password: string;
   rememberMe?: boolean;
 }): Promise<AuthSession> {
   const result = await authSession.signIn(args);
-  if (!result.ok) {
-    throw new Error(result.error.message);
-  }
-  return result.value;
+  return unwrapAuthResult(result);
 }
 
 export async function resendVerificationEmail(
   email: string,
 ): Promise<{ message: string }> {
   const result = await authSession.resendVerificationEmail(email);
-  if (!result.ok) {
-    throw new Error(result.error.message);
-  }
-  return result.value;
+  return unwrapAuthResult(result);
 }
 
 export async function refresh(): Promise<AuthSession> {
   const result = await authSession.refreshAccessToken();
-  if (!result.ok) {
-    throw new Error(result.error.message);
-  }
-  return result.value;
+  return unwrapAuthResult(result);
 }
 
 export async function register(args: {
@@ -100,10 +99,7 @@ export async function register(args: {
   phone?: string;
 }): Promise<{ message: string; user?: AuthUser }> {
   const result = await authSession.signUp(args);
-  if (!result.ok) {
-    throw new Error(result.error.message);
-  }
-  return result.value;
+  return unwrapAuthResult(result);
 }
 
 export async function logout(): Promise<void> {
@@ -114,10 +110,7 @@ export async function requestPasswordReset(args: {
   email: string;
 }): Promise<ResetPasswordResponse> {
   const result = await authSession.requestPasswordReset(args);
-  if (!result.ok) {
-    throw new Error(result.error.message);
-  }
-  return result.value;
+  return unwrapAuthResult(result);
 }
 
 export async function confirmPasswordReset(args: {
@@ -126,10 +119,7 @@ export async function confirmPasswordReset(args: {
   confirmPassword: string;
 }): Promise<ResetPasswordResponse> {
   const result = await authSession.confirmPasswordReset(args);
-  if (!result.ok) {
-    throw new Error(result.error.message);
-  }
-  return result.value;
+  return unwrapAuthResult(result);
 }
 
 export { createBrowserAuthSessionStorageAdapter };


### PR DESCRIPTION
## Why
Extract platform-specific login response logic to PlatformTokenHandler. Follow-up commits refine the branch before merging `feat/deepen-backend-auth-seam-for-controller-modules` into `main`.

## Changes
- Move login response construction from AuthController to a dedicated helper
- Leverage @myorganizer/auth for client type resolution and refresh token logic
- Add unit tests for PlatformTokenHandler covering mobile and web paths
- Refs #190
- Add requireUserId guard, replace manual JWT and cron header checks in YouTubeController, unify 401 responses, and add cron sync-and-notify integration tests. Refs #189
- Replace private getUserId with AuthGuard.requireUserId in VaultController and VaultBackupController.
- Standardize 401 Unauthorized responses and error handling across 9 vault endpoints.
- Add integration tests for auth requirements, 401 body consistency, and missing user ID scenarios.
- Refs #188
- Add focused coverage for requireUserId, getAuthenticatedUser, and UnauthorizedError so auth boundary behavior stays stable as the backend auth seam is deepened for Issue #187.

## Validation
- Generated from 4 commit(s) on `feat/deepen-backend-auth-seam-for-controller-modules`.
- Compared against base branch `main`.

## Linked Issues
Closes #186
Closes #191
