### PR TITLE
feat(backend): implement platform admin user lifecycle APIs and audit logging

### DIFF
--- a/apps/backend/src/controllers/AdminAuditLogController.ts
+++ b/apps/backend/src/controllers/AdminAuditLogController.ts
@@ -1,0 +1,49 @@
+import { Controller, Get, Query, Request, Route, Security, Tags } from 'tsoa';
+import { Request as ExRequest } from 'express';
+import {
+  ForbiddenError,
+  UnauthorizedError,
+  requirePlatformAdmin,
+} from '../guards/AuthGuard';
+import userService from '../services/UserService';
+import { AdminAuditLogEntry } from '../types';
+
+@Tags('Platform Admin')
+@Route('/admin/audit-logs')
+@Security('jwt', ['platform_admin'])
+export class AdminAuditLogController extends Controller {
+  /**
+   * List recent Admin Audit Log entries (newest first). Platform Admin only.
+   */
+  @Get()
+  async listAuditLogs(
+    @Request() req: ExRequest,
+    @Query() limit?: number,
+  ): Promise<AdminAuditLogEntry[]> {
+    this.assertPlatformAdmin(req);
+    const rows = await userService.listAdminAuditLogs(limit);
+    return rows.map((row) => ({
+      id: row.id,
+      actorUserId: row.actor_user_id,
+      targetUserId: row.target_user_id,
+      action: row.action,
+      createdAt: row.created_at,
+    }));
+  }
+
+  private assertPlatformAdmin(req: ExRequest): void {
+    try {
+      requirePlatformAdmin(req);
+    } catch (err) {
+      if (err instanceof UnauthorizedError) {
+        this.setStatus(401);
+        throw err;
+      }
+      if (err instanceof ForbiddenError) {
+        this.setStatus(403);
+        throw err;
+      }
+      throw err;
+    }
+  }
+}

--- a/apps/backend/src/controllers/AdminLifecycle.int.test.ts
+++ b/apps/backend/src/controllers/AdminLifecycle.int.test.ts
@@ -1,0 +1,433 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import bodyParser from 'body-parser';
+import express from 'express';
+import request from 'supertest';
+import { ValidateError } from 'tsoa';
+import {
+  LastPlatformAdminError,
+  UserNotFoundError,
+  VerificationCooldownError,
+} from '../errors/AdminLifecycleErrors';
+
+jest.setTimeout(30_000);
+
+jest.mock('../helpers/PlatformTokenHandler', () => ({
+  __esModule: true,
+  PlatformTokenHandler: {
+    buildLoginResponse: jest.fn(),
+  },
+  default: {
+    buildLoginResponse: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/passport', () => ({
+  __esModule: true,
+  default: {
+    authenticate: () => (_req: any, _res: any, next: any) => next(),
+  },
+}));
+
+jest.mock('../middleware/authentication', () => {
+  return {
+    expressAuthentication: async (
+      req: any,
+      _securityName: string,
+      scopes?: string[],
+    ) => {
+      const authHeader = req?.headers?.authorization;
+      if (!authHeader) {
+        const err = new Error('Unauthorized') as Error & { status?: number };
+        err.status = 401;
+        throw err;
+      }
+
+      const token = authHeader.startsWith('Bearer ')
+        ? authHeader.slice('Bearer '.length)
+        : authHeader;
+
+      if (token === 'disabled') {
+        const err = new Error('Account disabled') as Error & {
+          status?: number;
+        };
+        err.status = 401;
+        throw err;
+      }
+
+      if (token === 'user') {
+        if (scopes?.includes('platform_admin')) {
+          const err = new Error('Platform Admin role required') as Error & {
+            status?: number;
+          };
+          err.status = 403;
+          throw err;
+        }
+        req.user = { id: 'user-1', role: 'user', disabled: false };
+        return req.user;
+      }
+
+      if (token === 'admin') {
+        req.user = { id: 'admin-1', role: 'platform_admin', disabled: false };
+        return req.user;
+      }
+
+      const err = new Error('Unauthorized') as Error & { status?: number };
+      err.status = 401;
+      throw err;
+    },
+  };
+});
+
+jest.mock('../services/UserService', () => ({
+  __esModule: true,
+  default: {
+    listIdentityUsers: jest.fn(),
+    getIdentityById: jest.fn(),
+    disableUser: jest.fn(),
+    enableUser: jest.fn(),
+    forceLogoutUser: jest.fn(),
+    adminResendVerification: jest.fn(),
+    promoteUser: jest.fn(),
+    demoteUser: jest.fn(),
+    listAdminAuditLogs: jest.fn(),
+  },
+}));
+
+jest.mock('../services/VaultService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/VaultBackupService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/YouTubeNotificationService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../services/YouTubeSyncService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+function makeApp() {
+  jest.resetModules();
+
+  const { RegisterRoutes } = require('../routes/routes');
+
+  const app = express();
+  app.use(bodyParser.json({ limit: '2mb' }));
+  RegisterRoutes(app);
+
+  app.use(function tsoaErrorHandler(
+    err: unknown,
+    _req: any,
+    res: any,
+    next: any,
+  ) {
+    if (err instanceof ValidateError) {
+      return res.status(422).json({
+        message: 'Validation Failed',
+        details: err?.fields,
+      });
+    }
+
+    const anyErr = err as any;
+    if (
+      anyErr &&
+      typeof anyErr === 'object' &&
+      typeof anyErr.status === 'number'
+    ) {
+      return res.status(anyErr.status).json({ message: anyErr.message });
+    }
+
+    if (err instanceof Error) {
+      return res.status(500).json({ message: 'Internal Server Error' });
+    }
+
+    return next(err);
+  });
+
+  return app;
+}
+
+const identityRow = {
+  id: 'u1',
+  name: 'Alice Example',
+  first_name: 'Alice',
+  last_name: 'Example',
+  phone: null,
+  email: 'alice@example.com',
+  role: 'user',
+  disabled: false,
+  email_verification_timestamp: new Date('2024-01-01'),
+  password: 'secret-hash',
+  blacklisted_tokens: ['old-token'],
+  reset_password_token: 'reset-token',
+  email_verification_token: 'verify-token',
+  youtube_access_token: 'yt-token',
+  encrypted_vault: 'vault-ciphertext',
+};
+
+const expectedIdentityDto = {
+  id: 'u1',
+  name: 'Alice Example',
+  email: 'alice@example.com',
+  firstName: 'Alice',
+  lastName: 'Example',
+  role: 'user',
+  disabled: false,
+  emailVerified: true,
+};
+
+const auditLogRow = {
+  id: 'log-1',
+  actor_user_id: 'admin-1',
+  target_user_id: 'u1',
+  action: 'disable' as const,
+  created_at: new Date('2024-06-01T12:00:00.000Z'),
+};
+
+describe('Admin lifecycle mutations and audit logs (HTTP integration)', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = makeApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /admin/users/:userId/disable', () => {
+    test('returns 401 when unauthenticated', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app).post('/admin/users/u1/disable');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(userService.disableUser).not.toHaveBeenCalled();
+    });
+
+    test('returns 403 for authenticated non-platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app)
+        .post('/admin/users/u1/disable')
+        .set('Authorization', 'Bearer user');
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ message: 'Platform Admin role required' });
+      expect(userService.disableUser).not.toHaveBeenCalled();
+    });
+
+    test('returns 200 with identity DTO for platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.disableUser.mockResolvedValueOnce(identityRow);
+
+      const res = await request(app)
+        .post('/admin/users/u1/disable')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.disableUser).toHaveBeenCalledWith('admin-1', 'u1');
+      expect(res.body).toEqual(expectedIdentityDto);
+    });
+
+    test('returns 404 when user not found', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.disableUser.mockRejectedValueOnce(new UserNotFoundError());
+
+      const res = await request(app)
+        .post('/admin/users/u1/disable')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ message: 'User not found' });
+      expect(userService.disableUser).toHaveBeenCalledWith('admin-1', 'u1');
+    });
+  });
+
+  describe('POST /admin/users/:userId/enable', () => {
+    test('returns 200 and calls enableUser for platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.enableUser.mockResolvedValueOnce(identityRow);
+
+      const res = await request(app)
+        .post('/admin/users/u1/enable')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.enableUser).toHaveBeenCalledWith('admin-1', 'u1');
+      expect(res.body).toEqual(expectedIdentityDto);
+    });
+  });
+
+  describe('POST /admin/users/:userId/force-logout', () => {
+    test('returns 200 and calls forceLogoutUser for platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.forceLogoutUser.mockResolvedValueOnce(identityRow);
+
+      const res = await request(app)
+        .post('/admin/users/u1/force-logout')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.forceLogoutUser).toHaveBeenCalledWith('admin-1', 'u1');
+      expect(res.body).toEqual(expectedIdentityDto);
+    });
+  });
+
+  describe('POST /admin/users/:userId/promote', () => {
+    test('returns 200 and calls promoteUser for platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.promoteUser.mockResolvedValueOnce({
+        ...identityRow,
+        role: 'platform_admin',
+      });
+
+      const res = await request(app)
+        .post('/admin/users/u1/promote')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.promoteUser).toHaveBeenCalledWith('admin-1', 'u1');
+      expect(res.body).toEqual({
+        ...expectedIdentityDto,
+        role: 'platform_admin',
+      });
+    });
+  });
+
+  describe('POST /admin/users/:userId/demote', () => {
+    test('returns 409 when demoting the last Platform Admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.demoteUser.mockRejectedValueOnce(
+        new LastPlatformAdminError(),
+      );
+
+      const res = await request(app)
+        .post('/admin/users/admin-1/demote')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(409);
+      expect(res.body).toEqual({
+        message: 'Cannot demote the last Platform Admin',
+      });
+      expect(userService.demoteUser).toHaveBeenCalledWith('admin-1', 'admin-1');
+    });
+
+    test('returns 200 and calls demoteUser for platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.demoteUser.mockResolvedValueOnce(identityRow);
+
+      const res = await request(app)
+        .post('/admin/users/u1/demote')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.demoteUser).toHaveBeenCalledWith('admin-1', 'u1');
+      expect(res.body).toEqual(expectedIdentityDto);
+    });
+  });
+
+  describe('POST /admin/users/:userId/resend-verification', () => {
+    test('returns 429 when verification cooldown is active', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.adminResendVerification.mockRejectedValueOnce(
+        new VerificationCooldownError(),
+      );
+
+      const res = await request(app)
+        .post('/admin/users/u1/resend-verification')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(429);
+      expect(res.body).toEqual({
+        message:
+          'A verification email was already sent recently. Please try again later.',
+      });
+      expect(userService.adminResendVerification).toHaveBeenCalledWith(
+        'admin-1',
+        'u1',
+      );
+    });
+
+    test('returns 200 with success message', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.adminResendVerification.mockResolvedValueOnce(undefined);
+
+      const res = await request(app)
+        .post('/admin/users/u1/resend-verification')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        message: 'Verification email sent successfully',
+      });
+      expect(userService.adminResendVerification).toHaveBeenCalledWith(
+        'admin-1',
+        'u1',
+      );
+    });
+  });
+
+  describe('GET /admin/audit-logs', () => {
+    test('returns 401 when unauthenticated', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app).get('/admin/audit-logs');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ message: 'Unauthorized' });
+      expect(userService.listAdminAuditLogs).not.toHaveBeenCalled();
+    });
+
+    test('returns 403 for authenticated non-platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      const res = await request(app)
+        .get('/admin/audit-logs')
+        .set('Authorization', 'Bearer user');
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ message: 'Platform Admin role required' });
+      expect(userService.listAdminAuditLogs).not.toHaveBeenCalled();
+    });
+
+    test('returns 200 with mapped audit log entries for platform_admin', async () => {
+      const userService = require('../services/UserService').default;
+
+      userService.listAdminAuditLogs.mockResolvedValueOnce([auditLogRow]);
+
+      const res = await request(app)
+        .get('/admin/audit-logs')
+        .set('Authorization', 'Bearer admin');
+
+      expect(res.status).toBe(200);
+      expect(userService.listAdminAuditLogs).toHaveBeenCalledWith(undefined);
+      expect(res.body).toEqual([
+        {
+          id: 'log-1',
+          actorUserId: 'admin-1',
+          targetUserId: 'u1',
+          action: 'disable',
+          createdAt: '2024-06-01T12:00:00.000Z',
+        },
+      ]);
+    });
+  });
+});

