### PR TITLE
feat(backend): implement platform admin foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ REFRESH_JWT_SECRET=
 VERIFY_JWT_SECRET=
 RESET_JWT_SECRET=
 
+# Optional: elevate an existing User (by email) to platform_admin on backend startup.
+# Idempotent; does not create the account. Leave empty after the first admin exists.
+PLATFORM_ADMIN_BOOTSTRAP_EMAIL=
+
 # Server
 NODE_ENV=development
 PORT=3000

--- a/apps/backend/src/bootstrap/platformAdminBootstrap.test.ts
+++ b/apps/backend/src/bootstrap/platformAdminBootstrap.test.ts
@@ -1,0 +1,101 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals';
+
+jest.mock('../services/UserService', () => ({
+  __esModule: true,
+  default: {
+    elevateToPlatformAdminByEmail: jest.fn(),
+  },
+}));
+
+const userService = require('../services/UserService').default as {
+  elevateToPlatformAdminByEmail: jest.MockedFunction<
+    (
+      email: string,
+    ) => Promise<{ id: string; email: string; role: string } | null>
+  >;
+};
+const { bootstrapPlatformAdminFromEnv } =
+  require('./platformAdminBootstrap') as {
+    bootstrapPlatformAdminFromEnv: () => Promise<void>;
+  };
+
+const elevateMock = userService.elevateToPlatformAdminByEmail;
+
+describe('bootstrapPlatformAdminFromEnv', () => {
+  let warnSpy: jest.SpiedFunction<typeof console.warn>;
+  let logSpy: jest.SpiedFunction<typeof console.log>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.PLATFORM_ADMIN_BOOTSTRAP_EMAIL;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  test('no-ops when PLATFORM_ADMIN_BOOTSTRAP_EMAIL is unset', async () => {
+    await bootstrapPlatformAdminFromEnv();
+
+    expect(elevateMock).not.toHaveBeenCalled();
+  });
+
+  test('no-ops when PLATFORM_ADMIN_BOOTSTRAP_EMAIL is empty or whitespace', async () => {
+    process.env.PLATFORM_ADMIN_BOOTSTRAP_EMAIL = '   ';
+
+    await bootstrapPlatformAdminFromEnv();
+
+    expect(elevateMock).not.toHaveBeenCalled();
+  });
+
+  test('calls elevateToPlatformAdminByEmail with trimmed email when set', async () => {
+    process.env.PLATFORM_ADMIN_BOOTSTRAP_EMAIL = '  admin@example.com  ';
+    elevateMock.mockResolvedValueOnce({
+      id: 'admin-1',
+      email: 'admin@example.com',
+      role: 'platform_admin',
+    });
+
+    await bootstrapPlatformAdminFromEnv();
+
+    expect(elevateMock).toHaveBeenCalledWith('admin@example.com');
+  });
+
+  test('warns and does not throw when elevate returns null', async () => {
+    process.env.PLATFORM_ADMIN_BOOTSTRAP_EMAIL = 'missing@example.com';
+    elevateMock.mockResolvedValueOnce(null);
+
+    await expect(bootstrapPlatformAdminFromEnv()).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[bootstrap] PLATFORM_ADMIN_BOOTSTRAP_EMAIL=missing@example.com did not match any User; skipping elevation.',
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  test('logs success when elevated user is returned', async () => {
+    process.env.PLATFORM_ADMIN_BOOTSTRAP_EMAIL = 'admin@example.com';
+    elevateMock.mockResolvedValueOnce({
+      id: 'admin-1',
+      email: 'admin@example.com',
+      role: 'platform_admin',
+    });
+
+    await bootstrapPlatformAdminFromEnv();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '[bootstrap] Platform Admin ready for admin@example.com (role=platform_admin).',
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/bootstrap/platformAdminBootstrap.ts
+++ b/apps/backend/src/bootstrap/platformAdminBootstrap.ts
@@ -1,0 +1,28 @@
+import userService from '../services/UserService';
+
+/**
+ * Idempotently elevate PLATFORM_ADMIN_BOOTSTRAP_EMAIL to platform_admin when set.
+ * Does not create Users — the account must already exist (e.g. via normal register).
+ */
+export async function bootstrapPlatformAdminFromEnv(): Promise<void> {
+  const raw = process.env.PLATFORM_ADMIN_BOOTSTRAP_EMAIL;
+  if (!raw || !raw.trim()) {
+    return;
+  }
+
+  const email = raw.trim();
+  try {
+    const elevated = await userService.elevateToPlatformAdminByEmail(email);
+    if (!elevated) {
+      console.warn(
+        `[bootstrap] PLATFORM_ADMIN_BOOTSTRAP_EMAIL=${email} did not match any User; skipping elevation.`,
+      );
+      return;
+    }
+    console.log(
+      `[bootstrap] Platform Admin ready for ${elevated.email} (role=${elevated.role}).`,
+    );
+  } catch (err) {
+    console.error('[bootstrap] Failed to elevate Platform Admin:', err);
+  }
+}

--- a/apps/backend/src/controllers/AdminUsersController.int.test.ts
+++ b/apps/backend/src/controllers/AdminUsersController.int.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import bodyParser from 'body-parser';
+import express from 'express';
+import request from 'supertest';
+import { ValidateError } from 'tsoa';
+
+jest.setTimeout(30_000);
+
+jest.mock('../helpers/PlatformTokenHandler', () => ({
+  __esModule: true,
+  PlatformTokenHandler: {
+    buildLoginResponse: jest.fn(),
+  },
+  default: {
+    buildLoginResponse: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/passport', () => ({
+  __esModule: true,
+  default: {
+    authenticate: () => (_req: any, _res: any, next: any) => next(),
+  },
+}));
+
+jest.mock('../middleware/authentication', () => {
+  return {
+    expressAuthentication: async (
+      req: any,
+      _securityName: string,
+      scopes?: string[],
+    ) => {
+      const authHeader = req?.headers?.authorization;
+      if (!authHeader) {
+        const err = new Error('Unauthorized') as Error & { status?: number };
+        err.status = 401;
+        throw err;
+      }
+
+      const token = authHeader.startsWith('Bearer ')
+        ? authHeader.slice('Bearer '.length)
+        : authHeader;
+
+      if (token === 'disabled') {
+        const err = new Error('Account disabled') as Error & {
+          status?: number;
+        };
+        err.status = 401;
+        throw err;
+      }
+
+      if (token === 'user') {
+        if (scopes?.includes('platform_admin')) {
+          const err = new Error('Platform Admin role required') as Error & {
+            status?: number;
+          };
+          err.status = 403;
+          throw err;
+        }
+        req.user = { id: 'user-1', role: 'user', disabled: false };
+        return req.user;
+      }
+
+      if (token === 'admin') {
+        req.user = { id: 'admin-1', role: 'platform_admin', disabled: false };
+        return req.user;
+      }
+
+      const err = new Error('Unauthorized') as Error & { status?: number };
+      err.status = 401;
+      throw err;
+    },
+  };
+});
+
+jest.mock('../services/UserService', () => ({
+  __esModule: true,
+  default: {
+    listIdentityUsers: jest.fn(),
+    getIdentityById: jest.fn(),
+  },
+}));
+
+jest.mock('../services/VaultService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/VaultBackupService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/YouTubeNotificationService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/YouTubeSyncService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+function makeApp() {
+  jest.resetModules();
+
+  const { RegisterRoutes } = require('../routes/routes');
+
+  const app = express();
+  app.use(bodyParser.json({ limit: '2mb' }));
+  RegisterRoutes(app);
+
+  app.use(function tsoaErrorHandler(
+    err: unknown,
+    _req: any,
+    res: any,
+    next: any,
+  ) {
+    if (err instanceof ValidateError) {
+      return res.status(422).json({
+        message: 'Validation Failed',
+        details: err?.fields,
+      });
+    }
+
+    const anyErr = err as any;
+    if (
+      anyErr &&
+      typeof anyErr === 'object' &&
+      typeof anyErr.status === 'number'
+    ) {
+      return res.status(anyErr.status).json({ message: anyErr.message });
+    }
+
+    if (err instanceof Error) {
+      return res.status(500).json({ message: 'Internal Server Error' });
+    }
+
+    return next(err);
+  });
+
+  return app;
+}
+
+const identityRow = {
+  id: 'u1',
+  name: 'Alice Example',
+  first_name: 'Alice',
+  last_name: 'Example',
+  phone: null,
+  email: 'alice@example.com',
+  role: 'user',
+  disabled: false,
+  email_verification_timestamp: new Date('2024-01-01'),
+  password: 'secret-hash',
+  blacklisted_tokens: ['old-token'],
+  reset_password_token: 'reset-token',
+  email_verification_token: 'verify-token',
+  youtube_access_token: 'yt-token',
+  encrypted_vault: 'vault-ciphertext',
+};
+
+const sensitiveFields = [
+  'password',
+  'blacklisted_tokens',
+  'reset_password_token',
+  'email_verification_token',
+  'youtube_access_token',
+  'encrypted_vault',
+];
+
+describe('AdminUsersController (HTTP integration)', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = makeApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /admin/users', () => {
+    test('returns 401 when unauthenticated', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app).get('/admin/users');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(userService.listIdentityUsers).not.toHaveBeenCalled();
+    });
+
+    test('returns 403 for authenticated non-platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app)
+        .get('/admin/users')
+        .set('Authorization', 'Bearer user');
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ message: 'Platform Admin role required' });
+      expect(userService.listIdentityUsers).not.toHaveBeenCalled();
+    });
+
+    test('returns 401 when bearer account is disabled', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app)
+        .get('/admin/users')
+        .set('Authorization', 'Bearer disabled');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Account disabled' });
+      expect(userService.listIdentityUsers).not.toHaveBeenCalled();
+    });
+
+    test('returns 200 with identity DTOs for platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.listIdentityUsers.mockResolvedValueOnce([identityRow]);
+
+      const res = await request(app)
+        .get('/admin/users')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.listIdentityUsers).toHaveBeenCalledWith(undefined);
+      expect(res.body).toEqual([
+        {
+          id: 'u1',
+          name: 'Alice Example',
+          email: 'alice@example.com',
+          firstName: 'Alice',
+          lastName: 'Example',
+          role: 'user',
+          disabled: false,
+          emailVerified: true,
+        },
+      ]);
+    });
+
+    test('passes search query to listIdentityUsers', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.listIdentityUsers.mockResolvedValueOnce([]);
+
+      const res = await request(app)
+        .get('/admin/users')
+        .query({ q: 'alice' })
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.listIdentityUsers).toHaveBeenCalledWith('alice');
+    });
+
+    test('returns identity-only fields without sensitive data', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.listIdentityUsers.mockResolvedValueOnce([identityRow]);
+
+      const res = await request(app)
+        .get('/admin/users')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+
+      const item = res.body[0];
+      expect(Object.keys(item).sort()).toEqual(
+        [
+          'disabled',
+          'email',
+          'emailVerified',
+          'firstName',
+          'id',
+          'lastName',
+          'name',
+          'role',
+        ].sort(),
+      );
+      for (const field of sensitiveFields) {
+        expect(item).not.toHaveProperty(field);
+      }
+    });
+  });
+
+  describe('GET /admin/users/:userId', () => {
+    test('returns 401 when unauthenticated', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app).get('/admin/users/u1');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(userService.getIdentityById).not.toHaveBeenCalled();
+    });
+
+    test('returns 403 for authenticated non-platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app)
+        .get('/admin/users/u1')
+        .set('Authorization', 'Bearer user');
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ message: 'Platform Admin role required' });
+      expect(userService.getIdentityById).not.toHaveBeenCalled();
+    });
+
+    test('returns 200 with identity DTO when user found', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.getIdentityById.mockResolvedValueOnce(identityRow);
+
+      const res = await request(app)
+        .get('/admin/users/u1')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.getIdentityById).toHaveBeenCalledWith('u1');
+      expect(res.body).toEqual({
+        id: 'u1',
+        name: 'Alice Example',
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'Example',
+        role: 'user',
+        disabled: false,
+        emailVerified: true,
+      });
+      for (const field of sensitiveFields) {
+        expect(res.body).not.toHaveProperty(field);
+      }
+    });
+
+    test('returns 404 when user not found', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.getIdentityById.mockResolvedValueOnce(null);
+
+      const res = await request(app)
+        .get('/admin/users/u1')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ message: 'User not found' });
+      expect(userService.getIdentityById).toHaveBeenCalledWith('u1');
+    });
+  });
+});