--- a/apps/backend/src/controllers/AdminUsersController.ts
+++ b/apps/backend/src/controllers/AdminUsersController.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Path,
+  Post,
   Query,
   Request,
   Res,
@@ -12,6 +13,13 @@ import {
   TsoaResponse,
 } from 'tsoa';
 import { Request as ExRequest } from 'express';
+import {
+  EmailAlreadyVerifiedError,
+  LastPlatformAdminError,
+  UserNotFoundError,
+  VerificationCooldownError,
+  VerificationSendFailedError,
+} from '../errors/AdminLifecycleErrors';
 import {
   ForbiddenError,
   UnauthorizedError,
@@ -56,9 +64,161 @@ export class AdminUsersController extends Controller {
     return toAdminUserIdentity(user);
   }
 
-  private assertPlatformAdmin(req: ExRequest): void {
+  /**
+   * Disable a User (soft-block) and invalidate active sessions immediately.
+   */
+  @Post('{userId}/disable')
+  @Response(404, 'User not found')
+  async disableUser(
+    @Request() req: ExRequest,
+    @Path() userId: string,
+    @Res() notFound: TsoaResponse<404, { message: string }>,
+  ): Promise<AdminUserIdentity> {
+    const actor = this.assertPlatformAdmin(req);
     try {
-      requirePlatformAdmin(req);
+      const user = await userService.disableUser(actor.id, userId);
+      return toAdminUserIdentity(user);
+    } catch (err) {
+      if (err instanceof UserNotFoundError) {
+        return notFound(404, { message: err.message });
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Re-enable a Disabled User so authentication works again.
+   */
+  @Post('{userId}/enable')
+  @Response(404, 'User not found')
+  async enableUser(
+    @Request() req: ExRequest,
+    @Path() userId: string,
+    @Res() notFound: TsoaResponse<404, { message: string }>,
+  ): Promise<AdminUserIdentity> {
+    const actor = this.assertPlatformAdmin(req);
+    try {
+      const user = await userService.enableUser(actor.id, userId);
+      return toAdminUserIdentity(user);
+    } catch (err) {
+      if (err instanceof UserNotFoundError) {
+        return notFound(404, { message: err.message });
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Force logout a User without disabling the account.
+   */
+  @Post('{userId}/force-logout')
+  @Response(404, 'User not found')
+  async forceLogoutUser(
+    @Request() req: ExRequest,
+    @Path() userId: string,
+    @Res() notFound: TsoaResponse<404, { message: string }>,
+  ): Promise<AdminUserIdentity> {
+    const actor = this.assertPlatformAdmin(req);
+    try {
+      const user = await userService.forceLogoutUser(actor.id, userId);
+      return toAdminUserIdentity(user);
+    } catch (err) {
+      if (err instanceof UserNotFoundError) {
+        return notFound(404, { message: err.message });
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Resend verification email for an unverified User (existing cooldown rules).
+   */
+  @Post('{userId}/resend-verification')
+  @Response(404, 'User not found')
+  @Response(409, 'Email already verified')
+  @Response(429, 'Verification email cooldown')
+  async resendVerification(
+    @Request() req: ExRequest,
+    @Path() userId: string,
+    @Res() notFound: TsoaResponse<404, { message: string }>,
+    @Res() conflict: TsoaResponse<409, { message: string }>,
+    @Res() tooMany: TsoaResponse<429, { message: string }>,
+  ): Promise<{ message: string }> {
+    const actor = this.assertPlatformAdmin(req);
+    try {
+      await userService.adminResendVerification(actor.id, userId);
+      return { message: 'Verification email sent successfully' };
+    } catch (err) {
+      if (err instanceof UserNotFoundError) {
+        return notFound(404, { message: err.message });
+      }
+      if (err instanceof EmailAlreadyVerifiedError) {
+        return conflict(409, { message: err.message });
+      }
+      if (err instanceof VerificationCooldownError) {
+        return tooMany(429, { message: err.message });
+      }
+      if (err instanceof VerificationSendFailedError) {
+        this.setStatus(500);
+        throw err;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Promote a User to Platform Admin.
+   */
+  @Post('{userId}/promote')
+  @Response(404, 'User not found')
+  async promoteUser(
+    @Request() req: ExRequest,
+    @Path() userId: string,
+    @Res() notFound: TsoaResponse<404, { message: string }>,
+  ): Promise<AdminUserIdentity> {
+    const actor = this.assertPlatformAdmin(req);
+    try {
+      const user = await userService.promoteUser(actor.id, userId);
+      return toAdminUserIdentity(user);
+    } catch (err) {
+      if (err instanceof UserNotFoundError) {
+        return notFound(404, { message: err.message });
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Demote a Platform Admin to a normal User.
+   * Rejects demotion of the last Platform Admin.
+   */
+  @Post('{userId}/demote')
+  @Response(404, 'User not found')
+  @Response(409, 'Cannot demote the last Platform Admin')
+  async demoteUser(
+    @Request() req: ExRequest,
+    @Path() userId: string,
+    @Res() notFound: TsoaResponse<404, { message: string }>,
+    @Res() conflict: TsoaResponse<409, { message: string }>,
+  ): Promise<AdminUserIdentity> {
+    const actor = this.assertPlatformAdmin(req);
+    try {
+      const user = await userService.demoteUser(actor.id, userId);
+      return toAdminUserIdentity(user);
+    } catch (err) {
+      if (err instanceof UserNotFoundError) {
+        return notFound(404, { message: err.message });
+      }
+      if (err instanceof LastPlatformAdminError) {
+        return conflict(409, { message: err.message });
+      }
+      throw err;
+    }
+  }
+
+  private assertPlatformAdmin(req: ExRequest) {
+    try {
+      return requirePlatformAdmin(req);
     } catch (err) {
       if (err instanceof UnauthorizedError) {
         this.setStatus(401);

--- a/apps/backend/src/controllers/AuthController.ts
+++ b/apps/backend/src/controllers/AuthController.ts
@@ -20,6 +20,7 @@ import apiTokens from '../helpers/ApiTokens';
 import filterUser from '../helpers/filterUser';
 import PlatformTokenHandler from '../helpers/PlatformTokenHandler';
 import { decodeToken } from '../helpers/jwtHelper';
+import { isTokenIssuedBeforeInvalidation } from '../helpers/sessionInvalidation';
 import { ValidateErrorJSON } from '../interfaces';
 import { RegisterUserResponse } from '../models/Auth';
 import {
@@ -134,6 +135,23 @@ export class AuthController extends Controller {
 
     if ((user as { disabled?: boolean }).disabled) {
       return unauthorized(401, { message: 'Account disabled' });
+    }
+
+    const refreshPayload = decodeToken(
+      refresh_token,
+      process.env.REFRESH_JWT_SECRET as string,
+    );
+    if (
+      refreshPayload &&
+      !(refreshPayload instanceof Error) &&
+      typeof refreshPayload === 'object' &&
+      isTokenIssuedBeforeInvalidation(
+        (refreshPayload as { iat?: number }).iat,
+        (user as { sessions_invalidated_at?: Date | null })
+          .sessions_invalidated_at,
+      )
+    ) {
+      return unauthorized(401, { message: 'Session invalidated' });
     }
 
     if (user.blacklisted_tokens?.includes(refresh_token)) {

--- a/apps/backend/src/errors/AdminLifecycleErrors.ts
+++ b/apps/backend/src/errors/AdminLifecycleErrors.ts
@@ -1,0 +1,46 @@
+export class UserNotFoundError extends Error {
+  status = 404;
+
+  constructor(message = 'User not found') {
+    super(message);
+    this.name = 'UserNotFoundError';
+  }
+}
+
+export class LastPlatformAdminError extends Error {
+  status = 409;
+
+  constructor(message = 'Cannot demote the last Platform Admin') {
+    super(message);
+    this.name = 'LastPlatformAdminError';
+  }
+}
+
+export class EmailAlreadyVerifiedError extends Error {
+  status = 409;
+
+  constructor(message = 'Email already verified') {
+    super(message);
+    this.name = 'EmailAlreadyVerifiedError';
+  }
+}
+
+export class VerificationCooldownError extends Error {
+  status = 429;
+
+  constructor(
+    message = 'A verification email was already sent recently. Please try again later.',
+  ) {
+    super(message);
+    this.name = 'VerificationCooldownError';
+  }
+}
+
+export class VerificationSendFailedError extends Error {
+  status = 500;
+
+  constructor(message = 'Failed to send verification email') {
+    super(message);
+    this.name = 'VerificationSendFailedError';
+  }
+}

--- a/apps/backend/src/helpers/sessionInvalidation.test.ts
+++ b/apps/backend/src/helpers/sessionInvalidation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { isTokenIssuedBeforeInvalidation } from './sessionInvalidation';
+
+describe('isTokenIssuedBeforeInvalidation', () => {
+  const invalidatedAt = new Date('2025-06-01T12:00:00.000Z');
+
+  test('returns false when sessions_invalidated_at is null or undefined', () => {
+    expect(isTokenIssuedBeforeInvalidation(1_700_000_000, null)).toBe(false);
+    expect(isTokenIssuedBeforeInvalidation(1_700_000_000, undefined)).toBe(
+      false,
+    );
+  });
+
+  test('returns true when token iat is before invalidation timestamp', () => {
+    const iatSeconds = Math.floor(invalidatedAt.getTime() / 1000 - 60);
+
+    expect(isTokenIssuedBeforeInvalidation(iatSeconds, invalidatedAt)).toBe(
+      true,
+    );
+  });
+
+  test('returns false when token iat is after invalidation timestamp', () => {
+    const iatSeconds = Math.floor(invalidatedAt.getTime() / 1000 + 60);
+
+    expect(isTokenIssuedBeforeInvalidation(iatSeconds, invalidatedAt)).toBe(
+      false,
+    );
+  });
+
+  test('returns false when token iat is missing', () => {
+    expect(isTokenIssuedBeforeInvalidation(undefined, invalidatedAt)).toBe(
+      false,
+    );
+  });
+});

--- a/apps/backend/src/helpers/sessionInvalidation.ts
+++ b/apps/backend/src/helpers/sessionInvalidation.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns true when a JWT (access or refresh) was issued before the User's
+ * sessions were invalidated (disable / force logout).
+ *
+ * `tokenIat` is the JWT `iat` claim in seconds since epoch.
+ */
+export function isTokenIssuedBeforeInvalidation(
+  tokenIat: number | undefined,
+  sessionsInvalidatedAt: Date | null | undefined,
+): boolean {
+  if (!sessionsInvalidatedAt || tokenIat == null) {
+    return false;
+  }
+  return tokenIat * 1000 < sessionsInvalidatedAt.getTime();
+}

--- a/apps/backend/src/middleware/authentication.test.ts
+++ b/apps/backend/src/middleware/authentication.test.ts
@@ -163,6 +163,51 @@ describe('expressAuthentication (tsoa jwt)', () => {
     });
   });
 
+  test('rejects when token was issued before sessions were invalidated', async () => {
+    const sessionsInvalidatedAt = new Date('2025-06-01T12:00:00.000Z');
+    const iatSeconds = Math.floor(sessionsInvalidatedAt.getTime() / 1000 - 60);
+
+    decodeTokenMock.mockReturnValue({ userId: 'u1', iat: iatSeconds });
+    getByIdMock.mockResolvedValue({
+      id: 'u1',
+      disabled: false,
+      sessions_invalidated_at: sessionsInvalidatedAt,
+    });
+
+    const req = makeReq({ headers: { authorization: 'Bearer abc' } });
+
+    await expect(expressAuthentication(req, 'jwt')).rejects.toMatchObject({
+      status: 401,
+      message: 'Session invalidated',
+    });
+  });
+
+  test('allows when token was issued after sessions were invalidated', async () => {
+    const sessionsInvalidatedAt = new Date('2025-06-01T12:00:00.000Z');
+    const iatSeconds = Math.floor(sessionsInvalidatedAt.getTime() / 1000 + 60);
+
+    decodeTokenMock.mockReturnValue({ userId: 'u1', iat: iatSeconds });
+    getByIdMock.mockResolvedValue({
+      id: 'u1',
+      disabled: false,
+      sessions_invalidated_at: sessionsInvalidatedAt,
+    });
+
+    const req = makeReq({ headers: { authorization: 'Bearer abc' } });
+    const user = await expressAuthentication(req, 'jwt');
+
+    expect(user).toEqual({
+      id: 'u1',
+      disabled: false,
+      sessions_invalidated_at: sessionsInvalidatedAt,
+    });
+    expect((req as any).user).toEqual({
+      id: 'u1',
+      disabled: false,
+      sessions_invalidated_at: sessionsInvalidatedAt,
+    });
+  });
+
   test('rejects non-admin when scopes include platform_admin', async () => {
     decodeTokenMock.mockReturnValue({ userId: 'u1' });
     getByIdMock.mockResolvedValue({ id: 'u1', role: 'user', disabled: false });

--- a/apps/backend/src/middleware/authentication.ts
+++ b/apps/backend/src/middleware/authentication.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import { JwtPayload } from 'jsonwebtoken';
 import { decodeToken } from '../helpers/jwtHelper';
+import { isTokenIssuedBeforeInvalidation } from '../helpers/sessionInvalidation';
 import userService from '../services/UserService';
 
 function unauthorized(message = 'Unauthorized') {
@@ -82,6 +83,16 @@ export function expressAuthentication(
 
     if ((user as { disabled?: boolean }).disabled) {
       throw unauthorized('Account disabled');
+    }
+
+    if (
+      isTokenIssuedBeforeInvalidation(
+        payload.iat,
+        (user as { sessions_invalidated_at?: Date | null })
+          .sessions_invalidated_at,
+      )
+    ) {
+      throw unauthorized('Session invalidated');
     }
 
     if (scopes?.includes('platform_admin')) {

--- a/apps/backend/src/prisma/migrations/20260724055741_add_admin_audit_log_and_sessions_invalidated/migration.sql
+++ b/apps/backend/src/prisma/migrations/20260724055741_add_admin_audit_log_and_sessions_invalidated/migration.sql
@@ -1,0 +1,32 @@
+-- CreateEnum
+CREATE TYPE "AdminAuditAction" AS ENUM ('disable', 'enable', 'force_logout', 'resend_verification', 'promote', 'demote');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "sessions_invalidated_at" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "AdminAuditLog" (
+    "id" TEXT NOT NULL,
+    "actor_user_id" TEXT NOT NULL,
+    "target_user_id" TEXT NOT NULL,
+    "action" "AdminAuditAction" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "meta" JSONB,
+
+    CONSTRAINT "AdminAuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AdminAuditLog_created_at_idx" ON "AdminAuditLog"("created_at");
+
+-- CreateIndex
+CREATE INDEX "AdminAuditLog_actor_user_id_idx" ON "AdminAuditLog"("actor_user_id");
+
+-- CreateIndex
+CREATE INDEX "AdminAuditLog_target_user_id_idx" ON "AdminAuditLog"("target_user_id");
+
+-- AddForeignKey
+ALTER TABLE "AdminAuditLog" ADD CONSTRAINT "AdminAuditLog_actor_user_id_fkey" FOREIGN KEY ("actor_user_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdminAuditLog" ADD CONSTRAINT "AdminAuditLog_target_user_id_fkey" FOREIGN KEY ("target_user_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/backend/src/prisma/schema/user.prisma
+++ b/apps/backend/src/prisma/schema/user.prisma
@@ -3,6 +3,15 @@ enum UserRole {
     platform_admin
 }
 
+enum AdminAuditAction {
+    disable
+    enable
+    force_logout
+    resend_verification
+    promote
+    demote
+}
+
 model User {
     id                              String      @id @default(cuid()) 
     name                            String?
@@ -17,6 +26,8 @@ model User {
     blacklisted_tokens              String[]
     role                            UserRole    @default(user)
     disabled                        Boolean     @default(false)
+    /// When set, refresh/access tokens with iat before this timestamp are rejected.
+    sessions_invalidated_at         DateTime?
 
     encrypted_vault                  EncryptedVault?
     vault_backup_records             VaultBackupRecord[]
@@ -25,6 +36,26 @@ model User {
     youtube_videos                   YouTubeVideo[]
     youtube_notification_settings    YouTubeNotificationSettings?
 
+    admin_audit_logs_as_actor        AdminAuditLog[] @relation("AdminAuditActor")
+    admin_audit_logs_as_target       AdminAuditLog[] @relation("AdminAuditTarget")
+
     @@index([email])
     @@index([role])
+}
+
+/// Durable record of Platform Admin mutations on Users.
+model AdminAuditLog {
+    id              String           @id @default(cuid())
+    actor_user_id   String
+    target_user_id  String
+    action          AdminAuditAction
+    created_at      DateTime         @default(now())
+    meta            Json?
+
+    actor           User             @relation("AdminAuditActor", fields: [actor_user_id], references: [id])
+    target          User             @relation("AdminAuditTarget", fields: [target_user_id], references: [id])
+
+    @@index([created_at])
+    @@index([actor_user_id])
+    @@index([target_user_id])
 }

--- a/apps/backend/src/routes/auth.test.ts
+++ b/apps/backend/src/routes/auth.test.ts
@@ -385,6 +385,46 @@ describe('Auth Routes', () => {
       expect(apiTokens.createTokens).not.toHaveBeenCalled();
     });
 
+    test('returns 401 and clears refresh cookie when session was invalidated after token was issued', async () => {
+      const sessionsInvalidatedAt = new Date('2025-06-01T12:00:00.000Z');
+      const iatSeconds = Math.floor(
+        sessionsInvalidatedAt.getTime() / 1000 - 60,
+      );
+
+      (userService.refreshToken as jest.Mock).mockResolvedValue({
+        id: 'user-1',
+        email: 'test@example.com',
+        email_verification_timestamp: new Date(),
+        disabled: false,
+        sessions_invalidated_at: sessionsInvalidatedAt,
+        blacklisted_tokens: [],
+      });
+      (decodeToken as jest.Mock).mockReturnValue({
+        userId: 'user-1',
+        iat: iatSeconds,
+      });
+
+      const response = await request(app)
+        .post('/auth/refresh')
+        .set('Cookie', ['refresh_cookie=refresh-token']);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ message: 'Session invalidated' });
+
+      const rawSetCookie = response.headers['set-cookie'] as
+        | string
+        | string[]
+        | undefined;
+      const setCookie = Array.isArray(rawSetCookie)
+        ? rawSetCookie
+        : rawSetCookie
+          ? [rawSetCookie]
+          : [];
+
+      expect(setCookie.some((c) => c.startsWith('refresh_cookie='))).toBe(true);
+      expect(apiTokens.createTokens).not.toHaveBeenCalled();
+    });
+
     test('returns 200 with role and disabled in user payload', async () => {
       const verifiedUser = {
         id: 'user-1',

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -3,6 +3,8 @@ import authController from '../controllers/AuthController';
 import apiTokens from '../helpers/ApiTokens';
 import { getExpiry } from '../helpers/cookieHelper';
 import filterUser from '../helpers/filterUser';
+import { decodeToken } from '../helpers/jwtHelper';
+import { isTokenIssuedBeforeInvalidation } from '../helpers/sessionInvalidation';
 import isOwner from '../middleware/isOwner';
 import { LoginSchema, refreshTokenSchema } from '../schemas/auth.schema';
 import { UserSchema } from '../schemas/user.schema';
@@ -385,6 +387,25 @@ router.post('/refresh', async (req, res, next: NextFunction) => {
       res.status(403).json({
         message: 'Email not verified. Please verify your email first.',
       });
+      return;
+    }
+
+    const refreshPayload = decodeToken(
+      refreshToken,
+      process.env.REFRESH_JWT_SECRET as string,
+    );
+    if (
+      refreshPayload &&
+      !(refreshPayload instanceof Error) &&
+      typeof refreshPayload === 'object' &&
+      isTokenIssuedBeforeInvalidation(
+        (refreshPayload as { iat?: number }).iat,
+        (user as { sessions_invalidated_at?: Date | null })
+          .sessions_invalidated_at,
+      )
+    ) {
+      res.clearCookie('refresh_cookie');
+      res.status(401).json({ message: 'Session invalidated' });
       return;
     }
 

--- a/apps/backend/src/routes/routes.ts
+++ b/apps/backend/src/routes/routes.ts
@@ -13,6 +13,8 @@ import { VaultBackupController } from './../controllers/VaultBackupController';
 import { AuthController } from './../controllers/AuthController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AdminUsersController } from './../controllers/AdminUsersController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AdminAuditLogController } from './../controllers/AdminAuditLogController';
 import { expressAuthentication } from './../middleware/authentication';
 // @ts-ignore - no great way to install types from subpackage
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
@@ -378,6 +380,23 @@ const models: TsoaRoute.Models = {
             "role": {"ref":"UserRole","required":true},
             "disabled": {"dataType":"boolean","required":true},
             "emailVerified": {"dataType":"boolean","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AdminAuditAction": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["disable"]},{"dataType":"enum","enums":["enable"]},{"dataType":"enum","enums":["force_logout"]},{"dataType":"enum","enums":["resend_verification"]},{"dataType":"enum","enums":["promote"]},{"dataType":"enum","enums":["demote"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AdminAuditLogEntry": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "actorUserId": {"dataType":"string","required":true},
+            "targetUserId": {"dataType":"string","required":true},
+            "action": {"ref":"AdminAuditAction","required":true},
+            "createdAt": {"dataType":"datetime","required":true},
         },
         "additionalProperties": false,
     },
@@ -1403,6 +1422,239 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'getUserById',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminUsersController_disableUser: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
+                notFound: {"in":"res","name":"404","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+        };
+        app.post('/admin/users/:userId/disable',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController.prototype.disableUser)),
+
+            async function AdminUsersController_disableUser(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminUsersController_disableUser, request, response });
+
+                const controller = new AdminUsersController();
+
+              await templateService.apiHandler({
+                methodName: 'disableUser',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminUsersController_enableUser: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
+                notFound: {"in":"res","name":"404","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+        };
+        app.post('/admin/users/:userId/enable',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController.prototype.enableUser)),
+
+            async function AdminUsersController_enableUser(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminUsersController_enableUser, request, response });
+
+                const controller = new AdminUsersController();
+
+              await templateService.apiHandler({
+                methodName: 'enableUser',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminUsersController_forceLogoutUser: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
+                notFound: {"in":"res","name":"404","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+        };
+        app.post('/admin/users/:userId/force-logout',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController.prototype.forceLogoutUser)),
+
+            async function AdminUsersController_forceLogoutUser(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminUsersController_forceLogoutUser, request, response });
+
+                const controller = new AdminUsersController();
+
+              await templateService.apiHandler({
+                methodName: 'forceLogoutUser',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminUsersController_resendVerification: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
+                notFound: {"in":"res","name":"404","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+                conflict: {"in":"res","name":"409","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+                tooMany: {"in":"res","name":"429","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+        };
+        app.post('/admin/users/:userId/resend-verification',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController.prototype.resendVerification)),
+
+            async function AdminUsersController_resendVerification(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminUsersController_resendVerification, request, response });
+
+                const controller = new AdminUsersController();
+
+              await templateService.apiHandler({
+                methodName: 'resendVerification',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminUsersController_promoteUser: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
+                notFound: {"in":"res","name":"404","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+        };
+        app.post('/admin/users/:userId/promote',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController.prototype.promoteUser)),
+
+            async function AdminUsersController_promoteUser(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminUsersController_promoteUser, request, response });
+
+                const controller = new AdminUsersController();
+
+              await templateService.apiHandler({
+                methodName: 'promoteUser',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminUsersController_demoteUser: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
+                notFound: {"in":"res","name":"404","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+                conflict: {"in":"res","name":"409","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
+        };
+        app.post('/admin/users/:userId/demote',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminUsersController.prototype.demoteUser)),
+
+            async function AdminUsersController_demoteUser(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminUsersController_demoteUser, request, response });
+
+                const controller = new AdminUsersController();
+
+              await templateService.apiHandler({
+                methodName: 'demoteUser',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminAuditLogController_listAuditLogs: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                limit: {"in":"query","name":"limit","dataType":"double"},
+        };
+        app.get('/admin/audit-logs',
+            authenticateMiddleware([{"jwt":["platform_admin"]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminAuditLogController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminAuditLogController.prototype.listAuditLogs)),
+
+            async function AdminAuditLogController_listAuditLogs(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminAuditLogController_listAuditLogs, request, response });
+
+                const controller = new AdminAuditLogController();
+
+              await templateService.apiHandler({
+                methodName: 'listAuditLogs',
                 controller,
                 response,
                 next,

--- a/apps/backend/src/services/UserService.lifecycle.test.ts
+++ b/apps/backend/src/services/UserService.lifecycle.test.ts
@@ -1,0 +1,386 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+import {
+  EmailAlreadyVerifiedError,
+  LastPlatformAdminError,
+  UserNotFoundError,
+  VerificationCooldownError,
+} from '../errors/AdminLifecycleErrors';
+import userService from './UserService';
+
+type AsyncMock = jest.Mock<(...args: unknown[]) => Promise<unknown>>;
+type CountMock = jest.Mock<(...args: unknown[]) => Promise<number>>;
+
+type MockPrismaClient = {
+  user: {
+    findUnique: AsyncMock;
+    update: AsyncMock;
+    count: CountMock;
+  };
+  adminAuditLog: {
+    create: AsyncMock;
+    findMany: AsyncMock;
+  };
+  $transaction: AsyncMock;
+};
+
+jest.mock('../prisma', () => {
+  const __mockPrisma = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      count: jest.fn(),
+    },
+    adminAuditLog: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+    $transaction: jest.fn(async (fn: (tx: typeof __mockPrisma) => unknown) =>
+      fn(__mockPrisma),
+    ),
+  };
+
+  return {
+    __esModule: true,
+    __mockPrisma,
+    createPrismaClient: jest.fn(() => __mockPrisma),
+    PrismaClient: jest.fn(),
+  };
+});
+
+jest.mock('./EmailService', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../helpers/ApiTokens', () => ({
+  __esModule: true,
+  default: {
+    generateEmailVerificationToken: jest.fn(),
+  },
+}));
+
+const mockPrisma = require('../prisma').__mockPrisma as MockPrismaClient;
+
+const ACTOR_ID = 'actor-1';
+const TARGET_ID = 'target-1';
+
+type IdentityUser = {
+  id: string;
+  name: string;
+  first_name: string;
+  last_name: string;
+  phone: null;
+  email: string;
+  role: 'user' | 'platform_admin';
+  disabled: boolean;
+  email_verification_timestamp: null;
+};
+
+const identityUser: IdentityUser = {
+  id: TARGET_ID,
+  name: 'Target User',
+  first_name: 'Target',
+  last_name: 'User',
+  phone: null,
+  email: 'target@example.com',
+  role: 'user',
+  disabled: false,
+  email_verification_timestamp: null,
+};
+
+const fullUser = {
+  id: TARGET_ID,
+  email: 'target@example.com',
+  name: 'Target User',
+  email_verification_timestamp: null,
+  email_verification_token: null,
+};
+
+function mockIdentityLookup(user: IdentityUser | null = identityUser) {
+  mockPrisma.user.findUnique.mockImplementation(
+    ({ select }: { select?: unknown }) => {
+      if (select) {
+        return Promise.resolve(user);
+      }
+      return Promise.resolve(user ? fullUser : null);
+    },
+  );
+}
+
+describe('UserService lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrisma.$transaction.mockImplementation(
+      async (fn: (tx: MockPrismaClient) => unknown) => fn(mockPrisma),
+    );
+  });
+
+  describe('disableUser', () => {
+    test('sets disabled and sessions_invalidated_at and writes disable audit', async () => {
+      mockIdentityLookup();
+      const updated = { ...identityUser, disabled: true };
+      mockPrisma.user.update.mockResolvedValue(updated);
+      mockPrisma.adminAuditLog.create.mockResolvedValue({});
+
+      const result = await userService.disableUser(ACTOR_ID, TARGET_ID);
+
+      expect(result).toEqual(updated);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: TARGET_ID },
+        data: {
+          disabled: true,
+          sessions_invalidated_at: expect.any(Date),
+        },
+        select: expect.objectContaining({ id: true, disabled: true }),
+      });
+      expect(mockPrisma.adminAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          actor_user_id: ACTOR_ID,
+          target_user_id: TARGET_ID,
+          action: 'disable',
+        },
+      });
+    });
+
+    test('throws UserNotFoundError when target is missing', async () => {
+      mockIdentityLookup(null);
+
+      await expect(
+        userService.disableUser(ACTOR_ID, TARGET_ID),
+      ).rejects.toThrow(UserNotFoundError);
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('enableUser', () => {
+    test('clears disabled flag without touching sessions_invalidated_at', async () => {
+      mockIdentityLookup({ ...identityUser, disabled: true });
+      const updated = { ...identityUser, disabled: false };
+      mockPrisma.user.update.mockResolvedValue(updated);
+      mockPrisma.adminAuditLog.create.mockResolvedValue({});
+
+      const result = await userService.enableUser(ACTOR_ID, TARGET_ID);
+
+      expect(result).toEqual(updated);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: TARGET_ID },
+        data: { disabled: false },
+        select: expect.objectContaining({ id: true, disabled: true }),
+      });
+      expect(mockPrisma.adminAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          actor_user_id: ACTOR_ID,
+          target_user_id: TARGET_ID,
+          action: 'enable',
+        },
+      });
+    });
+  });
+
+  describe('forceLogoutUser', () => {
+    test('sets sessions_invalidated_at without disabling the account', async () => {
+      mockIdentityLookup();
+      mockPrisma.user.update.mockResolvedValue(identityUser);
+      mockPrisma.adminAuditLog.create.mockResolvedValue({});
+
+      const result = await userService.forceLogoutUser(ACTOR_ID, TARGET_ID);
+
+      expect(result).toEqual(identityUser);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: TARGET_ID },
+        data: { sessions_invalidated_at: expect.any(Date) },
+        select: expect.objectContaining({ id: true, disabled: true }),
+      });
+      expect(
+        (
+          mockPrisma.user.update.mock.calls[0][0] as {
+            data: Record<string, unknown>;
+          }
+        ).data,
+      ).not.toHaveProperty('disabled');
+      expect(mockPrisma.adminAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          actor_user_id: ACTOR_ID,
+          target_user_id: TARGET_ID,
+          action: 'force_logout',
+        },
+      });
+    });
+  });
+
+  describe('promoteUser', () => {
+    test('promotes a user to platform_admin and writes promote audit', async () => {
+      mockIdentityLookup();
+      const promoted = { ...identityUser, role: 'platform_admin' as const };
+      mockPrisma.user.update.mockResolvedValue(promoted);
+      mockPrisma.adminAuditLog.create.mockResolvedValue({});
+
+      const result = await userService.promoteUser(ACTOR_ID, TARGET_ID);
+
+      expect(result).toEqual(promoted);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: TARGET_ID },
+        data: { role: 'platform_admin' },
+        select: expect.objectContaining({ role: true }),
+      });
+      expect(mockPrisma.adminAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          actor_user_id: ACTOR_ID,
+          target_user_id: TARGET_ID,
+          action: 'promote',
+        },
+      });
+    });
+  });
+
+  describe('demoteUser', () => {
+    test('demotes platform_admin when more than one admin exists', async () => {
+      mockIdentityLookup({ ...identityUser, role: 'platform_admin' });
+      mockPrisma.user.count.mockResolvedValue(2);
+      const demoted = { ...identityUser, role: 'user' as const };
+      mockPrisma.user.update.mockResolvedValue(demoted);
+      mockPrisma.adminAuditLog.create.mockResolvedValue({});
+
+      const result = await userService.demoteUser(ACTOR_ID, TARGET_ID);
+
+      expect(result).toEqual(demoted);
+      expect(mockPrisma.user.count).toHaveBeenCalledWith({
+        where: { role: 'platform_admin' },
+      });
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: TARGET_ID },
+        data: { role: 'user' },
+        select: expect.objectContaining({ role: true }),
+      });
+      expect(mockPrisma.adminAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          actor_user_id: ACTOR_ID,
+          target_user_id: TARGET_ID,
+          action: 'demote',
+        },
+      });
+    });
+
+    test('throws LastPlatformAdminError when target is the last platform admin', async () => {
+      mockIdentityLookup({ ...identityUser, role: 'platform_admin' });
+      mockPrisma.user.count.mockResolvedValue(1);
+
+      await expect(userService.demoteUser(ACTOR_ID, TARGET_ID)).rejects.toThrow(
+        LastPlatformAdminError,
+      );
+
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+      expect(mockPrisma.adminAuditLog.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('adminResendVerification', () => {
+    test('stores verification token and writes resend_verification audit on success', async () => {
+      mockIdentityLookup();
+      const sendSpy = jest
+        .spyOn(userService, 'sendVerificationMail')
+        .mockResolvedValue('new-verification-token');
+      mockPrisma.user.update.mockResolvedValue({});
+      mockPrisma.adminAuditLog.create.mockResolvedValue({});
+
+      const result = await userService.adminResendVerification(
+        ACTOR_ID,
+        TARGET_ID,
+      );
+
+      expect(result).toEqual(identityUser);
+      expect(sendSpy).toHaveBeenCalledWith(fullUser);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: TARGET_ID },
+        data: { email_verification_token: 'new-verification-token' },
+      });
+      expect(mockPrisma.adminAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          actor_user_id: ACTOR_ID,
+          target_user_id: TARGET_ID,
+          action: 'resend_verification',
+        },
+      });
+
+      sendSpy.mockRestore();
+    });
+
+    test('throws VerificationCooldownError and skips audit when email was sent recently', async () => {
+      mockIdentityLookup();
+      const sendSpy = jest
+        .spyOn(userService, 'sendVerificationMail')
+        .mockResolvedValue(
+          new Error('Verification email already sent recently'),
+        );
+
+      await expect(
+        userService.adminResendVerification(ACTOR_ID, TARGET_ID),
+      ).rejects.toThrow(VerificationCooldownError);
+
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+      expect(mockPrisma.adminAuditLog.create).not.toHaveBeenCalled();
+
+      sendSpy.mockRestore();
+    });
+
+    test('throws EmailAlreadyVerifiedError and skips audit when already verified', async () => {
+      mockIdentityLookup();
+      const sendSpy = jest
+        .spyOn(userService, 'sendVerificationMail')
+        .mockResolvedValue(new Error('Email already verified'));
+
+      await expect(
+        userService.adminResendVerification(ACTOR_ID, TARGET_ID),
+      ).rejects.toThrow(EmailAlreadyVerifiedError);
+
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+      expect(mockPrisma.adminAuditLog.create).not.toHaveBeenCalled();
+
+      sendSpy.mockRestore();
+    });
+  });
+
+  describe('listAdminAuditLogs', () => {
+    test('returns newest-first rows and clamps limit between 1 and 200', async () => {
+      const rows = [
+        {
+          id: 'log-2',
+          actor_user_id: ACTOR_ID,
+          target_user_id: TARGET_ID,
+          action: 'disable',
+          created_at: new Date('2025-06-02T00:00:00.000Z'),
+        },
+        {
+          id: 'log-1',
+          actor_user_id: ACTOR_ID,
+          target_user_id: TARGET_ID,
+          action: 'enable',
+          created_at: new Date('2025-06-01T00:00:00.000Z'),
+        },
+      ];
+      mockPrisma.adminAuditLog.findMany.mockResolvedValue(rows);
+
+      const result = await userService.listAdminAuditLogs(500);
+
+      expect(result).toEqual(rows);
+      expect(mockPrisma.adminAuditLog.findMany).toHaveBeenCalledWith({
+        take: 200,
+        orderBy: { created_at: 'desc' },
+        select: {
+          id: true,
+          actor_user_id: true,
+          target_user_id: true,
+          action: true,
+          created_at: true,
+        },
+      });
+
+      mockPrisma.adminAuditLog.findMany.mockClear();
+      await userService.listAdminAuditLogs(0);
+      expect(mockPrisma.adminAuditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 1 }),
+      );
+    });
+  });
+});

--- a/apps/backend/src/services/UserService.ts
+++ b/apps/backend/src/services/UserService.ts
@@ -2,10 +2,22 @@ import bcrypt from 'bcrypt';
 import fs from 'fs';
 import { JsonWebTokenError, JwtPayload, TokenExpiredError } from 'jsonwebtoken';
 import path from 'path';
+import {
+  EmailAlreadyVerifiedError,
+  LastPlatformAdminError,
+  UserNotFoundError,
+  VerificationCooldownError,
+  VerificationSendFailedError,
+} from '../errors/AdminLifecycleErrors';
 import apiTokens from '../helpers/ApiTokens';
 import { decodeToken } from '../helpers/jwtHelper';
 import { User, UserCreationBody } from '../models/User';
-import { Prisma, PrismaClient, createPrismaClient } from '../prisma';
+import {
+  AdminAuditAction,
+  Prisma,
+  PrismaClient,
+  createPrismaClient,
+} from '../prisma';
 import sendEmail from './EmailService';
 
 /** Fields safe to return from Platform Admin directory APIs. */
@@ -24,6 +36,14 @@ const ADMIN_IDENTITY_SELECT = {
 export type AdminIdentityUser = Prisma.UserGetPayload<{
   select: typeof ADMIN_IDENTITY_SELECT;
 }>;
+
+export type AdminAuditLogRow = {
+  id: string;
+  actor_user_id: string;
+  target_user_id: string;
+  action: AdminAuditAction;
+  created_at: Date;
+};
 
 class UserService {
   Users: User[] = [];
@@ -83,6 +103,7 @@ class UserService {
   /**
    * Elevate an existing User to platform_admin by email.
    * Idempotent: no-op if already platform_admin. Returns null if no User matches.
+   * Bootstrap path only — does not write an Admin Audit Log entry.
    */
   async elevateToPlatformAdminByEmail(
     email: string,
@@ -104,6 +125,220 @@ class UserService {
       where: { id: existing.id },
       data: { role: 'platform_admin' },
       select: ADMIN_IDENTITY_SELECT,
+    });
+  }
+
+  private async writeAdminAuditLog(
+    tx: Prisma.TransactionClient,
+    actorUserId: string,
+    targetUserId: string,
+    action: AdminAuditAction,
+  ): Promise<void> {
+    await tx.adminAuditLog.create({
+      data: {
+        actor_user_id: actorUserId,
+        target_user_id: targetUserId,
+        action,
+      },
+    });
+  }
+
+  private async requireIdentityUser(
+    userId: string,
+  ): Promise<AdminIdentityUser> {
+    const user = await this.getIdentityById(userId);
+    if (!user) {
+      throw new UserNotFoundError();
+    }
+    return user;
+  }
+
+  /**
+   * Soft-block a User and invalidate active refresh/access sessions immediately.
+   */
+  async disableUser(
+    actorUserId: string,
+    targetUserId: string,
+  ): Promise<AdminIdentityUser> {
+    await this.requireIdentityUser(targetUserId);
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.user.update({
+        where: { id: targetUserId },
+        data: {
+          disabled: true,
+          sessions_invalidated_at: new Date(),
+        },
+        select: ADMIN_IDENTITY_SELECT,
+      });
+      await this.writeAdminAuditLog(tx, actorUserId, targetUserId, 'disable');
+      return updated;
+    });
+  }
+
+  /**
+   * Re-enable a Disabled User so authentication works again.
+   * Does not restore previously invalidated sessions.
+   */
+  async enableUser(
+    actorUserId: string,
+    targetUserId: string,
+  ): Promise<AdminIdentityUser> {
+    await this.requireIdentityUser(targetUserId);
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.user.update({
+        where: { id: targetUserId },
+        data: { disabled: false },
+        select: ADMIN_IDENTITY_SELECT,
+      });
+      await this.writeAdminAuditLog(tx, actorUserId, targetUserId, 'enable');
+      return updated;
+    });
+  }
+
+  /**
+   * Invalidate all refresh/access sessions without disabling the account.
+   */
+  async forceLogoutUser(
+    actorUserId: string,
+    targetUserId: string,
+  ): Promise<AdminIdentityUser> {
+    await this.requireIdentityUser(targetUserId);
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.user.update({
+        where: { id: targetUserId },
+        data: { sessions_invalidated_at: new Date() },
+        select: ADMIN_IDENTITY_SELECT,
+      });
+      await this.writeAdminAuditLog(
+        tx,
+        actorUserId,
+        targetUserId,
+        'force_logout',
+      );
+      return updated;
+    });
+  }
+
+  /**
+   * Promote a User to Platform Admin. Idempotent if already platform_admin.
+   */
+  async promoteUser(
+    actorUserId: string,
+    targetUserId: string,
+  ): Promise<AdminIdentityUser> {
+    const existing = await this.requireIdentityUser(targetUserId);
+
+    if (existing.role === 'platform_admin') {
+      await this.prisma.$transaction(async (tx) => {
+        await this.writeAdminAuditLog(tx, actorUserId, targetUserId, 'promote');
+      });
+      return existing;
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.user.update({
+        where: { id: targetUserId },
+        data: { role: 'platform_admin' },
+        select: ADMIN_IDENTITY_SELECT,
+      });
+      await this.writeAdminAuditLog(tx, actorUserId, targetUserId, 'promote');
+      return updated;
+    });
+  }
+
+  /**
+   * Demote a Platform Admin to a normal User.
+   * Rejects when the target is the last Platform Admin.
+   */
+  async demoteUser(
+    actorUserId: string,
+    targetUserId: string,
+  ): Promise<AdminIdentityUser> {
+    const existing = await this.requireIdentityUser(targetUserId);
+
+    if (existing.role !== 'platform_admin') {
+      await this.prisma.$transaction(async (tx) => {
+        await this.writeAdminAuditLog(tx, actorUserId, targetUserId, 'demote');
+      });
+      return existing;
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const adminCount = await tx.user.count({
+        where: { role: 'platform_admin' },
+      });
+      if (adminCount <= 1) {
+        throw new LastPlatformAdminError();
+      }
+
+      const updated = await tx.user.update({
+        where: { id: targetUserId },
+        data: { role: 'user' },
+        select: ADMIN_IDENTITY_SELECT,
+      });
+      await this.writeAdminAuditLog(tx, actorUserId, targetUserId, 'demote');
+      return updated;
+    });
+  }
+
+  /**
+   * Admin-triggered verification email resend.
+   * Reuses public cooldown / already-verified semantics.
+   */
+  async adminResendVerification(
+    actorUserId: string,
+    targetUserId: string,
+  ): Promise<AdminIdentityUser> {
+    const identity = await this.requireIdentityUser(targetUserId);
+    const user = await this.getById(targetUserId);
+    if (!user) {
+      throw new UserNotFoundError();
+    }
+
+    const token = await this.sendVerificationMail(user);
+    if (token instanceof Error) {
+      if (token.message.includes('already verified')) {
+        throw new EmailAlreadyVerifiedError();
+      }
+      if (token.message.includes('already sent recently')) {
+        throw new VerificationCooldownError();
+      }
+      throw new VerificationSendFailedError();
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: targetUserId },
+        data: { email_verification_token: token },
+      });
+      await this.writeAdminAuditLog(
+        tx,
+        actorUserId,
+        targetUserId,
+        'resend_verification',
+      );
+      return identity;
+    });
+  }
+
+  /**
+   * List recent Admin Audit Log entries (newest first).
+   */
+  async listAdminAuditLogs(limit = 50): Promise<AdminAuditLogRow[]> {
+    const take = Math.min(Math.max(limit, 1), 200);
+    return this.prisma.adminAuditLog.findMany({
+      take,
+      orderBy: { created_at: 'desc' },
+      select: {
+        id: true,
+        actor_user_id: true,
+        target_user_id: true,
+        action: true,
+        created_at: true,
+      },
     });
   }
 

--- a/apps/backend/src/swagger/swagger.yaml
+++ b/apps/backend/src/swagger/swagger.yaml
@@ -621,6 +621,37 @@ components:
         - emailVerified
       type: object
       additionalProperties: false
+    AdminAuditAction:
+      type: string
+      enum:
+        - disable
+        - enable
+        - force_logout
+        - resend_verification
+        - promote
+        - demote
+    AdminAuditLogEntry:
+      description: Platform Admin Audit Log entry returned by list APIs.
+      properties:
+        id:
+          type: string
+        actorUserId:
+          type: string
+        targetUserId:
+          type: string
+        action:
+          $ref: "#/components/schemas/AdminAuditAction"
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - actorUserId
+        - targetUserId
+        - action
+        - createdAt
+      type: object
+      additionalProperties: false
   securitySchemes:
     OAuth2PasswordSecurity:
       type: oauth2
@@ -1536,6 +1567,270 @@ paths:
           required: true
           schema:
             type: string
+  /admin/users/{userId}/disable:
+    post:
+      operationId: DisableUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Disable a User (soft-block) and invalidate active sessions immediately.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/enable:
+    post:
+      operationId: EnableUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Re-enable a Disabled User so authentication works again.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/force-logout:
+    post:
+      operationId: ForceLogoutUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Force logout a User without disabling the account.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/resend-verification:
+    post:
+      operationId: ResendVerification
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+        "409":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+        "429":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Resend verification email for an unverified User (existing cooldown
+        rules).
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/promote:
+    post:
+      operationId: PromoteUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Promote a User to Platform Admin.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/demote:
+    post:
+      operationId: DemoteUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+        "409":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: |-
+        Demote a Platform Admin to a normal User.
+        Rejects demotion of the last Platform Admin.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/audit-logs:
+    get:
+      operationId: ListAuditLogs
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AdminAuditLogEntry"
+                type: array
+      description: List recent Admin Audit Log entries (newest first). Platform Admin only.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          schema:
+            format: double
+            type: number
 servers:
   - url: http://localhost:3000/api/v1/
     description: Local server