--- a/apps/backend/src/controllers/AdminUsersController.ts
+++ b/apps/backend/src/controllers/AdminUsersController.ts
@@ -1,0 +1,74 @@
+import {
+  Controller,
+  Get,
+  Path,
+  Query,
+  Request,
+  Res,
+  Response,
+  Route,
+  Security,
+  Tags,
+  TsoaResponse,
+} from 'tsoa';
+import { Request as ExRequest } from 'express';
+import {
+  ForbiddenError,
+  UnauthorizedError,
+  requirePlatformAdmin,
+} from '../guards/AuthGuard';
+import { toAdminUserIdentity } from '../helpers/filterUser';
+import userService from '../services/UserService';
+import { AdminUserIdentity } from '../types';
+
+@Tags('Platform Admin')
+@Route('/admin/users')
+@Security('jwt', ['platform_admin'])
+export class AdminUsersController extends Controller {
+  /**
+   * List/search Users (identity fields only). Platform Admin only.
+   */
+  @Get()
+  async listUsers(
+    @Request() req: ExRequest,
+    @Query() q?: string,
+  ): Promise<AdminUserIdentity[]> {
+    this.assertPlatformAdmin(req);
+    const users = await userService.listIdentityUsers(q);
+    return users.map((user) => toAdminUserIdentity(user));
+  }
+
+  /**
+   * Get a User by id (identity fields only). Platform Admin only.
+   */
+  @Get('{userId}')
+  @Response(404, 'User not found')
+  async getUserById(
+    @Request() req: ExRequest,
+    @Path() userId: string,
+    @Res() notFound: TsoaResponse<404, { message: string }>,
+  ): Promise<AdminUserIdentity> {
+    this.assertPlatformAdmin(req);
+    const user = await userService.getIdentityById(userId);
+    if (!user) {
+      return notFound(404, { message: 'User not found' });
+    }
+    return toAdminUserIdentity(user);
+  }
+
+  private assertPlatformAdmin(req: ExRequest): void {
+    try {
+      requirePlatformAdmin(req);
+    } catch (err) {
+      if (err instanceof UnauthorizedError) {
+        this.setStatus(401);
+        throw err;
+      }
+      if (err instanceof ForbiddenError) {
+        this.setStatus(403);
+        throw err;
+      }
+      throw err;
+    }
+  }
+}