--- a/apps/backend/src/types/index.ts
+++ b/apps/backend/src/types/index.ts
@@ -47,6 +47,23 @@ export interface AdminUserIdentity {
   emailVerified: boolean;
 }
 
+export type AdminAuditAction =
+  | 'disable'
+  | 'enable'
+  | 'force_logout'
+  | 'resend_verification'
+  | 'promote'
+  | 'demote';
+
+/** Platform Admin Audit Log entry returned by list APIs. */
+export interface AdminAuditLogEntry {
+  id: string;
+  actorUserId: string;
+  targetUserId: string;
+  action: AdminAuditAction;
+  createdAt: Date;
+}
+
 export class MyError extends Error {
   public statusCode;
   public data;

--- a/apps/backend/src/utils/passport.ts
+++ b/apps/backend/src/utils/passport.ts
@@ -2,6 +2,7 @@ import bcrypt from 'bcrypt';
 import passport from 'passport';
 import jwtStrat, { ExtractJwt } from 'passport-jwt';
 import localStrat from 'passport-local';
+import { isTokenIssuedBeforeInvalidation } from '../helpers/sessionInvalidation';
 import { User } from '../models/User';
 import { createPrismaClient } from '../prisma';
 
@@ -82,6 +83,15 @@ passport.use(
             return done(null, false);
           }
           if ((user as { disabled?: boolean }).disabled) {
+            return done(null, false);
+          }
+          if (
+            isTokenIssuedBeforeInvalidation(
+              jwt_payload.iat,
+              (user as { sessions_invalidated_at?: Date | null })
+                .sessions_invalidated_at,
+            )
+          ) {
             return done(null, false);
           }
           return done(null, user);

--- a/libs/api-specs/src/api-specs.openapi.yaml
+++ b/libs/api-specs/src/api-specs.openapi.yaml
@@ -621,6 +621,37 @@ components:
         - emailVerified
       type: object
       additionalProperties: false
+    AdminAuditAction:
+      type: string
+      enum:
+        - disable
+        - enable
+        - force_logout
+        - resend_verification
+        - promote
+        - demote
+    AdminAuditLogEntry:
+      description: Platform Admin Audit Log entry returned by list APIs.
+      properties:
+        id:
+          type: string
+        actorUserId:
+          type: string
+        targetUserId:
+          type: string
+        action:
+          $ref: "#/components/schemas/AdminAuditAction"
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - actorUserId
+        - targetUserId
+        - action
+        - createdAt
+      type: object
+      additionalProperties: false
   securitySchemes:
     OAuth2PasswordSecurity:
       type: oauth2
@@ -1536,6 +1567,270 @@ paths:
           required: true
           schema:
             type: string
+  /admin/users/{userId}/disable:
+    post:
+      operationId: DisableUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Disable a User (soft-block) and invalidate active sessions immediately.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/enable:
+    post:
+      operationId: EnableUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Re-enable a Disabled User so authentication works again.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/force-logout:
+    post:
+      operationId: ForceLogoutUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Force logout a User without disabling the account.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/resend-verification:
+    post:
+      operationId: ResendVerification
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+        "409":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+        "429":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Resend verification email for an unverified User (existing cooldown
+        rules).
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/promote:
+    post:
+      operationId: PromoteUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: Promote a User to Platform Admin.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/users/{userId}/demote:
+    post:
+      operationId: DemoteUser
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserIdentity"
+        "404":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+        "409":
+          description: ""
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+                type: object
+      description: |-
+        Demote a Platform Admin to a normal User.
+        Rejects demotion of the last Platform Admin.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+  /admin/audit-logs:
+    get:
+      operationId: ListAuditLogs
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AdminAuditLogEntry"
+                type: array
+      description: List recent Admin Audit Log entries (newest first). Platform Admin only.
+      tags:
+        - Platform Admin
+      security:
+        - jwt:
+            - platform_admin
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          schema:
+            format: double
+            type: number
 servers:
   - url: http://localhost:3000/api/v1/
     description: Local server

--- a/libs/app-api-client/src/api.ts
+++ b/libs/app-api-client/src/api.ts
@@ -24,6 +24,63 @@ import type { RequestArgs } from './base';
 import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerMap } from './base';
 
 /**
+ * 
+ * @export
+ * @enum {string}
+ */
+
+export const AdminAuditAction = {
+    Disable: 'disable',
+    Enable: 'enable',
+    ForceLogout: 'force_logout',
+    ResendVerification: 'resend_verification',
+    Promote: 'promote',
+    Demote: 'demote'
+} as const;
+
+export type AdminAuditAction = typeof AdminAuditAction[keyof typeof AdminAuditAction];
+
+
+/**
+ * Platform Admin Audit Log entry returned by list APIs.
+ * @export
+ * @interface AdminAuditLogEntry
+ */
+export interface AdminAuditLogEntry {
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminAuditLogEntry
+     */
+    'id': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminAuditLogEntry
+     */
+    'actorUserId': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminAuditLogEntry
+     */
+    'targetUserId': string;
+    /**
+     * 
+     * @type {AdminAuditAction}
+     * @memberof AdminAuditLogEntry
+     */
+    'action': AdminAuditAction;
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminAuditLogEntry
+     */
+    'createdAt': string;
+}
+
+
+/**
  * Identity-only User projection for Platform Admin directory APIs.
  * @export
  * @interface AdminUserIdentity
@@ -2728,6 +2785,154 @@ export class AuthenticationApi extends BaseAPI {
 export const PlatformAdminApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
+         * Demote a Platform Admin to a normal User. Rejects demotion of the last Platform Admin.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        demoteUser: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('demoteUser', 'userId', userId)
+            const localVarPath = `/admin/users/{userId}/demote`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication jwt required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Disable a User (soft-block) and invalidate active sessions immediately.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        disableUser: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('disableUser', 'userId', userId)
+            const localVarPath = `/admin/users/{userId}/disable`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication jwt required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Re-enable a Disabled User so authentication works again.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        enableUser: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('enableUser', 'userId', userId)
+            const localVarPath = `/admin/users/{userId}/enable`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication jwt required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Force logout a User without disabling the account.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        forceLogoutUser: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('forceLogoutUser', 'userId', userId)
+            const localVarPath = `/admin/users/{userId}/force-logout`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication jwt required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Get a User by id (identity fields only). Platform Admin only.
          * @param {string} userId 
          * @param {*} [options] Override http request option.
@@ -2752,6 +2957,44 @@ export const PlatformAdminApiAxiosParamCreator = function (configuration?: Confi
             // authentication jwt required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * List recent Admin Audit Log entries (newest first). Platform Admin only.
+         * @param {number} [limit] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listAuditLogs: async (limit?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/admin/audit-logs`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication jwt required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (limit !== undefined) {
+                localVarQueryParameter['limit'] = limit;
+            }
 
 
     
@@ -2802,6 +3045,80 @@ export const PlatformAdminApiAxiosParamCreator = function (configuration?: Confi
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Promote a User to Platform Admin.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        promoteUser: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('promoteUser', 'userId', userId)
+            const localVarPath = `/admin/users/{userId}/promote`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication jwt required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Resend verification email for an unverified User (existing cooldown rules).
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resendVerification: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('resendVerification', 'userId', userId)
+            const localVarPath = `/admin/users/{userId}/resend-verification`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication jwt required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -2813,6 +3130,54 @@ export const PlatformAdminApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = PlatformAdminApiAxiosParamCreator(configuration)
     return {
         /**
+         * Demote a Platform Admin to a normal User. Rejects demotion of the last Platform Admin.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async demoteUser(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminUserIdentity>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.demoteUser(userId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.demoteUser']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Disable a User (soft-block) and invalidate active sessions immediately.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async disableUser(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminUserIdentity>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.disableUser(userId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.disableUser']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Re-enable a Disabled User so authentication works again.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async enableUser(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminUserIdentity>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.enableUser(userId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.enableUser']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Force logout a User without disabling the account.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async forceLogoutUser(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminUserIdentity>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.forceLogoutUser(userId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.forceLogoutUser']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Get a User by id (identity fields only). Platform Admin only.
          * @param {string} userId 
          * @param {*} [options] Override http request option.
@@ -2822,6 +3187,18 @@ export const PlatformAdminApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getUserById(userId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.getUserById']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * List recent Admin Audit Log entries (newest first). Platform Admin only.
+         * @param {number} [limit] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async listAuditLogs(limit?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<AdminAuditLogEntry>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listAuditLogs(limit, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.listAuditLogs']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -2836,6 +3213,30 @@ export const PlatformAdminApiFp = function(configuration?: Configuration) {
             const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.listUsers']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
+        /**
+         * Promote a User to Platform Admin.
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async promoteUser(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminUserIdentity>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.promoteUser(userId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.promoteUser']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Resend verification email for an unverified User (existing cooldown rules).
+         * @param {string} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async resendVerification(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Login401Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.resendVerification(userId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['PlatformAdminApi.resendVerification']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
     }
 };
 
@@ -2847,6 +3248,42 @@ export const PlatformAdminApiFactory = function (configuration?: Configuration, 
     const localVarFp = PlatformAdminApiFp(configuration)
     return {
         /**
+         * Demote a Platform Admin to a normal User. Rejects demotion of the last Platform Admin.
+         * @param {PlatformAdminApiDemoteUserRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        demoteUser(requestParameters: PlatformAdminApiDemoteUserRequest, options?: RawAxiosRequestConfig): AxiosPromise<AdminUserIdentity> {
+            return localVarFp.demoteUser(requestParameters.userId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Disable a User (soft-block) and invalidate active sessions immediately.
+         * @param {PlatformAdminApiDisableUserRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        disableUser(requestParameters: PlatformAdminApiDisableUserRequest, options?: RawAxiosRequestConfig): AxiosPromise<AdminUserIdentity> {
+            return localVarFp.disableUser(requestParameters.userId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Re-enable a Disabled User so authentication works again.
+         * @param {PlatformAdminApiEnableUserRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        enableUser(requestParameters: PlatformAdminApiEnableUserRequest, options?: RawAxiosRequestConfig): AxiosPromise<AdminUserIdentity> {
+            return localVarFp.enableUser(requestParameters.userId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Force logout a User without disabling the account.
+         * @param {PlatformAdminApiForceLogoutUserRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        forceLogoutUser(requestParameters: PlatformAdminApiForceLogoutUserRequest, options?: RawAxiosRequestConfig): AxiosPromise<AdminUserIdentity> {
+            return localVarFp.forceLogoutUser(requestParameters.userId, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Get a User by id (identity fields only). Platform Admin only.
          * @param {PlatformAdminApiGetUserByIdRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
@@ -2854,6 +3291,15 @@ export const PlatformAdminApiFactory = function (configuration?: Configuration, 
          */
         getUserById(requestParameters: PlatformAdminApiGetUserByIdRequest, options?: RawAxiosRequestConfig): AxiosPromise<AdminUserIdentity> {
             return localVarFp.getUserById(requestParameters.userId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * List recent Admin Audit Log entries (newest first). Platform Admin only.
+         * @param {PlatformAdminApiListAuditLogsRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listAuditLogs(requestParameters: PlatformAdminApiListAuditLogsRequest = {}, options?: RawAxiosRequestConfig): AxiosPromise<Array<AdminAuditLogEntry>> {
+            return localVarFp.listAuditLogs(requestParameters.limit, options).then((request) => request(axios, basePath));
         },
         /**
          * List/search Users (identity fields only). Platform Admin only.
@@ -2864,8 +3310,82 @@ export const PlatformAdminApiFactory = function (configuration?: Configuration, 
         listUsers(requestParameters: PlatformAdminApiListUsersRequest = {}, options?: RawAxiosRequestConfig): AxiosPromise<Array<AdminUserIdentity>> {
             return localVarFp.listUsers(requestParameters.q, options).then((request) => request(axios, basePath));
         },
+        /**
+         * Promote a User to Platform Admin.
+         * @param {PlatformAdminApiPromoteUserRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        promoteUser(requestParameters: PlatformAdminApiPromoteUserRequest, options?: RawAxiosRequestConfig): AxiosPromise<AdminUserIdentity> {
+            return localVarFp.promoteUser(requestParameters.userId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Resend verification email for an unverified User (existing cooldown rules).
+         * @param {PlatformAdminApiResendVerificationRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resendVerification(requestParameters: PlatformAdminApiResendVerificationRequest, options?: RawAxiosRequestConfig): AxiosPromise<Login401Response> {
+            return localVarFp.resendVerification(requestParameters.userId, options).then((request) => request(axios, basePath));
+        },
     };
 };
+
+/**
+ * Request parameters for demoteUser operation in PlatformAdminApi.
+ * @export
+ * @interface PlatformAdminApiDemoteUserRequest
+ */
+export interface PlatformAdminApiDemoteUserRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof PlatformAdminApiDemoteUser
+     */
+    readonly userId: string
+}
+
+/**
+ * Request parameters for disableUser operation in PlatformAdminApi.
+ * @export
+ * @interface PlatformAdminApiDisableUserRequest
+ */
+export interface PlatformAdminApiDisableUserRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof PlatformAdminApiDisableUser
+     */
+    readonly userId: string
+}
+
+/**
+ * Request parameters for enableUser operation in PlatformAdminApi.
+ * @export
+ * @interface PlatformAdminApiEnableUserRequest
+ */
+export interface PlatformAdminApiEnableUserRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof PlatformAdminApiEnableUser
+     */
+    readonly userId: string
+}
+
+/**
+ * Request parameters for forceLogoutUser operation in PlatformAdminApi.
+ * @export
+ * @interface PlatformAdminApiForceLogoutUserRequest
+ */
+export interface PlatformAdminApiForceLogoutUserRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof PlatformAdminApiForceLogoutUser
+     */
+    readonly userId: string
+}
 
 /**
  * Request parameters for getUserById operation in PlatformAdminApi.
@@ -2879,6 +3399,20 @@ export interface PlatformAdminApiGetUserByIdRequest {
      * @memberof PlatformAdminApiGetUserById
      */
     readonly userId: string
+}
+
+/**
+ * Request parameters for listAuditLogs operation in PlatformAdminApi.
+ * @export
+ * @interface PlatformAdminApiListAuditLogsRequest
+ */
+export interface PlatformAdminApiListAuditLogsRequest {
+    /**
+     * 
+     * @type {number}
+     * @memberof PlatformAdminApiListAuditLogs
+     */
+    readonly limit?: number
 }
 
 /**
@@ -2896,12 +3430,84 @@ export interface PlatformAdminApiListUsersRequest {
 }
 
 /**
+ * Request parameters for promoteUser operation in PlatformAdminApi.
+ * @export
+ * @interface PlatformAdminApiPromoteUserRequest
+ */
+export interface PlatformAdminApiPromoteUserRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof PlatformAdminApiPromoteUser
+     */
+    readonly userId: string
+}
+
+/**
+ * Request parameters for resendVerification operation in PlatformAdminApi.
+ * @export
+ * @interface PlatformAdminApiResendVerificationRequest
+ */
+export interface PlatformAdminApiResendVerificationRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof PlatformAdminApiResendVerification
+     */
+    readonly userId: string
+}
+
+/**
  * PlatformAdminApi - object-oriented interface
  * @export
  * @class PlatformAdminApi
  * @extends {BaseAPI}
  */
 export class PlatformAdminApi extends BaseAPI {
+    /**
+     * Demote a Platform Admin to a normal User. Rejects demotion of the last Platform Admin.
+     * @param {PlatformAdminApiDemoteUserRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlatformAdminApi
+     */
+    public demoteUser(requestParameters: PlatformAdminApiDemoteUserRequest, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).demoteUser(requestParameters.userId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Disable a User (soft-block) and invalidate active sessions immediately.
+     * @param {PlatformAdminApiDisableUserRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlatformAdminApi
+     */
+    public disableUser(requestParameters: PlatformAdminApiDisableUserRequest, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).disableUser(requestParameters.userId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Re-enable a Disabled User so authentication works again.
+     * @param {PlatformAdminApiEnableUserRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlatformAdminApi
+     */
+    public enableUser(requestParameters: PlatformAdminApiEnableUserRequest, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).enableUser(requestParameters.userId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Force logout a User without disabling the account.
+     * @param {PlatformAdminApiForceLogoutUserRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlatformAdminApi
+     */
+    public forceLogoutUser(requestParameters: PlatformAdminApiForceLogoutUserRequest, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).forceLogoutUser(requestParameters.userId, options).then((request) => request(this.axios, this.basePath));
+    }
+
     /**
      * Get a User by id (identity fields only). Platform Admin only.
      * @param {PlatformAdminApiGetUserByIdRequest} requestParameters Request parameters.
@@ -2914,6 +3520,17 @@ export class PlatformAdminApi extends BaseAPI {
     }
 
     /**
+     * List recent Admin Audit Log entries (newest first). Platform Admin only.
+     * @param {PlatformAdminApiListAuditLogsRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlatformAdminApi
+     */
+    public listAuditLogs(requestParameters: PlatformAdminApiListAuditLogsRequest = {}, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).listAuditLogs(requestParameters.limit, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
      * List/search Users (identity fields only). Platform Admin only.
      * @param {PlatformAdminApiListUsersRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -2922,6 +3539,28 @@ export class PlatformAdminApi extends BaseAPI {
      */
     public listUsers(requestParameters: PlatformAdminApiListUsersRequest = {}, options?: RawAxiosRequestConfig) {
         return PlatformAdminApiFp(this.configuration).listUsers(requestParameters.q, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Promote a User to Platform Admin.
+     * @param {PlatformAdminApiPromoteUserRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlatformAdminApi
+     */
+    public promoteUser(requestParameters: PlatformAdminApiPromoteUserRequest, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).promoteUser(requestParameters.userId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Resend verification email for an unverified User (existing cooldown rules).
+     * @param {PlatformAdminApiResendVerificationRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlatformAdminApi
+     */
+    public resendVerification(requestParameters: PlatformAdminApiResendVerificationRequest, options?: RawAxiosRequestConfig) {
+        return PlatformAdminApiFp(this.configuration).resendVerification(requestParameters.userId, options).then((request) => request(this.axios, this.basePath));
     }
 }
 


### PR DESCRIPTION
## Why
Implement platform admin user lifecycle APIs and audit logging.

## Changes
- Add administrative endpoints to disable/enable users, force logout, and resend verification
- Implement role promotion and demotion with a last-admin guard to prevent lockout
- Introduce AdminAuditLog model and list API to track all administrative actions
- Enforce session invalidation via sessions_invalidated_at and disabled status in auth middleware
- Sync OpenAPI specifications and generated API client for new admin routes
- Add comprehensive integration and unit tests for lifecycle operations
- Refs #199

## Validation
- Generated from 1 commit(s) on `feat/199-admin-lifecycle-apis`.
- Compared against base branch `main`.