--- a/apps/backend/src/controllers/AuthController.ts
+++ b/apps/backend/src/controllers/AuthController.ts
@@ -50,6 +50,7 @@ export class AuthController extends Controller {
   async login(
     @Request() req: ExRequest,
     @Body() requestBody: UserLoginBody,
+    @Res() unauthorized: TsoaResponse<401, { message: string }>,
   ): Promise<{
     token: string;
     expires_in: number;
@@ -58,6 +59,10 @@ export class AuthController extends Controller {
   }> {
     void requestBody;
     const requestUser = req.user as UserInterface;
+
+    if (requestUser?.disabled) {
+      return unauthorized(401, { message: 'Account disabled' });
+    }
 
     try {
       const response = PlatformTokenHandler.buildLoginResponse(
@@ -125,6 +130,10 @@ export class AuthController extends Controller {
     const user = await userService.refreshToken(refresh_token);
     if (user instanceof Error || !user) {
       return notFound(404, { message: 'User not found' });
+    }
+
+    if ((user as { disabled?: boolean }).disabled) {
+      return unauthorized(401, { message: 'Account disabled' });
     }
 
     if (user.blacklisted_tokens?.includes(refresh_token)) {

--- a/apps/backend/src/controllers/UserController.ts
+++ b/apps/backend/src/controllers/UserController.ts
@@ -1,99 +1,14 @@
-import {
-  Controller,
-  Get,
-  Middlewares,
-  Path,
-  Post,
-  Response,
-  Route,
-  Security,
-  Tags,
-} from 'tsoa';
-import { Body, ValidateBody } from '../decorators/request-body-validator';
-import filterUser from '../helpers/filterUser';
-import { ValidateErrorJSON } from '../interfaces';
-import { User, UserCreationBody } from '../models/User';
-import { UserSchema } from '../schemas/user.schema';
-import userService from '../services/UserService';
-import { FilteredUserInterface, UserInterface } from '../types';
-import passport from '../utils/passport';
-
-@Tags('Users Management')
-@Route('/user')
-export class UserController extends Controller {
-  @Get()
-  @Middlewares([passport.authenticate('jwt', { session: false })])
-  @Security('jwt')
-  async getAllUsers(): Promise<User[]> {
-    return userService.getAll();
-  }
-
-  @Get('{userId}')
-  async getUserById(@Path() userId: string): Promise<User | null> {
-    return userService.getById(userId);
-  }
-
-  @Post()
-  @Response<ValidateErrorJSON>(422, 'Validation Failed') // Custom error response
-  @Response(201, 'Created') // Custom success response
-  @ValidateBody(UserSchema)
-  async createUser(
-    @Body() requestBody: UserCreationBody
-  ): Promise<FilteredUserInterface> {
-    const existing = await userService.getByEmail(requestBody.email);
-    if (existing) {
-      const isVerified = Boolean(
-        (existing as any)?.email_verification_timestamp
-      );
-      if (isVerified) {
-        this.setStatus(409);
-        throw new Error('Email already registered');
-      }
-
-      const token = await userService.sendVerificationMail(existing);
-      if (token instanceof Error) {
-        if (token.message.includes('already sent recently')) {
-          this.setStatus(429);
-          throw new Error(
-            'A verification email was already sent recently. Please try again later.'
-          );
-        }
-
-        this.setStatus(500);
-        throw new Error('Failed to send verification email');
-      }
-
-      await userService.update(existing.id, {
-        email_verification_token: token,
-      });
-
-      this.setStatus(200);
-      return filterUser(existing as UserInterface);
-    }
-
-    const user = await userService.create(requestBody);
-    const token = await userService.sendVerificationMail(user);
-    if (token instanceof Error) {
-      try {
-        await userService.deleteById(user.id);
-      } catch {
-        // best-effort rollback
-      }
-      this.setStatus(500);
-      throw token;
-    }
-
-    await userService.update(user.id, {
-      email_verification_token: token,
-    });
-
-    this.setStatus(201); // Set return status 201
-    return filterUser(user as UserInterface);
-  }
-
-  async findUserByEmail(email: string): Promise<User | null> {
-    return userService.getByEmail(email);
-  }
+/**
+ * Legacy `/user` HTTP surfaces have been removed (ADR-0011 / issue #198).
+ * Registration lives at `POST /auth/register`.
+ * Platform Admin directory lives at `GET /admin/users` and `GET /admin/users/{userId}`.
+ *
+ * This module remains only so existing imports (e.g. service helpers used by auth
+ * tests that mocked UserController) do not break at compile time if reintroduced.
+ * It intentionally exposes no TSOA routes.
+ */
+export class UserController {
+  // no HTTP endpoints
 }
 
 const userController = new UserController();

--- a/apps/backend/src/controllers/VaultBackupController.int.test.ts
+++ b/apps/backend/src/controllers/VaultBackupController.int.test.ts
@@ -58,8 +58,10 @@ jest.mock('../services/VaultBackupService', () => {
     VaultBackupService: jest.fn(),
     VAULT_BACKUP_BLOB_TYPES: [
       'addresses',
+      'groceries',
       'mobileNumbers',
       'subscriptions',
+      'tasks',
       'todos',
     ],
   };

--- a/apps/backend/src/guards/AuthGuard.test.ts
+++ b/apps/backend/src/guards/AuthGuard.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from '@jest/globals';
 import type * as express from 'express';
 
 import {
+  ForbiddenError,
   getAuthenticatedUser,
+  isPlatformAdmin,
+  requirePlatformAdmin,
   requireUserId,
   UnauthorizedError,
 } from './AuthGuard';
@@ -38,6 +41,76 @@ describe('UnauthorizedError', () => {
     expect(error.status).toBe(401);
     expect(error.name).toBe('UnauthorizedError');
     expect(error.message).toBe('Unauthorized');
+  });
+});
+
+describe('ForbiddenError', () => {
+  test('has status 403, name, and default message', () => {
+    const error = new ForbiddenError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ForbiddenError);
+    expect(error.status).toBe(403);
+    expect(error.name).toBe('ForbiddenError');
+    expect(error.message).toBe('Forbidden');
+  });
+});
+
+describe('isPlatformAdmin', () => {
+  test('returns true when role is platform_admin', () => {
+    expect(isPlatformAdmin({ role: 'platform_admin' })).toBe(true);
+  });
+
+  test('returns false for user role or missing role', () => {
+    expect(isPlatformAdmin({ role: 'user' })).toBe(false);
+    expect(isPlatformAdmin({})).toBe(false);
+  });
+});
+
+describe('requirePlatformAdmin', () => {
+  test('returns user when role is platform_admin and not disabled', () => {
+    const user = makeUser({ role: 'platform_admin', disabled: false });
+    const req = makeReq();
+    (req as express.Request & { user?: UserInterface }).user = user;
+
+    expect(requirePlatformAdmin(req)).toBe(user);
+  });
+
+  test('throws ForbiddenError when role is user', () => {
+    const user = makeUser({ role: 'user' });
+    const req = makeReq();
+    (req as express.Request & { user?: UserInterface }).user = user;
+
+    expect(() => requirePlatformAdmin(req)).toThrow(ForbiddenError);
+    expect(() => requirePlatformAdmin(req)).toThrow(
+      expect.objectContaining({
+        status: 403,
+        message: 'Platform Admin role required',
+      }),
+    );
+  });
+
+  test('throws UnauthorizedError when platform_admin is disabled', () => {
+    const user = makeUser({ role: 'platform_admin', disabled: true });
+    const req = makeReq();
+    (req as express.Request & { user?: UserInterface }).user = user;
+
+    expect(() => requirePlatformAdmin(req)).toThrow(UnauthorizedError);
+    expect(() => requirePlatformAdmin(req)).toThrow(
+      expect.objectContaining({
+        status: 401,
+        message: 'Account disabled',
+      }),
+    );
+  });
+
+  test('throws UnauthorizedError when no user is present', () => {
+    const req = makeReq();
+
+    expect(() => requirePlatformAdmin(req)).toThrow(UnauthorizedError);
+    expect(() => requirePlatformAdmin(req)).toThrow(
+      expect.objectContaining({ status: 401, message: 'Unauthorized' }),
+    );
   });
 });
 

--- a/apps/backend/src/guards/AuthGuard.ts
+++ b/apps/backend/src/guards/AuthGuard.ts
@@ -1,5 +1,5 @@
 import { Request as ExRequest } from 'express';
-import { UserInterface } from '../types';
+import { UserInterface, UserRole } from '../types';
 
 export class UnauthorizedError extends Error {
   status = 401;
@@ -7,6 +7,15 @@ export class UnauthorizedError extends Error {
   constructor(message = 'Unauthorized') {
     super(message);
     this.name = 'UnauthorizedError';
+  }
+}
+
+export class ForbiddenError extends Error {
+  status = 403;
+
+  constructor(message = 'Forbidden') {
+    super(message);
+    this.name = 'ForbiddenError';
   }
 }
 
@@ -24,4 +33,21 @@ export function requireUserId(req: ExRequest): string {
     throw new UnauthorizedError();
   }
   return user.id;
+}
+
+export function isPlatformAdmin(
+  user: UserInterface | { role?: UserRole },
+): boolean {
+  return user.role === 'platform_admin';
+}
+
+export function requirePlatformAdmin(req: ExRequest): UserInterface {
+  const user = getAuthenticatedUser(req);
+  if (!isPlatformAdmin(user)) {
+    throw new ForbiddenError('Platform Admin role required');
+  }
+  if (user.disabled) {
+    throw new UnauthorizedError('Account disabled');
+  }
+  return user;
 }

--- a/apps/backend/src/helpers/PlatformTokenHandler.spec.ts
+++ b/apps/backend/src/helpers/PlatformTokenHandler.spec.ts
@@ -38,6 +38,8 @@ describe('PlatformTokenHandler', () => {
     email: 'test@example.com',
     firstName: 'Test',
     lastName: 'User',
+    role: 'user',
+    disabled: false,
   };
 
   beforeEach(() => {

--- a/apps/backend/src/helpers/filterUser.test.ts
+++ b/apps/backend/src/helpers/filterUser.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from '@jest/globals';
+
+import filterUser, { toAdminUserIdentity } from './filterUser';
+import type { UserInterface } from '../types';
+
+function makeUser(overrides: Partial<UserInterface> = {}): UserInterface {
+  return {
+    id: 'u1',
+    name: 'Alice Example',
+    email: 'alice@example.com',
+    password: 'hashed',
+    password_reset_token: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    first_name: 'Alice',
+    last_name: 'Example',
+    ...overrides,
+  };
+}
+
+describe('filterUser', () => {
+  test('includes role and disabled with defaults when missing', () => {
+    const result = filterUser(makeUser());
+
+    expect(result.role).toBe('user');
+    expect(result.disabled).toBe(false);
+  });
+
+  test('preserves platform_admin role and disabled flag', () => {
+    const result = filterUser(
+      makeUser({ role: 'platform_admin', disabled: true } as UserInterface),
+    );
+
+    expect(result.role).toBe('platform_admin');
+    expect(result.disabled).toBe(true);
+  });
+});
+
+describe('toAdminUserIdentity', () => {
+  test('maps snake_case fields and emailVerified from email_verification_timestamp', () => {
+    const result = toAdminUserIdentity({
+      id: 'u1',
+      name: 'Alice Example',
+      first_name: 'Alice',
+      last_name: 'Example',
+      email: 'alice@example.com',
+      phone: null,
+      role: 'user',
+      disabled: false,
+      email_verification_timestamp: new Date('2024-01-01'),
+    });
+
+    expect(result).toEqual({
+      id: 'u1',
+      name: 'Alice Example',
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Example',
+      phone: undefined,
+      role: 'user',
+      disabled: false,
+      emailVerified: true,
+    });
+  });
+
+  test('emailVerified is false when email_verification_timestamp is absent', () => {
+    const result = toAdminUserIdentity({
+      id: 'u2',
+      name: 'Bob',
+      first_name: 'Bob',
+      last_name: 'User',
+      email: 'bob@example.com',
+    });
+
+    expect(result.emailVerified).toBe(false);
+  });
+});

--- a/apps/backend/src/helpers/filterUser.ts
+++ b/apps/backend/src/helpers/filterUser.ts
@@ -1,9 +1,62 @@
-import { FilteredUserInterface, UserInterface } from '../types';
+import {
+  AdminUserIdentity,
+  FilteredUserInterface,
+  UserInterface,
+  UserRole,
+} from '../types';
+
+function resolveRole(user: UserInterface | Record<string, unknown>): UserRole {
+  const role = (user as { role?: unknown }).role;
+  return role === 'platform_admin' ? 'platform_admin' : 'user';
+}
+
+function resolveDisabled(
+  user: UserInterface | Record<string, unknown>,
+): boolean {
+  return Boolean((user as { disabled?: unknown }).disabled);
+}
 
 export default (user: UserInterface): FilteredUserInterface => {
   const { id, name, email } = user;
   const firstName = (user.first_name ?? '').trim();
   const lastName = (user.last_name ?? '').trim();
   const phone = user.phone ?? undefined;
-  return { id, name, email, firstName, lastName, phone };
+  return {
+    id,
+    name,
+    email,
+    firstName,
+    lastName,
+    phone,
+    role: resolveRole(user),
+    disabled: resolveDisabled(user),
+  };
 };
+
+export function toAdminUserIdentity(
+  user: UserInterface | Record<string, unknown>,
+): AdminUserIdentity {
+  const record = user as UserInterface & {
+    first_name?: string;
+    last_name?: string;
+    email_verification_timestamp?: Date | null;
+  };
+  const firstName = (record.first_name ?? '').trim();
+  const lastName = (record.last_name ?? '').trim();
+  const phone = record.phone ?? undefined;
+  const emailVerified = Boolean(
+    record.email_verification_timestamp ?? record.email_verified_at,
+  );
+
+  return {
+    id: record.id,
+    name: record.name ?? `${firstName} ${lastName}`.trim(),
+    email: record.email,
+    firstName,
+    lastName,
+    phone,
+    role: resolveRole(record),
+    disabled: resolveDisabled(record),
+    emailVerified,
+  };
+}

--- a/apps/backend/src/main.test.ts
+++ b/apps/backend/src/main.test.ts
@@ -42,8 +42,9 @@ describe('Main Application', () => {
     );
   });
 
-  it('should register /users route', async () => {
+  it('returns 404 for legacy /user route (closed per ADR-0011)', async () => {
     const response = await request(app).get('/api/v1/user');
-    expect(response.status).not.toBe(404);
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Not Found' });
   });
 });

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -16,6 +16,7 @@ import { ValidateError } from 'tsoa';
 import { createCorsOptions, getSessionSecret } from './config/http';
 import { maybeCreateGlobalApiRateLimiterFromEnv } from './middleware/globalRateLimit';
 import { vaultRateLimiter } from './middleware/vaultRateLimit';
+import { bootstrapPlatformAdminFromEnv } from './bootstrap/platformAdminBootstrap';
 import authRouter from './routes/auth';
 import { RegisterRoutes } from './routes/routes';
 import usersRouter from './routes/user';
@@ -245,6 +246,7 @@ app.use(function errorHandler(
 const port = process.env.PORT || 3000;
 const server = app.listen(port, () => {
   console.log(`Listening at: http://localhost:${port}/`);
+  void bootstrapPlatformAdminFromEnv();
 });
 server.on('error', console.error);
 

--- a/apps/backend/src/middleware/authentication.test.ts
+++ b/apps/backend/src/middleware/authentication.test.ts
@@ -150,6 +150,55 @@ describe('expressAuthentication (tsoa jwt)', () => {
       'Unauthorized',
     );
   });
+
+  test('rejects disabled user with 401 Account disabled', async () => {
+    decodeTokenMock.mockReturnValue({ userId: 'u1' });
+    getByIdMock.mockResolvedValue({ id: 'u1', disabled: true });
+
+    const req = makeReq({ headers: { authorization: 'Bearer abc' } });
+
+    await expect(expressAuthentication(req, 'jwt')).rejects.toMatchObject({
+      status: 401,
+      message: 'Account disabled',
+    });
+  });
+
+  test('rejects non-admin when scopes include platform_admin', async () => {
+    decodeTokenMock.mockReturnValue({ userId: 'u1' });
+    getByIdMock.mockResolvedValue({ id: 'u1', role: 'user', disabled: false });
+
+    const req = makeReq({ headers: { authorization: 'Bearer abc' } });
+
+    await expect(
+      expressAuthentication(req, 'jwt', ['platform_admin']),
+    ).rejects.toMatchObject({
+      status: 403,
+      message: 'Platform Admin role required',
+    });
+  });
+
+  test('allows platform_admin when scopes include platform_admin', async () => {
+    decodeTokenMock.mockReturnValue({ userId: 'admin-1' });
+    getByIdMock.mockResolvedValue({
+      id: 'admin-1',
+      role: 'platform_admin',
+      disabled: false,
+    });
+
+    const req = makeReq({ headers: { authorization: 'Bearer abc' } });
+    const user = await expressAuthentication(req, 'jwt', ['platform_admin']);
+
+    expect(user).toEqual({
+      id: 'admin-1',
+      role: 'platform_admin',
+      disabled: false,
+    });
+    expect((req as any).user).toEqual({
+      id: 'admin-1',
+      role: 'platform_admin',
+      disabled: false,
+    });
+  });
 });
 
 describe('expressAuthentication (tsoa cron-secret)', () => {

--- a/apps/backend/src/middleware/authentication.ts
+++ b/apps/backend/src/middleware/authentication.ts
@@ -9,6 +9,12 @@ function unauthorized(message = 'Unauthorized') {
   return err;
 }
 
+function forbidden(message = 'Forbidden') {
+  const err = new Error(message) as Error & { status?: number };
+  err.status = 403;
+  return err;
+}
+
 function getBearerToken(request: express.Request): string | undefined {
   const header = request.headers.authorization;
   if (typeof header !== 'string') return undefined;
@@ -74,6 +80,16 @@ export function expressAuthentication(
       throw unauthorized();
     }
 
+    if ((user as { disabled?: boolean }).disabled) {
+      throw unauthorized('Account disabled');
+    }
+
+    if (scopes?.includes('platform_admin')) {
+      if ((user as { role?: string }).role !== 'platform_admin') {
+        throw forbidden('Platform Admin role required');
+      }
+    }
+
     // Ensure downstream authZ can consistently rely on request.user.
     (request as any).user = user;
 
@@ -88,7 +104,8 @@ export function expressAuthentication(
       err &&
       typeof err === 'object' &&
       'status' in err &&
-      (err as { status?: unknown }).status === 401
+      ((err as { status?: unknown }).status === 401 ||
+        (err as { status?: unknown }).status === 403)
     ) {
       throw err;
     }

--- a/apps/backend/src/models/User.ts
+++ b/apps/backend/src/models/User.ts
@@ -1,3 +1,5 @@
+export type UserRole = 'user' | 'platform_admin';
+
 export interface User {
   id: string;
   name?: string;
@@ -8,7 +10,10 @@ export interface User {
   password?: string;
   reset_password_token?: string;
   email_verification_timestamp?: Date;
+  email_verification_token?: string | null;
   blacklisted_tokens?: string[];
+  role?: UserRole;
+  disabled?: boolean;
 }
 
 export interface UserCreationBody {

--- a/apps/backend/src/prisma/migrations/20260721082337_add_user_role_and_disabled/migration.sql
+++ b/apps/backend/src/prisma/migrations/20260721082337_add_user_role_and_disabled/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "UserRole" AS ENUM ('user', 'platform_admin');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "disabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "role" "UserRole" NOT NULL DEFAULT 'user';
+
+-- CreateIndex
+CREATE INDEX "User_role_idx" ON "User"("role");

--- a/apps/backend/src/prisma/schema/user.prisma
+++ b/apps/backend/src/prisma/schema/user.prisma
@@ -1,3 +1,8 @@
+enum UserRole {
+    user
+    platform_admin
+}
+
 model User {
     id                              String      @id @default(cuid()) 
     name                            String?
@@ -10,6 +15,8 @@ model User {
     email_verification_token         String?
     email_verification_timestamp    DateTime? 
     blacklisted_tokens              String[]
+    role                            UserRole    @default(user)
+    disabled                        Boolean     @default(false)
 
     encrypted_vault                  EncryptedVault?
     vault_backup_records             VaultBackupRecord[]
@@ -19,4 +26,5 @@ model User {
     youtube_notification_settings    YouTubeNotificationSettings?
 
     @@index([email])
+    @@index([role])
 }

--- a/apps/backend/src/routes/auth.test.ts
+++ b/apps/backend/src/routes/auth.test.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import request from 'supertest';
 import authRouter from './auth';
 
+import apiTokens from '../helpers/ApiTokens';
 import userController from '../controllers/UserController';
 import userService from '../services/UserService';
 import passport from '../utils/passport';
@@ -60,6 +61,8 @@ jest.mock('../helpers/filterUser', () => ({
     firstName: user.first_name || 'Test',
     lastName: user.last_name || 'User',
     phone: user.phone,
+    role: user.role === 'platform_admin' ? 'platform_admin' : 'user',
+    disabled: Boolean(user.disabled),
   })),
 }));
 
@@ -98,6 +101,93 @@ describe('Auth Routes', () => {
       expect(response.body).toEqual({
         message: 'Email not verified. Please verify your email first.',
       });
+    });
+
+    test('returns 401 when user account is disabled even if email is verified', async () => {
+      (passport.authenticate as jest.Mock).mockImplementation(
+        (_strategy: string, _options: any, cb: any) => {
+          return (_req: any, _res: any, _next: any) => {
+            cb(
+              null,
+              {
+                id: 'user-disabled',
+                email: 'disabled@example.com',
+                email_verification_timestamp: new Date(),
+                disabled: true,
+              },
+              undefined,
+            );
+          };
+        },
+      );
+
+      const response = await request(app).post('/auth/login').send({
+        email: 'disabled@example.com',
+        password: 'password',
+      });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ message: 'Account disabled' });
+      expect(apiTokens.createTokens).not.toHaveBeenCalled();
+      expect(response.headers['set-cookie']).toBeUndefined();
+    });
+
+    test('returns 200 with platform_admin role and disabled false in user payload', async () => {
+      const platformAdminUser = {
+        id: 'admin-1',
+        email: 'admin@example.com',
+        email_verification_timestamp: new Date(),
+        name: 'Platform Admin',
+        first_name: 'Platform',
+        last_name: 'Admin',
+        role: 'platform_admin',
+        disabled: false,
+      };
+
+      (passport.authenticate as jest.Mock).mockImplementation(
+        (_strategy: string, _options: any, cb: any) => {
+          return (_req: any, _res: any, _next: any) => {
+            cb(null, platformAdminUser, undefined);
+          };
+        },
+      );
+
+      const response = await request(app).post('/auth/login').send({
+        email: 'admin@example.com',
+        password: 'password',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.user.role).toBe('platform_admin');
+      expect(response.body.user.disabled).toBe(false);
+    });
+
+    test('returns 200 with default role user and disabled false when role and disabled are omitted', async () => {
+      const verifiedUser = {
+        id: 'user-default',
+        email: 'default@example.com',
+        email_verification_timestamp: new Date(),
+        name: 'Default User',
+        first_name: 'Default',
+        last_name: 'User',
+      };
+
+      (passport.authenticate as jest.Mock).mockImplementation(
+        (_strategy: string, _options: any, cb: any) => {
+          return (_req: any, _res: any, _next: any) => {
+            cb(null, verifiedUser, undefined);
+          };
+        },
+      );
+
+      const response = await request(app).post('/auth/login').send({
+        email: 'default@example.com',
+        password: 'password',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.user.role).toBe('user');
+      expect(response.body.user.disabled).toBe(false);
     });
 
     test('returns 200 with refresh_token in body when client_type is mobile', async () => {
@@ -265,6 +355,60 @@ describe('Auth Routes', () => {
   });
 
   describe('POST /auth/refresh', () => {
+    test('returns 401 and clears refresh cookie when user account is disabled', async () => {
+      (userService.refreshToken as jest.Mock).mockResolvedValue({
+        id: 'user-disabled',
+        email: 'disabled@example.com',
+        email_verification_timestamp: new Date(),
+        disabled: true,
+        blacklisted_tokens: [],
+      });
+
+      const response = await request(app)
+        .post('/auth/refresh')
+        .set('Cookie', ['refresh_cookie=refresh-token']);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ message: 'Account disabled' });
+
+      const rawSetCookie = response.headers['set-cookie'] as
+        | string
+        | string[]
+        | undefined;
+      const setCookie = Array.isArray(rawSetCookie)
+        ? rawSetCookie
+        : rawSetCookie
+          ? [rawSetCookie]
+          : [];
+
+      expect(setCookie.some((c) => c.startsWith('refresh_cookie='))).toBe(true);
+      expect(apiTokens.createTokens).not.toHaveBeenCalled();
+    });
+
+    test('returns 200 with role and disabled in user payload', async () => {
+      const verifiedUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        email_verification_timestamp: new Date(),
+        name: 'Test User',
+        first_name: 'Test',
+        last_name: 'User',
+        role: 'user',
+        disabled: false,
+        blacklisted_tokens: [],
+      };
+
+      (userService.refreshToken as jest.Mock).mockResolvedValue(verifiedUser);
+
+      const response = await request(app)
+        .post('/auth/refresh')
+        .set('Cookie', ['refresh_cookie=old-refresh-token']);
+
+      expect(response.status).toBe(200);
+      expect(response.body.user.role).toBe('user');
+      expect(response.body.user.disabled).toBe(false);
+    });
+
     test('returns 403 and clears refresh cookie when user email is not verified', async () => {
       (userService.refreshToken as jest.Mock).mockResolvedValue({
         id: 'user-1',
@@ -505,7 +649,7 @@ describe('Auth Routes', () => {
       });
       expect(userService.sendVerificationMail).toHaveBeenCalledTimes(1);
       expect(userService.update).toHaveBeenCalledTimes(1);
-      expect(userController.createUser).not.toHaveBeenCalled();
+      expect((userController as any).createUser).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -39,8 +39,14 @@ router.post(
           }
 
           const requestUser = user as UserInterface;
+
+          if (requestUser.disabled) {
+            res.status(401).json({ message: 'Account disabled' });
+            return;
+          }
+
           const isVerified = Boolean(
-            (requestUser as any)?.email_verification_timestamp
+            (requestUser as any)?.email_verification_timestamp,
           );
 
           if (!isVerified) {
@@ -88,9 +94,9 @@ router.post(
         } catch (caught) {
           next(caught);
         }
-      }
+      },
     )(req, res, next);
-  }
+  },
 );
 
 router.post(
@@ -126,7 +132,7 @@ router.post(
     } catch (err) {
       next(err);
     }
-  }
+  },
 );
 
 router.post('/register', async (req, res) => {
@@ -138,7 +144,7 @@ router.post('/register', async (req, res) => {
       const existing = await userService.getByEmail(email);
       if (existing) {
         const isVerified = Boolean(
-          (existing as any)?.email_verification_timestamp
+          (existing as any)?.email_verification_timestamp,
         );
         if (isVerified) {
           res
@@ -325,7 +331,7 @@ router.post(
         message: `Failed to resend verification email: ${error.message}`,
       });
     }
-  }
+  },
 );
 
 router.post('/verify/resend', async (req, res) => {
@@ -367,6 +373,12 @@ router.post('/refresh', async (req, res, next: NextFunction) => {
       return;
     }
 
+    if ((user as { disabled?: boolean }).disabled) {
+      res.clearCookie('refresh_cookie');
+      res.status(401).json({ message: 'Account disabled' });
+      return;
+    }
+
     const isVerified = Boolean((user as any)?.email_verification_timestamp);
     if (!isVerified) {
       res.clearCookie('refresh_cookie');
@@ -382,7 +394,7 @@ router.post('/refresh', async (req, res, next: NextFunction) => {
     }
 
     const { token, refreshToken: newRefreshToken } = apiTokens.createTokens(
-      user as unknown as UserInterface
+      user as unknown as UserInterface,
     );
 
     if (token instanceof Error || newRefreshToken instanceof Error) {
@@ -391,7 +403,7 @@ router.post('/refresh', async (req, res, next: NextFunction) => {
     }
 
     const filteredUser: FilteredUserInterface = filterUser(
-      user as unknown as UserInterface
+      user as unknown as UserInterface,
     );
 
     const expiry = getExpiry();

--- a/apps/backend/src/routes/routes.ts
+++ b/apps/backend/src/routes/routes.ts
@@ -10,9 +10,9 @@ import { VaultController } from './../controllers/VaultController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { VaultBackupController } from './../controllers/VaultBackupController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { UserController } from './../controllers/UserController';
-// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AuthController } from './../controllers/AuthController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AdminUsersController } from './../controllers/AdminUsersController';
 import { expressAuthentication } from './../middleware/authentication';
 // @ts-ignore - no great way to install types from subpackage
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
@@ -287,21 +287,9 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"VaultBackupHistoryPage"},{"ref":"ErrorResponse"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "User": {
-        "dataType": "refObject",
-        "properties": {
-            "id": {"dataType":"string","required":true},
-            "name": {"dataType":"string"},
-            "first_name": {"dataType":"string"},
-            "last_name": {"dataType":"string"},
-            "phone": {"dataType":"string"},
-            "email": {"dataType":"string","required":true},
-            "password": {"dataType":"string"},
-            "reset_password_token": {"dataType":"string"},
-            "email_verification_timestamp": {"dataType":"datetime"},
-            "blacklisted_tokens": {"dataType":"array","array":{"dataType":"string"}},
-        },
-        "additionalProperties": false,
+    "UserRole": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["user"]},{"dataType":"enum","enums":["platform_admin"]}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "FilteredUserInterface": {
@@ -313,28 +301,8 @@ const models: TsoaRoute.Models = {
             "firstName": {"dataType":"string","required":true},
             "lastName": {"dataType":"string","required":true},
             "phone": {"dataType":"string"},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ValidateErrorJSON": {
-        "dataType": "refObject",
-        "properties": {
-            "message": {"dataType":"enum","enums":["Validation failed"],"required":true},
-            "details": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"dataType":"any"},"required":true},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UserCreationBody": {
-        "dataType": "refObject",
-        "properties": {
-            "name": {"dataType":"string"},
-            "firstName": {"dataType":"string","required":true},
-            "lastName": {"dataType":"string","required":true},
-            "phone": {"dataType":"string"},
-            "email": {"dataType":"string","required":true},
-            "password": {"dataType":"string","required":true},
+            "role": {"ref":"UserRole","required":true},
+            "disabled": {"dataType":"boolean","required":true},
         },
         "additionalProperties": false,
     },
@@ -349,11 +317,33 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ValidateErrorJSON": {
+        "dataType": "refObject",
+        "properties": {
+            "message": {"dataType":"enum","enums":["Validation failed"],"required":true},
+            "details": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"dataType":"any"},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "RegisterUserResponse": {
         "dataType": "refObject",
         "properties": {
             "message": {"dataType":"string","required":true},
             "user": {"ref":"FilteredUserInterface"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UserCreationBody": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string"},
+            "firstName": {"dataType":"string","required":true},
+            "lastName": {"dataType":"string","required":true},
+            "phone": {"dataType":"string"},
+            "email": {"dataType":"string","required":true},
+            "password": {"dataType":"string","required":true},
         },
         "additionalProperties": false,
     },
@@ -372,6 +362,22 @@ const models: TsoaRoute.Models = {
             "token": {"dataType":"string","required":true},
             "password": {"dataType":"string","required":true},
             "confirm_password": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AdminUserIdentity": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "name": {"dataType":"string","required":true},
+            "email": {"dataType":"string","required":true},
+            "firstName": {"dataType":"string","required":true},
+            "lastName": {"dataType":"string","required":true},
+            "phone": {"dataType":"string"},
+            "role": {"ref":"UserRole","required":true},
+            "disabled": {"dataType":"boolean","required":true},
+            "emailVerified": {"dataType":"boolean","required":true},
         },
         "additionalProperties": false,
     },
@@ -1065,99 +1071,10 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsUserController_getAllUsers: Record<string, TsoaRoute.ParameterSchema> = {
-        };
-        app.get('/user',
-            authenticateMiddleware([{"jwt":[]}]),
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getAllUsers)),
-
-            async function UserController_getAllUsers(request: ExRequest, response: ExResponse, next: any) {
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_getAllUsers, request, response });
-
-                const controller = new UserController();
-
-              await templateService.apiHandler({
-                methodName: 'getAllUsers',
-                controller,
-                response,
-                next,
-                validatedArgs,
-                successStatus: undefined,
-              });
-            } catch (err) {
-                return next(err);
-            }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsUserController_getUserById: Record<string, TsoaRoute.ParameterSchema> = {
-                userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
-        };
-        app.get('/user/:userId',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.getUserById)),
-
-            async function UserController_getUserById(request: ExRequest, response: ExResponse, next: any) {
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_getUserById, request, response });
-
-                const controller = new UserController();
-
-              await templateService.apiHandler({
-                methodName: 'getUserById',
-                controller,
-                response,
-                next,
-                validatedArgs,
-                successStatus: undefined,
-              });
-            } catch (err) {
-                return next(err);
-            }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsUserController_createUser: Record<string, TsoaRoute.ParameterSchema> = {
-                requestBody: {"in":"body","name":"requestBody","required":true,"ref":"UserCreationBody"},
-        };
-        app.post('/user',
-            ...(fetchMiddlewares<RequestHandler>(UserController)),
-            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.createUser)),
-
-            async function UserController_createUser(request: ExRequest, response: ExResponse, next: any) {
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_createUser, request, response });
-
-                const controller = new UserController();
-
-              await templateService.apiHandler({
-                methodName: 'createUser',
-                controller,
-                response,
-                next,
-                validatedArgs,
-                successStatus: undefined,
-              });
-            } catch (err) {
-                return next(err);
-            }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsAuthController_login: Record<string, TsoaRoute.ParameterSchema> = {
                 req: {"in":"request","name":"req","required":true,"dataType":"object"},
                 requestBody: {"in":"body","name":"requestBody","required":true,"ref":"UserLoginBody"},
+                unauthorized: {"in":"res","name":"401","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
         };
         app.post('/auth/login',
             ...(fetchMiddlewares<RequestHandler>(AuthController)),
@@ -1421,6 +1338,71 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'confirmResetPassword',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminUsersController_listUsers: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                q: {"in":"query","name":"q","dataType":"string"},
+        };
+        app.get('/admin/users',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController.prototype.listUsers)),
+
+            async function AdminUsersController_listUsers(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminUsersController_listUsers, request, response });
+
+                const controller = new AdminUsersController();
+
+              await templateService.apiHandler({
+                methodName: 'listUsers',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminUsersController_getUserById: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
+                notFound: {"in":"res","name":"404","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+        };
+        app.get('/admin/users/:userId',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController.prototype.getUserById)),
+
+            async function AdminUsersController_getUserById(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminUsersController_getUserById, request, response });
+
+                const controller = new AdminUsersController();
+
+              await templateService.apiHandler({
+                methodName: 'getUserById',
                 controller,
                 response,
                 next,

--- a/apps/backend/src/routes/routes.ts
+++ b/apps/backend/src/routes/routes.ts
@@ -229,7 +229,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "VaultBackupBlobType": {
         "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["addresses"]},{"dataType":"enum","enums":["groceries"]},{"dataType":"enum","enums":["mobileNumbers"]},{"dataType":"enum","enums":["subscriptions"]},{"dataType":"enum","enums":["todos"]}],"validators":{}},
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["addresses"]},{"dataType":"enum","enums":["groceries"]},{"dataType":"enum","enums":["mobileNumbers"]},{"dataType":"enum","enums":["subscriptions"]},{"dataType":"enum","enums":["tasks"]},{"dataType":"enum","enums":["todos"]}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "VaultBackupRecordDto": {

--- a/apps/backend/src/routes/user.test.ts
+++ b/apps/backend/src/routes/user.test.ts
@@ -1,123 +1,41 @@
 import bodyParser from 'body-parser';
 import express from 'express';
 import request from 'supertest';
-import userController from '../controllers/UserController';
 import userRouter from './user';
 
 jest.mock('../utils/passport', () => ({
   __esModule: true,
   default: {
-    authenticate: () => (req: any, _res: any, next: any) => {
-      req.user = { id: 'test-user' };
-      next();
-    },
+    authenticate: () => (_req: any, _res: any, next: any) => next(),
   },
 }));
 
-jest.mock('../controllers/UserController');
-
-beforeEach(() => {
-  jest.clearAllMocks();
-});
-
 const app = express();
 app.use(bodyParser.json());
-app.use('/users', userRouter);
+// Mount at /user to match production (main.ts uses api.use('/user', usersRouter)).
+app.use('/user', userRouter);
 
-describe('User Routes', () => {
-  describe('GET /users', () => {
-    test('should return all users', async () => {
-      const users = [{ id: 1, name: 'John Doe' }];
-      (userController.getAllUsers as jest.Mock).mockResolvedValue(users);
+describe('User Routes (legacy closed)', () => {
+  test('GET /user returns 404 Not Found', async () => {
+    const response = await request(app).get('/user');
 
-      const response = await request(app).get('/users');
-
-      expect(response.status).toBe(200);
-      expect(response.body).toEqual(users);
-      expect(userController.getAllUsers).toHaveBeenCalledTimes(1);
-    });
-
-    test('should handle errors', async () => {
-      const errorMessage = 'Error fetching users';
-      (userController.getAllUsers as jest.Mock).mockRejectedValue(
-        new Error(errorMessage)
-      );
-
-      const response = await request(app).get('/users');
-
-      expect(response.status).toBe(500);
-      expect(response.body).toEqual({
-        message: `Failed to fetch users: ${errorMessage}`,
-      });
-      expect(userController.getAllUsers).toHaveBeenCalledTimes(1);
-    });
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Not Found' });
   });
 
-  describe('GET /users/:userId', () => {
-    test('should return a user by ID', async () => {
-      const user = { id: 1, name: 'John Doe' };
-      (userController.getUserById as jest.Mock).mockResolvedValue(user);
+  test('GET /user/:userId returns 404 Not Found', async () => {
+    const response = await request(app).get('/user/1');
 
-      const response = await request(app).get('/users/1');
-
-      expect(response.status).toBe(200);
-      expect(response.body).toEqual(user);
-      expect(userController.getUserById).toHaveBeenCalledTimes(1);
-      expect(userController.getUserById).toHaveBeenCalledWith('1');
-    });
-
-    test('should handle errors', async () => {
-      const errorMessage = 'Error fetching user';
-      (userController.getUserById as jest.Mock).mockRejectedValue(
-        new Error(errorMessage)
-      );
-
-      const response = await request(app).get('/users/1');
-
-      expect(response.status).toBe(500);
-      expect(response.body).toEqual({
-        message: `Failed to fetch user: ${errorMessage}`,
-      });
-      expect(userController.getUserById).toHaveBeenCalledTimes(1);
-      expect(userController.getUserById).toHaveBeenCalledWith('1');
-    });
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Not Found' });
   });
 
-  describe('POST /users', () => {
-    test('should create a new user', async () => {
-      const newUser = { id: 1, name: 'John Doe' };
-      (userController.createUser as jest.Mock).mockResolvedValue(newUser);
+  test('POST /user returns 404 Not Found', async () => {
+    const response = await request(app)
+      .post('/user')
+      .send({ name: 'John Doe' });
 
-      const response = await request(app)
-        .post('/users')
-        .send({ name: 'John Doe' });
-
-      expect(response.status).toBe(201);
-      expect(response.body).toEqual(newUser);
-      expect(userController.createUser).toHaveBeenCalledTimes(1);
-      expect(userController.createUser).toHaveBeenCalledWith({
-        name: 'John Doe',
-      });
-    });
-
-    test('should handle errors', async () => {
-      const errorMessage = 'Error creating user';
-      (userController.createUser as jest.Mock).mockRejectedValue(
-        new Error(errorMessage)
-      );
-
-      const response = await request(app)
-        .post('/users')
-        .send({ name: 'John Doe' });
-
-      expect(response.status).toBe(500);
-      expect(response.body).toEqual({
-        message: `Failed to create user: ${errorMessage}`,
-      });
-      expect(userController.createUser).toHaveBeenCalledTimes(1);
-      expect(userController.createUser).toHaveBeenCalledWith({
-        name: 'John Doe',
-      });
-    });
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Not Found' });
   });
 });

--- a/apps/backend/src/routes/user.ts
+++ b/apps/backend/src/routes/user.ts
@@ -1,43 +1,14 @@
-import { NextFunction, Router } from 'express';
-import userController from '../controllers/UserController';
-import passport from '../utils/passport';
+import { Router } from 'express';
 
+/**
+ * Legacy Express `/user` router — closed (ADR-0011).
+ * All methods return 404 so anonymous and non-admin callers cannot list/get/create Users.
+ * Prefer TSOA Platform Admin APIs under `/admin/users`.
+ */
 const router = Router();
 
-router.get(
-  '/',
-  passport.authenticate('jwt', { session: false }),
-  async (req, res, next: NextFunction) => {
-    try {
-      const users = await userController.getAllUsers();
-      res.status(200).json(users);
-    } catch (error) {
-      res
-        .status(500)
-        .json({ message: `Failed to fetch users: ${error.message}` });
-      next(error);
-    }
-  }
-);
-
-router.get('/:userId', async (req, res) => {
-  try {
-    const user = await userController.getUserById(req.params.userId);
-    res.status(200).json(user);
-  } catch (error) {
-    res.status(500).json({ message: `Failed to fetch user: ${error.message}` });
-  }
-});
-
-router.post('/', async (req, res) => {
-  try {
-    const user = await userController.createUser(req.body);
-    res.status(201).json(user);
-  } catch (error) {
-    res
-      .status(500)
-      .json({ message: `Failed to create user: ${error.message}` });
-  }
+router.use((_req, res) => {
+  res.status(404).json({ message: 'Not Found' });
 });
 
 export default router;

--- a/apps/backend/src/services/UserService.ts
+++ b/apps/backend/src/services/UserService.ts
@@ -5,19 +5,31 @@ import path from 'path';
 import apiTokens from '../helpers/ApiTokens';
 import { decodeToken } from '../helpers/jwtHelper';
 import { User, UserCreationBody } from '../models/User';
-import { PrismaClient, createPrismaClient } from '../prisma';
+import { Prisma, PrismaClient, createPrismaClient } from '../prisma';
 import sendEmail from './EmailService';
+
+/** Fields safe to return from Platform Admin directory APIs. */
+const ADMIN_IDENTITY_SELECT = {
+  id: true,
+  name: true,
+  first_name: true,
+  last_name: true,
+  phone: true,
+  email: true,
+  role: true,
+  disabled: true,
+  email_verification_timestamp: true,
+} as const;
+
+export type AdminIdentityUser = Prisma.UserGetPayload<{
+  select: typeof ADMIN_IDENTITY_SELECT;
+}>;
 
 class UserService {
   Users: User[] = [];
   SaltRounds = 10;
 
   constructor(private prisma: PrismaClient) {}
-
-  async getAll(): Promise<User[]> {
-    this.Users = await this.prisma.user.findMany();
-    return this.Users;
-  }
 
   async getById(id: string): Promise<User | null> {
     const user = await this.prisma.user.findUnique({
@@ -35,6 +47,64 @@ class UserService {
       },
     });
     return user;
+  }
+
+  /**
+   * List/search Users for Platform Admin directory (identity fields only).
+   * Optional `q` matches email, name, first_name, or last_name (case-insensitive).
+   */
+  async listIdentityUsers(q?: string): Promise<AdminIdentityUser[]> {
+    const query = (q ?? '').trim();
+    const where: Prisma.UserWhereInput = query
+      ? {
+          OR: [
+            { email: { contains: query, mode: 'insensitive' } },
+            { name: { contains: query, mode: 'insensitive' } },
+            { first_name: { contains: query, mode: 'insensitive' } },
+            { last_name: { contains: query, mode: 'insensitive' } },
+          ],
+        }
+      : {};
+
+    return this.prisma.user.findMany({
+      where,
+      select: ADMIN_IDENTITY_SELECT,
+      orderBy: [{ email: 'asc' }],
+    });
+  }
+
+  async getIdentityById(id: string): Promise<AdminIdentityUser | null> {
+    return this.prisma.user.findUnique({
+      where: { id },
+      select: ADMIN_IDENTITY_SELECT,
+    });
+  }
+
+  /**
+   * Elevate an existing User to platform_admin by email.
+   * Idempotent: no-op if already platform_admin. Returns null if no User matches.
+   */
+  async elevateToPlatformAdminByEmail(
+    email: string,
+  ): Promise<AdminIdentityUser | null> {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) return null;
+
+    const existing = await this.prisma.user.findFirst({
+      where: { email: { equals: normalized, mode: 'insensitive' } },
+      select: ADMIN_IDENTITY_SELECT,
+    });
+    if (!existing) return null;
+
+    if (existing.role === 'platform_admin') {
+      return existing;
+    }
+
+    return this.prisma.user.update({
+      where: { id: existing.id },
+      data: { role: 'platform_admin' },
+      select: ADMIN_IDENTITY_SELECT,
+    });
   }
 
   async create(user: UserCreationBody): Promise<User> {

--- a/apps/backend/src/services/vaultBackupConstants.ts
+++ b/apps/backend/src/services/vaultBackupConstants.ts
@@ -12,6 +12,7 @@ export const VAULT_BACKUP_BLOB_TYPES = [
   'groceries',
   'mobileNumbers',
   'subscriptions',
+  'tasks',
   'todos',
 ] as const;
 export type VaultBackupBlobType = (typeof VAULT_BACKUP_BLOB_TYPES)[number];

--- a/apps/backend/src/swagger/swagger.json
+++ b/apps/backend/src/swagger/swagger.json
@@ -617,46 +617,9 @@
           }
         ]
       },
-      "User": {
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "first_name": {
-            "type": "string"
-          },
-          "last_name": {
-            "type": "string"
-          },
-          "phone": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "password": {
-            "type": "string"
-          },
-          "reset_password_token": {
-            "type": "string"
-          },
-          "email_verification_timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "blacklisted_tokens": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["id", "email"],
-        "type": "object",
-        "additionalProperties": false
+      "UserRole": {
+        "type": "string",
+        "enum": ["user", "platform_admin"]
       },
       "FilteredUserInterface": {
         "properties": {
@@ -677,9 +640,40 @@
           },
           "phone": {
             "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/UserRole"
+          },
+          "disabled": {
+            "type": "boolean"
           }
         },
-        "required": ["id", "name", "email", "firstName", "lastName"],
+        "required": [
+          "id",
+          "name",
+          "email",
+          "firstName",
+          "lastName",
+          "role",
+          "disabled"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "UserLoginBody": {
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "client_type": {
+            "type": "string",
+            "enum": ["mobile", "web"]
+          }
+        },
+        "required": ["email", "password"],
         "type": "object",
         "additionalProperties": false
       },
@@ -697,6 +691,19 @@
           }
         },
         "required": ["message", "details"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "RegisterUserResponse": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/FilteredUserInterface"
+          }
+        },
+        "required": ["message"],
         "type": "object",
         "additionalProperties": false
       },
@@ -725,36 +732,6 @@
         "type": "object",
         "additionalProperties": false
       },
-      "UserLoginBody": {
-        "properties": {
-          "email": {
-            "type": "string"
-          },
-          "password": {
-            "type": "string"
-          },
-          "client_type": {
-            "type": "string",
-            "enum": ["mobile", "web"]
-          }
-        },
-        "required": ["email", "password"],
-        "type": "object",
-        "additionalProperties": false
-      },
-      "RegisterUserResponse": {
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "user": {
-            "$ref": "#/components/schemas/FilteredUserInterface"
-          }
-        },
-        "required": ["message"],
-        "type": "object",
-        "additionalProperties": false
-      },
       "ResetPasswordByEmailBody": {
         "properties": {
           "email": {
@@ -778,6 +755,50 @@
           }
         },
         "required": ["token", "password", "confirm_password"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AdminUserIdentity": {
+        "description": "Identity-only User projection for Platform Admin directory APIs.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/UserRole"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "emailVerified": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "email",
+          "firstName",
+          "lastName",
+          "role",
+          "disabled",
+          "emailVerified"
+        ],
         "type": "object",
         "additionalProperties": false
       }
@@ -1667,108 +1688,6 @@
         ]
       }
     },
-    "/user": {
-      "get": {
-        "operationId": "GetAllUsers",
-        "responses": {
-          "200": {
-            "description": "Ok",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/User"
-                  },
-                  "type": "array"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Users Management"],
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "parameters": []
-      },
-      "post": {
-        "operationId": "CreateUser",
-        "responses": {
-          "200": {
-            "description": "Ok",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FilteredUserInterface"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created"
-          },
-          "422": {
-            "description": "Validation Failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidateErrorJSON"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Users Management"],
-        "security": [],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserCreationBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/user/{userId}": {
-      "get": {
-        "operationId": "GetUserById",
-        "responses": {
-          "200": {
-            "description": "Ok",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/User"
-                    }
-                  ],
-                  "nullable": true
-                }
-              }
-            }
-          }
-        },
-        "tags": ["Users Management"],
-        "security": [],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "userId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ]
-      }
-    },
     "/auth/login": {
       "post": {
         "operationId": "Login",
@@ -2189,6 +2108,82 @@
             }
           }
         }
+      }
+    },
+    "/admin/users": {
+      "get": {
+        "operationId": "ListUsers",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AdminUserIdentity"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          }
+        },
+        "description": "List/search Users (identity fields only). Platform Admin only.",
+        "tags": ["Platform Admin"],
+        "security": [
+          {
+            "jwt": ["platform_admin"]
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/admin/users/{userId}": {
+      "get": {
+        "operationId": "GetUserById",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AdminUserIdentity"
+                    }
+                  ],
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a User by id (identity fields only). Platform Admin only.",
+        "tags": ["Platform Admin"],
+        "security": [
+          {
+            "jwt": ["platform_admin"]
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     }
   },

--- a/apps/backend/src/swagger/swagger.yaml
+++ b/apps/backend/src/swagger/swagger.yaml
@@ -470,36 +470,11 @@ components:
       anyOf:
         - $ref: "#/components/schemas/VaultBackupHistoryPage"
         - $ref: "#/components/schemas/ErrorResponse"
-    User:
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        first_name:
-          type: string
-        last_name:
-          type: string
-        phone:
-          type: string
-        email:
-          type: string
-        password:
-          type: string
-        reset_password_token:
-          type: string
-        email_verification_timestamp:
-          type: string
-          format: date-time
-        blacklisted_tokens:
-          items:
-            type: string
-          type: array
-      required:
-        - id
-        - email
-      type: object
-      additionalProperties: false
+    UserRole:
+      type: string
+      enum:
+        - user
+        - platform_admin
     FilteredUserInterface:
       properties:
         id:
@@ -514,12 +489,34 @@ components:
           type: string
         phone:
           type: string
+        role:
+          $ref: "#/components/schemas/UserRole"
+        disabled:
+          type: boolean
       required:
         - id
         - name
         - email
         - firstName
         - lastName
+        - role
+        - disabled
+      type: object
+      additionalProperties: false
+    UserLoginBody:
+      properties:
+        email:
+          type: string
+        password:
+          type: string
+        client_type:
+          type: string
+          enum:
+            - mobile
+            - web
+      required:
+        - email
+        - password
       type: object
       additionalProperties: false
     ValidateErrorJSON:
@@ -536,6 +533,16 @@ components:
       required:
         - message
         - details
+      type: object
+      additionalProperties: false
+    RegisterUserResponse:
+      properties:
+        message:
+          type: string
+        user:
+          $ref: "#/components/schemas/FilteredUserInterface"
+      required:
+        - message
       type: object
       additionalProperties: false
     UserCreationBody:
@@ -559,32 +566,6 @@ components:
         - password
       type: object
       additionalProperties: false
-    UserLoginBody:
-      properties:
-        email:
-          type: string
-        password:
-          type: string
-        client_type:
-          type: string
-          enum:
-            - mobile
-            - web
-      required:
-        - email
-        - password
-      type: object
-      additionalProperties: false
-    RegisterUserResponse:
-      properties:
-        message:
-          type: string
-        user:
-          $ref: "#/components/schemas/FilteredUserInterface"
-      required:
-        - message
-      type: object
-      additionalProperties: false
     ResetPasswordByEmailBody:
       properties:
         email:
@@ -605,6 +586,38 @@ components:
         - token
         - password
         - confirm_password
+      type: object
+      additionalProperties: false
+    AdminUserIdentity:
+      description: Identity-only User projection for Platform Admin directory APIs.
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        phone:
+          type: string
+        role:
+          $ref: "#/components/schemas/UserRole"
+        disabled:
+          type: boolean
+        emailVerified:
+          type: boolean
+      required:
+        - id
+        - name
+        - email
+        - firstName
+        - lastName
+        - role
+        - disabled
+        - emailVerified
       type: object
       additionalProperties: false
   securitySchemes:
@@ -1163,71 +1176,6 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/VaultBackupSource"
-  /user:
-    get:
-      operationId: GetAllUsers
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/User"
-                type: array
-      tags:
-        - Users Management
-      security:
-        - jwt: []
-      parameters: []
-    post:
-      operationId: CreateUser
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FilteredUserInterface"
-        "201":
-          description: Created
-        "422":
-          description: Validation Failed
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ValidateErrorJSON"
-      tags:
-        - Users Management
-      security: []
-      parameters: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserCreationBody"
-  /user/{userId}:
-    get:
-      operationId: GetUserById
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/User"
-                nullable: true
-      tags:
-        - Users Management
-      security: []
-      parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            type: string
   /auth/login:
     post:
       operationId: Login
@@ -1253,7 +1201,16 @@ paths:
                   - token
                 type: object
         "401":
-          description: Unauthorized
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
       tags:
         - Authentication
       security: []
@@ -1521,6 +1478,63 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/ConfirmResetPasswordBody"
+  /admin/users:
+    get:
+      operationId: ListUsers
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AdminUserIdentity"
+                type: array
+      description: List/search Users (identity fields only). Platform Admin only.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: query
+          name: q
+          required: false
+          schema:
+            type: string
+  /admin/users/{userId}:
+    get:
+      operationId: GetUserById
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Get a User by id (identity fields only). Platform Admin only.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
 servers:
   - url: http://localhost:3000/api/v1/
     description: Local server

--- a/apps/backend/src/swagger/swagger.yaml
+++ b/apps/backend/src/swagger/swagger.yaml
@@ -373,6 +373,7 @@ components:
         - groceries
         - mobileNumbers
         - subscriptions
+        - tasks
         - todos
     VaultBackupRecordDto:
       properties:

--- a/apps/backend/src/types/index.ts
+++ b/apps/backend/src/types/index.ts
@@ -1,3 +1,5 @@
+export type UserRole = 'user' | 'platform_admin';
+
 export interface LoginTokensInterface {
   token: string | Error;
   refreshToken: string | Error;
@@ -12,8 +14,11 @@ export interface UserInterface {
   email: string;
   password: string;
   email_verified_at?: Date;
+  email_verification_timestamp?: Date | null;
   password_reset_token: string | null;
   blacklisted_tokens?: Array<string>;
+  role?: UserRole;
+  disabled?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -25,6 +30,21 @@ export interface FilteredUserInterface {
   firstName: string;
   lastName: string;
   phone?: string;
+  role: UserRole;
+  disabled: boolean;
+}
+
+/** Identity-only User projection for Platform Admin directory APIs. */
+export interface AdminUserIdentity {
+  id: string;
+  name: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone?: string;
+  role: UserRole;
+  disabled: boolean;
+  emailVerified: boolean;
 }
 
 export class MyError extends Error {

--- a/apps/backend/src/utils/passport.ts
+++ b/apps/backend/src/utils/passport.ts
@@ -41,6 +41,11 @@ passport.use(
               message: 'Incorrect email or password!',
             });
           }
+          if ((user as { disabled?: boolean }).disabled) {
+            return done(null, false, {
+              message: 'Account disabled',
+            });
+          }
           bcrypt.compare(password, user.password, (err, result) => {
             if (err) {
               return done(err);
@@ -72,13 +77,14 @@ passport.use(
         .findFirst({
           where: { id: jwt_payload.userId },
         })
-        .then((user: User) => {
-          // if (user) {
-          //   return done(null, user)
-          // } else {
-          //   return done(null, false)
-          // }
-          return done(null, user || false);
+        .then((user: User | null) => {
+          if (!user) {
+            return done(null, false);
+          }
+          if ((user as { disabled?: boolean }).disabled) {
+            return done(null, false);
+          }
+          return done(null, user);
         })
         .catch((err: Error) => {
           return done(err, false);

--- a/libs/api-specs/src/api-specs.openapi.yaml
+++ b/libs/api-specs/src/api-specs.openapi.yaml
@@ -470,36 +470,11 @@ components:
       anyOf:
         - $ref: "#/components/schemas/VaultBackupHistoryPage"
         - $ref: "#/components/schemas/ErrorResponse"
-    User:
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        first_name:
-          type: string
-        last_name:
-          type: string
-        phone:
-          type: string
-        email:
-          type: string
-        password:
-          type: string
-        reset_password_token:
-          type: string
-        email_verification_timestamp:
-          type: string
-          format: date-time
-        blacklisted_tokens:
-          items:
-            type: string
-          type: array
-      required:
-        - id
-        - email
-      type: object
-      additionalProperties: false
+    UserRole:
+      type: string
+      enum:
+        - user
+        - platform_admin
     FilteredUserInterface:
       properties:
         id:
@@ -514,12 +489,34 @@ components:
           type: string
         phone:
           type: string
+        role:
+          $ref: "#/components/schemas/UserRole"
+        disabled:
+          type: boolean
       required:
         - id
         - name
         - email
         - firstName
         - lastName
+        - role
+        - disabled
+      type: object
+      additionalProperties: false
+    UserLoginBody:
+      properties:
+        email:
+          type: string
+        password:
+          type: string
+        client_type:
+          type: string
+          enum:
+            - mobile
+            - web
+      required:
+        - email
+        - password
       type: object
       additionalProperties: false
     ValidateErrorJSON:
@@ -536,6 +533,16 @@ components:
       required:
         - message
         - details
+      type: object
+      additionalProperties: false
+    RegisterUserResponse:
+      properties:
+        message:
+          type: string
+        user:
+          $ref: "#/components/schemas/FilteredUserInterface"
+      required:
+        - message
       type: object
       additionalProperties: false
     UserCreationBody:
@@ -559,32 +566,6 @@ components:
         - password
       type: object
       additionalProperties: false
-    UserLoginBody:
-      properties:
-        email:
-          type: string
-        password:
-          type: string
-        client_type:
-          type: string
-          enum:
-            - mobile
-            - web
-      required:
-        - email
-        - password
-      type: object
-      additionalProperties: false
-    RegisterUserResponse:
-      properties:
-        message:
-          type: string
-        user:
-          $ref: "#/components/schemas/FilteredUserInterface"
-      required:
-        - message
-      type: object
-      additionalProperties: false
     ResetPasswordByEmailBody:
       properties:
         email:
@@ -605,6 +586,38 @@ components:
         - token
         - password
         - confirm_password
+      type: object
+      additionalProperties: false
+    AdminUserIdentity:
+      description: Identity-only User projection for Platform Admin directory APIs.
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        phone:
+          type: string
+        role:
+          $ref: "#/components/schemas/UserRole"
+        disabled:
+          type: boolean
+        emailVerified:
+          type: boolean
+      required:
+        - id
+        - name
+        - email
+        - firstName
+        - lastName
+        - role
+        - disabled
+        - emailVerified
       type: object
       additionalProperties: false
   securitySchemes:
@@ -1163,71 +1176,6 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/VaultBackupSource"
-  /user:
-    get:
-      operationId: GetAllUsers
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/User"
-                type: array
-      tags:
-        - Users Management
-      security:
-        - jwt: []
-      parameters: []
-    post:
-      operationId: CreateUser
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FilteredUserInterface"
-        "201":
-          description: Created
-        "422":
-          description: Validation Failed
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ValidateErrorJSON"
-      tags:
-        - Users Management
-      security: []
-      parameters: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserCreationBody"
-  /user/{userId}:
-    get:
-      operationId: GetUserById
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/User"
-                nullable: true
-      tags:
-        - Users Management
-      security: []
-      parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            type: string
   /auth/login:
     post:
       operationId: Login
@@ -1253,7 +1201,16 @@ paths:
                   - token
                 type: object
         "401":
-          description: Unauthorized
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
       tags:
         - Authentication
       security: []
@@ -1521,6 +1478,63 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/ConfirmResetPasswordBody"
+  /admin/users:
+    get:
+      operationId: ListUsers
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AdminUserIdentity"
+                type: array
+      description: List/search Users (identity fields only). Platform Admin only.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: query
+          name: q
+          required: false
+          schema:
+            type: string
+  /admin/users/{userId}:
+    get:
+      operationId: GetUserById
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Get a User by id (identity fields only). Platform Admin only.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
 servers:
   - url: http://localhost:3000/api/v1/
     description: Local server

--- a/libs/api-specs/src/api-specs.openapi.yaml
+++ b/libs/api-specs/src/api-specs.openapi.yaml
@@ -373,6 +373,7 @@ components:
         - groceries
         - mobileNumbers
         - subscriptions
+        - tasks
         - todos
     VaultBackupRecordDto:
       properties:

--- a/libs/app-api-client/src/api.ts
+++ b/libs/app-api-client/src/api.ts
@@ -24,6 +24,69 @@ import type { RequestArgs } from './base';
 import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerMap } from './base';
 
 /**
+ * Identity-only User projection for Platform Admin directory APIs.
+ * @export
+ * @interface AdminUserIdentity
+ */
+export interface AdminUserIdentity {
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminUserIdentity
+     */
+    'id': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminUserIdentity
+     */
+    'name': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminUserIdentity
+     */
+    'email': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminUserIdentity
+     */
+    'firstName': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminUserIdentity
+     */
+    'lastName': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminUserIdentity
+     */
+    'phone'?: string;
+    /**
+     * 
+     * @type {UserRole}
+     * @memberof AdminUserIdentity
+     */
+    'role': UserRole;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AdminUserIdentity
+     */
+    'disabled': boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AdminUserIdentity
+     */
+    'emailVerified': boolean;
+}
+
+
+/**
  * 
  * @export
  * @interface AuthUrlResponse
@@ -274,7 +337,21 @@ export interface FilteredUserInterface {
      * @memberof FilteredUserInterface
      */
     'phone'?: string;
+    /**
+     * 
+     * @type {UserRole}
+     * @memberof FilteredUserInterface
+     */
+    'role': UserRole;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof FilteredUserInterface
+     */
+    'disabled': boolean;
 }
+
+
 /**
  * 
  * @export
@@ -749,6 +826,12 @@ export interface ListVaultBackupsResponse {
 export interface Login200Response {
     /**
      * 
+     * @type {string}
+     * @memberof Login200Response
+     */
+    'refresh_token'?: string;
+    /**
+     * 
      * @type {FilteredUserInterface}
      * @memberof Login200Response
      */
@@ -760,28 +843,22 @@ export interface Login200Response {
      */
     'expires_in': number;
     /**
-     *
+     * 
      * @type {string}
      * @memberof Login200Response
      */
     'token': string;
-    /**
-     * Present only when the request was made with client_type \"mobile\".
-     * @type {string}
-     * @memberof Login200Response
-     */
-    'refresh_token'?: string;
 }
 /**
- *
+ * 
  * @export
- * @interface Logout200Response
+ * @interface Login401Response
  */
-export interface Logout200Response {
+export interface Login401Response {
     /**
      * 
      * @type {string}
-     * @memberof Logout200Response
+     * @memberof Login401Response
      */
     'message': string;
 }
@@ -854,19 +931,19 @@ export interface PartialRecordVaultBlobTypeEncryptedBlobV1 {
      */
     'mobileNumbers'?: EncryptedBlobV1;
     /**
-     *
+     * 
      * @type {EncryptedBlobV1}
      * @memberof PartialRecordVaultBlobTypeEncryptedBlobV1
      */
     'subscriptions'?: EncryptedBlobV1;
     /**
-     *
+     * 
      * @type {EncryptedBlobV1}
      * @memberof PartialRecordVaultBlobTypeEncryptedBlobV1
      */
     'tasks'?: EncryptedBlobV1;
     /**
-     *
+     * 
      * @type {EncryptedBlobV1}
      * @memberof PartialRecordVaultBlobTypeEncryptedBlobV1
      */
@@ -1140,6 +1217,31 @@ export interface RecordVaultBackupResponse {
 /**
  * 
  * @export
+ * @interface RefreshToken200Response
+ */
+export interface RefreshToken200Response {
+    /**
+     * 
+     * @type {FilteredUserInterface}
+     * @memberof RefreshToken200Response
+     */
+    'user': FilteredUserInterface;
+    /**
+     * 
+     * @type {number}
+     * @memberof RefreshToken200Response
+     */
+    'expires_in': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof RefreshToken200Response
+     */
+    'token': string;
+}
+/**
+ * 
+ * @export
  * @interface RefreshTokenRequest
  */
 export interface RefreshTokenRequest {
@@ -1374,73 +1476,6 @@ export interface ToggleSubscriptionRequest {
 /**
  * 
  * @export
- * @interface User
- */
-export interface User {
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'id': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'name'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'first_name'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'last_name'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'phone'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'email': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'password'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'reset_password_token'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof User
-     */
-    'email_verification_timestamp'?: string;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof User
-     */
-    'blacklisted_tokens'?: Array<string>;
-}
-/**
- * 
- * @export
  * @interface UserCreationBody
  */
 export interface UserCreationBody {
@@ -1494,13 +1529,13 @@ export interface UserLoginBody {
      */
     'email': string;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserLoginBody
      */
     'password': string;
     /**
-     * Indicates the client type. When set to \"mobile\", the refresh token is included in the response body.
+     * 
      * @type {string}
      * @memberof UserLoginBody
      */
@@ -1511,9 +1546,25 @@ export const UserLoginBodyClientTypeEnum = {
     Mobile: 'mobile',
     Web: 'web'
 } as const;
+
 export type UserLoginBodyClientTypeEnum = typeof UserLoginBodyClientTypeEnum[keyof typeof UserLoginBodyClientTypeEnum];
+
 /**
- *
+ * 
+ * @export
+ * @enum {string}
+ */
+
+export const UserRole = {
+    User: 'user',
+    PlatformAdmin: 'platform_admin'
+} as const;
+
+export type UserRole = typeof UserRole[keyof typeof UserRole];
+
+
+/**
+ * 
  * @export
  * @interface ValidateErrorJSON
  */
@@ -1549,7 +1600,6 @@ export const VaultBackupBlobType = {
     Groceries: 'groceries',
     MobileNumbers: 'mobileNumbers',
     Subscriptions: 'subscriptions',
-    Tasks: 'tasks',
     Todos: 'todos'
 } as const;
 
@@ -2263,7 +2313,7 @@ export const AuthenticationApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async logout(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Logout200Response>> {
+        async logout(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Login401Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.logout(userId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['AuthenticationApi.logout']?.[localVarOperationServerIndex]?.url;
@@ -2275,7 +2325,7 @@ export const AuthenticationApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async refreshToken(refreshTokenRequest?: RefreshTokenRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Login200Response>> {
+        async refreshToken(refreshTokenRequest?: RefreshTokenRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RefreshToken200Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.refreshToken(refreshTokenRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['AuthenticationApi.refreshToken']?.[localVarOperationServerIndex]?.url;
@@ -2375,7 +2425,7 @@ export const AuthenticationApiFactory = function (configuration?: Configuration,
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        logout(requestParameters: AuthenticationApiLogoutRequest, options?: RawAxiosRequestConfig): AxiosPromise<Logout200Response> {
+        logout(requestParameters: AuthenticationApiLogoutRequest, options?: RawAxiosRequestConfig): AxiosPromise<Login401Response> {
             return localVarFp.logout(requestParameters.userId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -2384,7 +2434,7 @@ export const AuthenticationApiFactory = function (configuration?: Configuration,
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        refreshToken(requestParameters: AuthenticationApiRefreshTokenRequest = {}, options?: RawAxiosRequestConfig): AxiosPromise<Login200Response> {
+        refreshToken(requestParameters: AuthenticationApiRefreshTokenRequest = {}, options?: RawAxiosRequestConfig): AxiosPromise<RefreshToken200Response> {
             return localVarFp.refreshToken(requestParameters.refreshTokenRequest, options).then((request) => request(axios, basePath));
         },
         /**
@@ -2671,53 +2721,22 @@ export class AuthenticationApi extends BaseAPI {
 
 
 /**
- * UsersManagementApi - axios parameter creator
+ * PlatformAdminApi - axios parameter creator
  * @export
  */
-export const UsersManagementApiAxiosParamCreator = function (configuration?: Configuration) {
+export const PlatformAdminApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * 
-         * @param {UserCreationBody} userCreationBody 
+         * Get a User by id (identity fields only). Platform Admin only.
+         * @param {string} userId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (userCreationBody: UserCreationBody, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'userCreationBody' is not null or undefined
-            assertParamExists('createUser', 'userCreationBody', userCreationBody)
-            const localVarPath = `/user`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(userCreationBody, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAllUsers: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/user`;
+        getUserById: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('getUserById', 'userId', userId)
+            const localVarPath = `/admin/users/{userId}`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -2745,16 +2764,13 @@ export const UsersManagementApiAxiosParamCreator = function (configuration?: Con
             };
         },
         /**
-         * 
-         * @param {string} userId 
+         * List/search Users (identity fields only). Platform Admin only.
+         * @param {string} [q] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getUserById: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'userId' is not null or undefined
-            assertParamExists('getUserById', 'userId', userId)
-            const localVarPath = `/user/{userId}`
-                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+        listUsers: async (q?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/admin/users`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -2765,6 +2781,14 @@ export const UsersManagementApiAxiosParamCreator = function (configuration?: Con
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication jwt required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (q !== undefined) {
+                localVarQueryParameter['q'] = q;
+            }
 
 
     
@@ -2781,151 +2805,122 @@ export const UsersManagementApiAxiosParamCreator = function (configuration?: Con
 };
 
 /**
- * UsersManagementApi - functional programming interface
+ * PlatformAdminApi - functional programming interface
  * @export
  */
-export const UsersManagementApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = UsersManagementApiAxiosParamCreator(configuration)
+export const PlatformAdminApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = PlatformAdminApiAxiosParamCreator(configuration)
     return {
         /**
-         * 
-         * @param {UserCreationBody} userCreationBody 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createUser(userCreationBody: UserCreationBody, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FilteredUserInterface>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(userCreationBody, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['UsersManagementApi.createUser']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getAllUsers(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<User>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllUsers(options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['UsersManagementApi.getAllUsers']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
+         * Get a User by id (identity fields only). Platform Admin only.
          * @param {string} userId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserById(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+        async getUserById(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminUserIdentity>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getUserById(userId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['UsersManagementApi.getUserById']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.getUserById']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * List/search Users (identity fields only). Platform Admin only.
+         * @param {string} [q] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async listUsers(q?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<AdminUserIdentity>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listUsers(q, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.listUsers']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
     }
 };
 
 /**
- * UsersManagementApi - factory interface
+ * PlatformAdminApi - factory interface
  * @export
  */
-export const UsersManagementApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = UsersManagementApiFp(configuration)
+export const PlatformAdminApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = PlatformAdminApiFp(configuration)
     return {
         /**
-         * 
-         * @param {UsersManagementApiCreateUserRequest} requestParameters Request parameters.
+         * Get a User by id (identity fields only). Platform Admin only.
+         * @param {PlatformAdminApiGetUserByIdRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(requestParameters: UsersManagementApiCreateUserRequest, options?: RawAxiosRequestConfig): AxiosPromise<FilteredUserInterface> {
-            return localVarFp.createUser(requestParameters.userCreationBody, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAllUsers(options?: RawAxiosRequestConfig): AxiosPromise<Array<User>> {
-            return localVarFp.getAllUsers(options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @param {UsersManagementApiGetUserByIdRequest} requestParameters Request parameters.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getUserById(requestParameters: UsersManagementApiGetUserByIdRequest, options?: RawAxiosRequestConfig): AxiosPromise<User> {
+        getUserById(requestParameters: PlatformAdminApiGetUserByIdRequest, options?: RawAxiosRequestConfig): AxiosPromise<AdminUserIdentity> {
             return localVarFp.getUserById(requestParameters.userId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * List/search Users (identity fields only). Platform Admin only.
+         * @param {PlatformAdminApiListUsersRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listUsers(requestParameters: PlatformAdminApiListUsersRequest = {}, options?: RawAxiosRequestConfig): AxiosPromise<Array<AdminUserIdentity>> {
+            return localVarFp.listUsers(requestParameters.q, options).then((request) => request(axios, basePath));
         },
     };
 };
 
 /**
- * Request parameters for createUser operation in UsersManagementApi.
+ * Request parameters for getUserById operation in PlatformAdminApi.
  * @export
- * @interface UsersManagementApiCreateUserRequest
+ * @interface PlatformAdminApiGetUserByIdRequest
  */
-export interface UsersManagementApiCreateUserRequest {
-    /**
-     * 
-     * @type {UserCreationBody}
-     * @memberof UsersManagementApiCreateUser
-     */
-    readonly userCreationBody: UserCreationBody
-}
-
-/**
- * Request parameters for getUserById operation in UsersManagementApi.
- * @export
- * @interface UsersManagementApiGetUserByIdRequest
- */
-export interface UsersManagementApiGetUserByIdRequest {
+export interface PlatformAdminApiGetUserByIdRequest {
     /**
      * 
      * @type {string}
-     * @memberof UsersManagementApiGetUserById
+     * @memberof PlatformAdminApiGetUserById
      */
     readonly userId: string
 }
 
 /**
- * UsersManagementApi - object-oriented interface
+ * Request parameters for listUsers operation in PlatformAdminApi.
  * @export
- * @class UsersManagementApi
+ * @interface PlatformAdminApiListUsersRequest
+ */
+export interface PlatformAdminApiListUsersRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof PlatformAdminApiListUsers
+     */
+    readonly q?: string
+}
+
+/**
+ * PlatformAdminApi - object-oriented interface
+ * @export
+ * @class PlatformAdminApi
  * @extends {BaseAPI}
  */
-export class UsersManagementApi extends BaseAPI {
+export class PlatformAdminApi extends BaseAPI {
     /**
-     * 
-     * @param {UsersManagementApiCreateUserRequest} requestParameters Request parameters.
+     * Get a User by id (identity fields only). Platform Admin only.
+     * @param {PlatformAdminApiGetUserByIdRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
-     * @memberof UsersManagementApi
+     * @memberof PlatformAdminApi
      */
-    public createUser(requestParameters: UsersManagementApiCreateUserRequest, options?: RawAxiosRequestConfig) {
-        return UsersManagementApiFp(this.configuration).createUser(requestParameters.userCreationBody, options).then((request) => request(this.axios, this.basePath));
+    public getUserById(requestParameters: PlatformAdminApiGetUserByIdRequest, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).getUserById(requestParameters.userId, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
-     * 
+     * List/search Users (identity fields only). Platform Admin only.
+     * @param {PlatformAdminApiListUsersRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
-     * @memberof UsersManagementApi
+     * @memberof PlatformAdminApi
      */
-    public getAllUsers(options?: RawAxiosRequestConfig) {
-        return UsersManagementApiFp(this.configuration).getAllUsers(options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {UsersManagementApiGetUserByIdRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof UsersManagementApi
-     */
-    public getUserById(requestParameters: UsersManagementApiGetUserByIdRequest, options?: RawAxiosRequestConfig) {
-        return UsersManagementApiFp(this.configuration).getUserById(requestParameters.userId, options).then((request) => request(this.axios, this.basePath));
+    public listUsers(requestParameters: PlatformAdminApiListUsersRequest = {}, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).listUsers(requestParameters.q, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -3822,6 +3817,9 @@ export const YouTubeApiAxiosParamCreator = function (configuration?: Configurati
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication cron-secret required
+            await setApiKeyToObject(localVarHeaderParameter, "X-Cron-Secret", configuration)
 
 
     

--- a/libs/app-api-client/src/api.ts
+++ b/libs/app-api-client/src/api.ts
@@ -1600,6 +1600,7 @@ export const VaultBackupBlobType = {
     Groceries: 'groceries',
     MobileNumbers: 'mobileNumbers',
     Subscriptions: 'subscriptions',
+    Tasks: 'tasks',
     Todos: 'todos'
 } as const;
 

--- a/libs/auth/src/lib/auth-session-module.test.ts
+++ b/libs/auth/src/lib/auth-session-module.test.ts
@@ -18,6 +18,8 @@ describe('createAuthSessionModule', () => {
     name: 'Test User',
     firstName: 'Test',
     lastName: 'User',
+    role: 'user',
+    disabled: false,
   };
 
   const mockSessionData = {

--- a/libs/auth/src/lib/auth-session-storage-adapter.test.ts
+++ b/libs/auth/src/lib/auth-session-storage-adapter.test.ts
@@ -10,6 +10,8 @@ describe('createBrowserAuthSessionStorageAdapter', () => {
     name: 'Test User',
     firstName: 'Test',
     lastName: 'User',
+    role: 'user' as const,
+    disabled: false,
   };
 
   beforeEach(() => {

--- a/libs/auth/src/lib/auth-session-transport-adapter.test.ts
+++ b/libs/auth/src/lib/auth-session-transport-adapter.test.ts
@@ -24,6 +24,8 @@ describe('createAuthSessionTransportAdapter', () => {
     name: 'Test User',
     firstName: 'Test',
     lastName: 'User',
+    role: 'user' as const,
+    disabled: false,
   };
 
   beforeEach(() => {

--- a/libs/auth/src/lib/auth.refresh.test.ts
+++ b/libs/auth/src/lib/auth.refresh.test.ts
@@ -30,6 +30,8 @@ describe('auth.refresh', () => {
             name: 'Test User',
             firstName: 'Test',
             lastName: 'User',
+            role: 'user',
+            disabled: false,
           },
         },
       });
@@ -51,6 +53,8 @@ describe('auth.refresh', () => {
         name: 'Test User',
         firstName: 'Test',
         lastName: 'User',
+        role: 'user' as const,
+        disabled: false,
       };
 
       (AuthenticationApi.prototype.refreshToken as jest.Mock).mockResolvedValue(
@@ -75,6 +79,8 @@ describe('auth.refresh', () => {
         name: 'Test User',
         firstName: 'Test',
         lastName: 'User',
+        role: 'user' as const,
+        disabled: false,
       };
 
       (AuthenticationApi.prototype.refreshToken as jest.Mock).mockResolvedValue(
@@ -99,6 +105,8 @@ describe('auth.refresh', () => {
         name: 'Test User',
         firstName: 'Test',
         lastName: 'User',
+        role: 'user' as const,
+        disabled: false,
       };
 
       (AuthenticationApi.prototype.refreshToken as jest.Mock).mockResolvedValue(

--- a/libs/auth/src/lib/auth.test.ts
+++ b/libs/auth/src/lib/auth.test.ts
@@ -16,7 +16,7 @@ describe('auth storage', () => {
     expect(getAccessToken()).toBe('abc');
     expect(window.localStorage.getItem('myorganizer_access_token')).toBe('abc');
     expect(window.sessionStorage.getItem('myorganizer_access_token')).toBe(
-      null
+      null,
     );
   });
 
@@ -24,7 +24,7 @@ describe('auth storage', () => {
     setAccessToken('def', 'session');
     expect(getAccessToken()).toBe('def');
     expect(window.sessionStorage.getItem('myorganizer_access_token')).toBe(
-      'def'
+      'def',
     );
     expect(window.localStorage.getItem('myorganizer_access_token')).toBe(null);
   });
@@ -36,6 +36,8 @@ describe('auth storage', () => {
       name: 'A',
       firstName: 'A',
       lastName: 'B',
+      role: 'user',
+      disabled: false,
     });
 
     const user = getCurrentUser();


### PR DESCRIPTION
## Why
Implement platform admin foundation.

## Changes
- Add 'role' (user|platform_admin) and 'disabled' flag to User model
- Implement platform admin authorization guards and JWT scoping
- Add AdminUsersController with identity-only DTOs for user management
- Block disabled users from authentication and session refresh
- Introduce idempotent bootstrap mechanism for platform admin elevation
- Deprecate legacy /user HTTP APIs (returning 404)
- Sync OpenAPI specifications and generated API client
- Add integration tests for auth matrix, admin APIs, and bootstrap flow
- Refs #198

## Validation
- Generated from 1 commit(s) on `feat/platform-admin-foundation-198`.
- Compared against base branch `main`.
