### PR TITLE
feat(admin): add platform admin console shell and user directory (#200)

### DIFF
--- a/apps/myorganizer/src/app/admin/layout.tsx
+++ b/apps/myorganizer/src/app/admin/layout.tsx
@@ -1,0 +1,34 @@
+import {
+  Separator,
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+  Toaster,
+} from '@myorganizer/web-ui';
+
+import { AdminGuard, AdminSidebar } from '@myorganizer/web-pages/admin';
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <AdminGuard>
+      <SidebarProvider>
+        <AdminSidebar />
+        <SidebarInset>
+          <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
+            <div className="flex items-center gap-2 px-4">
+              <SidebarTrigger className="-ml-1" />
+              <Separator orientation="vertical" className="mr-2 h-4" />
+              <p className="text-sm font-medium">Platform Admin</p>
+            </div>
+          </header>
+          {children}
+        </SidebarInset>
+        <Toaster />
+      </SidebarProvider>
+    </AdminGuard>
+  );
+}

--- a/apps/myorganizer/src/app/admin/page.tsx
+++ b/apps/myorganizer/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { AdminHomePage } from '@myorganizer/web-pages/admin';
+
+export default function Page() {
+  return <AdminHomePage />;
+}

--- a/apps/myorganizer/src/app/admin/users/[userId]/page.tsx
+++ b/apps/myorganizer/src/app/admin/users/[userId]/page.tsx
@@ -1,0 +1,5 @@
+import { AdminUserDetailPage } from '@myorganizer/web-pages/admin';
+
+export default function Page() {
+  return <AdminUserDetailPage />;
+}

--- a/apps/myorganizer/src/app/admin/users/page.tsx
+++ b/apps/myorganizer/src/app/admin/users/page.tsx
@@ -1,0 +1,5 @@
+import { AdminUsersPage } from '@myorganizer/web-pages/admin';
+
+export default function Page() {
+  return <AdminUsersPage />;
+}

--- a/libs/web/pages/admin/AGENTS.md
+++ b/libs/web/pages/admin/AGENTS.md
@@ -1,0 +1,19 @@
+# Admin Page Agent Guide
+
+## Scope
+
+Platform Admin console page library for the `/admin` shell, AdminGuard, and User directory (identity fields only).
+
+## Do
+
+- Keep admin chrome separate from the personal dashboard (no vault unlock UI).
+- Use `PlatformAdminApi` list/get endpoints for directory data.
+- Preserve the import path `@myorganizer/web-pages/admin`.
+- Treat directory fields as identity metadata only.
+
+## Do Not
+
+- Do not nest admin under `/dashboard` or reuse dashboard sidebar/vault chrome.
+- Do not call removed legacy `/user` CRUD APIs.
+- Do not display, fetch, or imply Vault plaintext or YouTube operational data.
+- Do not add mutation action buttons until the lifecycle UI slice lands.

--- a/libs/web/pages/admin/README.md
+++ b/libs/web/pages/admin/README.md
@@ -1,0 +1,5 @@
+# web-pages-admin
+
+Platform Admin console page library (`/admin` shell, AdminGuard, User directory).
+
+Import via `@myorganizer/web-pages/admin`.

--- a/libs/web/pages/admin/eslint.config.js
+++ b/libs/web/pages/admin/eslint.config.js
@@ -1,0 +1,16 @@
+const nx = require('@nx/eslint-plugin');
+const baseConfig = require('../../../../eslint.config.js');
+
+module.exports = [
+  ...baseConfig,
+  ...nx.configs['flat/react'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@typescript-eslint/no-empty-function': [
+        'error',
+        { allow: ['arrowFunctions', 'functions', 'methods'] },
+      ],
+    },
+  },
+];

--- a/libs/web/pages/admin/jest.config.ts
+++ b/libs/web/pages/admin/jest.config.ts
@@ -1,0 +1,10 @@
+module.exports = {
+  displayName: 'web-pages-admin',
+  preset: '../../../../jest.preset.js',
+  transform: {
+    '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/next/babel'] }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../../coverage/libs/web/pages/admin',
+};

--- a/libs/web/pages/admin/project.json
+++ b/libs/web/pages/admin/project.json
@@ -1,0 +1,23 @@
+{
+  "name": "web-pages-admin",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/web/pages/admin/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": ["libs/web/pages/admin/src/**/*.{ts,tsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/web/pages/admin"],
+      "options": {
+        "jestConfig": "libs/web/pages/admin/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/libs/web/pages/admin/src/components/AdminGuard.tsx
+++ b/libs/web/pages/admin/src/components/AdminGuard.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import {
+  authSession,
+  getCurrentUser,
+  resolveOutboundGuard,
+} from '@myorganizer/auth';
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useEffect, useState } from 'react';
+
+import { isPlatformAdmin } from '../lib/isPlatformAdmin';
+
+interface AdminGuardProps {
+  children: ReactNode;
+}
+
+export default function AdminGuard({ children }: AdminGuardProps) {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function ensurePlatformAdmin() {
+      const outcome = await resolveOutboundGuard(authSession);
+
+      if (outcome.kind === 'redirect_login') {
+        if (!cancelled) router.replace('/login');
+        return;
+      }
+
+      if (outcome.kind === 'allow') {
+        const user = getCurrentUser();
+
+        if (isPlatformAdmin(user)) {
+          if (!cancelled) setReady(true);
+        } else if (!cancelled) {
+          router.replace('/dashboard');
+        }
+      }
+    }
+
+    void ensurePlatformAdmin();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  if (!ready) return null;
+
+  return children;
+}

--- a/libs/web/pages/admin/src/components/AdminSidebar.tsx
+++ b/libs/web/pages/admin/src/components/AdminSidebar.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import * as React from 'react';
+
+import { getCurrentUser, logout } from '@myorganizer/auth';
+import {
+  AppLogo,
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+  useSidebar,
+} from '@myorganizer/web-ui';
+import {
+  ChevronsUpDown,
+  Home,
+  LogOut,
+  Users,
+  type LucideIcon,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+const adminNavItems: {
+  title: string;
+  url: string;
+  icon: LucideIcon;
+}[] = [
+  {
+    title: 'Home',
+    url: '/admin',
+    icon: Home,
+  },
+  {
+    title: 'Users',
+    url: '/admin/users',
+    icon: Users,
+  },
+];
+
+type AdminSidebarProps = React.ComponentProps<typeof Sidebar>;
+
+export function AdminSidebar({ ...props }: AdminSidebarProps) {
+  const currentUser = getCurrentUser();
+  const router = useRouter();
+  const { state, isMobile } = useSidebar();
+
+  const userName = currentUser?.name ?? '';
+  const userEmail = currentUser?.email ?? '';
+  const initials = userName
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  const handleLogout = React.useCallback(async () => {
+    await logout();
+    router.push('/login');
+  }, [router]);
+
+  const handleLogoutSelect = React.useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      void handleLogout();
+    },
+    [handleLogout],
+  );
+
+  return (
+    <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader>
+        <div className="flex flex-col gap-1 px-2 py-3">
+          <AppLogo
+            variant={state === 'collapsed' ? 'icon' : 'full'}
+            height={28}
+          />
+          {state !== 'collapsed' ? (
+            <p className="text-xs text-muted-foreground">Platform Admin</p>
+          ) : null}
+        </div>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton
+                  size="lg"
+                  className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                >
+                  <Avatar className="h-8 w-8 rounded-lg">
+                    <AvatarImage src="" alt={userName} />
+                    <AvatarFallback className="rounded-lg">
+                      {initials}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-semibold">{userName}</span>
+                    <span className="truncate text-xs">{userEmail}</span>
+                  </div>
+                  <ChevronsUpDown className="ml-auto size-4" />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+                side={isMobile ? 'bottom' : 'right'}
+                align="end"
+                sideOffset={4}
+              >
+                <DropdownMenuLabel className="p-0 font-normal">
+                  <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                    <Avatar className="h-8 w-8 rounded-lg">
+                      <AvatarImage src="" alt={userName} />
+                      <AvatarFallback className="rounded-lg">
+                        {initials}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="grid flex-1 text-left text-sm leading-tight">
+                      <span className="truncate font-semibold">{userName}</span>
+                      <span className="truncate text-xs">{userEmail}</span>
+                    </div>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={handleLogoutSelect}>
+                  <LogOut />
+                  Log out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Directory</SidebarGroupLabel>
+          <SidebarMenu>
+            {adminNavItems.map((item) => (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton asChild tooltip={item.title}>
+                  <Link href={item.url}>
+                    <item.icon />
+                    <span>{item.title}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarRail />
+    </Sidebar>
+  );
+}

--- a/libs/web/pages/admin/src/components/UserDetailPageClient.tsx
+++ b/libs/web/pages/admin/src/components/UserDetailPageClient.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import type { AdminUserIdentity } from '@myorganizer/app-api-client';
+import { Button } from '@myorganizer/web-ui';
+import { isAxiosError } from 'axios';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+
+import { createPlatformAdminApi } from '../lib/apiClient';
+import {
+  formatBooleanLabel,
+  formatUserDisplayName,
+  formatUserRole,
+} from '../lib/formatUserIdentity';
+
+interface UserIdentityFieldProps {
+  label: string;
+  value: string;
+}
+
+function UserIdentityField({ label, value }: UserIdentityFieldProps) {
+  return (
+    <div className="grid gap-1">
+      <dt className="text-sm font-medium text-muted-foreground">{label}</dt>
+      <dd className="text-sm">{value}</dd>
+    </div>
+  );
+}
+
+export function UserDetailPageClient() {
+  const params = useParams();
+  const userId =
+    typeof params.userId === 'string' ? params.userId : params.userId?.[0];
+
+  const [user, setUser] = useState<AdminUserIdentity | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  const loadUser = useCallback(async (id: string) => {
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+
+    try {
+      const api = createPlatformAdminApi();
+      const response = await api.getUserById({ userId: id });
+      setUser(response.data);
+    } catch (err) {
+      setUser(null);
+
+      if (isAxiosError(err) && err.response?.status === 404) {
+        setNotFound(true);
+      } else {
+        setError('Unable to load user. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!userId) {
+      setLoading(false);
+      setNotFound(true);
+      return;
+    }
+
+    void loadUser(userId);
+  }, [loadUser, userId]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex items-center gap-4">
+        <Button variant="outline" asChild>
+          <Link href="/admin/users">Back to users</Link>
+        </Button>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : notFound ? (
+        <p className="text-sm text-muted-foreground">User not found.</p>
+      ) : error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : user ? (
+        <>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {formatUserDisplayName(user)}
+          </h1>
+
+          <dl className="grid max-w-xl gap-4">
+            <UserIdentityField label="ID" value={user.id} />
+            <UserIdentityField label="Name" value={user.name} />
+            <UserIdentityField label="Email" value={user.email} />
+            <UserIdentityField label="First name" value={user.firstName} />
+            <UserIdentityField label="Last name" value={user.lastName} />
+            {user.phone ? (
+              <UserIdentityField label="Phone" value={user.phone} />
+            ) : null}
+            <UserIdentityField label="Role" value={formatUserRole(user.role)} />
+            <UserIdentityField
+              label="Disabled"
+              value={formatBooleanLabel(user.disabled)}
+            />
+            <UserIdentityField
+              label="Email verified"
+              value={formatBooleanLabel(user.emailVerified)}
+            />
+          </dl>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/libs/web/pages/admin/src/components/UserDirectoryPageClient.tsx
+++ b/libs/web/pages/admin/src/components/UserDirectoryPageClient.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import type { AdminUserIdentity } from '@myorganizer/app-api-client';
+import {
+  Button,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@myorganizer/web-ui';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import type { ChangeEvent, FormEvent, MouseEvent } from 'react';
+
+import { createPlatformAdminApi } from '../lib/apiClient';
+import {
+  formatBooleanLabel,
+  formatUserDisplayName,
+  formatUserRole,
+} from '../lib/formatUserIdentity';
+
+export function UserDirectoryPageClient() {
+  const router = useRouter();
+  const [searchInput, setSearchInput] = useState('');
+  const [appliedQuery, setAppliedQuery] = useState<string | undefined>(
+    undefined,
+  );
+  const [users, setUsers] = useState<AdminUserIdentity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadUsers = useCallback(async (query?: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const api = createPlatformAdminApi();
+      const response = await api.listUsers({ q: query });
+      setUsers(response.data);
+    } catch {
+      setError('Unable to load users. Please try again.');
+      setUsers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadUsers(appliedQuery);
+  }, [appliedQuery, loadUsers]);
+
+  const handleSearchSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmed = searchInput.trim();
+      setAppliedQuery(trimmed || undefined);
+    },
+    [searchInput],
+  );
+
+  const handleSearchInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setSearchInput(event.target.value);
+    },
+    [],
+  );
+
+  const handleRowClick = useCallback(
+    (event: MouseEvent<HTMLTableRowElement>) => {
+      const userId = event.currentTarget.dataset.userId;
+
+      if (userId) {
+        router.push(`/admin/users/${userId}`);
+      }
+    },
+    [router],
+  );
+
+  const handleViewLinkClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      event.stopPropagation();
+    },
+    [],
+  );
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <h1 className="text-2xl font-semibold tracking-tight">Users</h1>
+
+      <form onSubmit={handleSearchSubmit} className="flex max-w-md gap-2">
+        <Input
+          value={searchInput}
+          onChange={handleSearchInputChange}
+          placeholder="Search by name or email"
+          aria-label="Search users"
+        />
+        <Button type="submit">Search</Button>
+      </form>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : users.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No users found.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Disabled</TableHead>
+              <TableHead>Email verified</TableHead>
+              <TableHead className="w-[80px]">
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user) => (
+              <TableRow
+                key={user.id}
+                data-user-id={user.id}
+                className="cursor-pointer"
+                onClick={handleRowClick}
+              >
+                <TableCell className="font-medium">
+                  {formatUserDisplayName(user)}
+                </TableCell>
+                <TableCell>{user.email}</TableCell>
+                <TableCell>{formatUserRole(user.role)}</TableCell>
+                <TableCell>{formatBooleanLabel(user.disabled)}</TableCell>
+                <TableCell>{formatBooleanLabel(user.emailVerified)}</TableCell>
+                <TableCell>
+                  <Link
+                    href={`/admin/users/${user.id}`}
+                    className="text-primary underline-offset-4 hover:underline"
+                    onClick={handleViewLinkClick}
+                  >
+                    View
+                  </Link>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/libs/web/pages/admin/src/index.ts
+++ b/libs/web/pages/admin/src/index.ts
@@ -1,0 +1,5 @@
+export { default as AdminGuard } from './components/AdminGuard';
+export { AdminSidebar } from './components/AdminSidebar';
+export { default as AdminHomePage } from './pages/AdminHomePage';
+export { default as AdminUsersPage } from './pages/AdminUsersPage';
+export { default as AdminUserDetailPage } from './pages/AdminUserDetailPage';

--- a/libs/web/pages/admin/src/lib/apiClient.ts
+++ b/libs/web/pages/admin/src/lib/apiClient.ts
@@ -1,0 +1,25 @@
+import {
+  Configuration,
+  PlatformAdminApi,
+  type ConfigurationParameters,
+} from '@myorganizer/app-api-client';
+import { getAccessToken, getAuthAxios } from '@myorganizer/auth';
+import { getApiBaseUrl } from '@myorganizer/core';
+
+export function createApiConfiguration(
+  overrides: Partial<ConfigurationParameters> = {},
+): Configuration {
+  return new Configuration({
+    basePath: getApiBaseUrl(),
+    accessToken: () => getAccessToken() ?? '',
+    ...overrides,
+  });
+}
+
+export function createPlatformAdminApi(): PlatformAdminApi {
+  return new PlatformAdminApi(
+    createApiConfiguration(),
+    undefined,
+    getAuthAxios(),
+  );
+}

--- a/libs/web/pages/admin/src/lib/formatUserIdentity.ts
+++ b/libs/web/pages/admin/src/lib/formatUserIdentity.ts
@@ -1,0 +1,22 @@
+import type { AdminUserIdentity } from '@myorganizer/app-api-client';
+
+export function formatUserDisplayName(user: AdminUserIdentity): string {
+  if (user.name.trim()) {
+    return user.name;
+  }
+
+  const combined = `${user.firstName} ${user.lastName}`.trim();
+  return combined || user.email;
+}
+
+export function formatUserRole(role: AdminUserIdentity['role']): string {
+  if (role === 'platform_admin') {
+    return 'Platform Admin';
+  }
+
+  return 'User';
+}
+
+export function formatBooleanLabel(value: boolean): string {
+  return value ? 'Yes' : 'No';
+}

--- a/libs/web/pages/admin/src/lib/isPlatformAdmin.ts
+++ b/libs/web/pages/admin/src/lib/isPlatformAdmin.ts
@@ -1,0 +1,5 @@
+import type { AuthUser } from '@myorganizer/auth';
+
+export function isPlatformAdmin(user: AuthUser | undefined | null): boolean {
+  return user?.role === 'platform_admin';
+}

--- a/libs/web/pages/admin/src/pages/AdminHomePage.tsx
+++ b/libs/web/pages/admin/src/pages/AdminHomePage.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function AdminHomePage() {
+  redirect('/admin/users');
+}

--- a/libs/web/pages/admin/src/pages/AdminHomePage.tsx
+++ b/libs/web/pages/admin/src/pages/AdminHomePage.tsx
@@ -1,5 +1,14 @@
-import { redirect } from 'next/navigation';
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 export default function AdminHomePage() {
-  redirect('/admin/users');
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/admin/users');
+  }, [router]);
+
+  return null;
 }

--- a/libs/web/pages/admin/src/pages/AdminUserDetailPage.tsx
+++ b/libs/web/pages/admin/src/pages/AdminUserDetailPage.tsx
@@ -1,0 +1,5 @@
+import { UserDetailPageClient } from '../components/UserDetailPageClient';
+
+export default function AdminUserDetailPage() {
+  return <UserDetailPageClient />;
+}

--- a/libs/web/pages/admin/src/pages/AdminUsersPage.tsx
+++ b/libs/web/pages/admin/src/pages/AdminUsersPage.tsx
@@ -1,0 +1,5 @@
+import { UserDirectoryPageClient } from '../components/UserDirectoryPageClient';
+
+export default function AdminUsersPage() {
+  return <UserDirectoryPageClient />;
+}

--- a/libs/web/pages/admin/tsconfig.json
+++ b/libs/web/pages/admin/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node", "jest"]
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/web/pages/admin/tsconfig.lib.json
+++ b/libs/web/pages/admin/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx"
+  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/libs/web/pages/admin/tsconfig.spec.json
+++ b/libs/web/pages/admin/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,7 @@
       "@myorganizer/design-tokens": ["libs/design-tokens/src/index.ts"],
       "@myorganizer/vault-core": ["libs/vault-core/src/index.ts"],
       "@myorganizer/web-pages/account": ["libs/web/pages/account/src/index.ts"],
+      "@myorganizer/web-pages/admin": ["libs/web/pages/admin/src/index.ts"],
       "@myorganizer/web-pages/addresses": [
         "libs/web/pages/addresses/src/index.ts"
       ],


### PR DESCRIPTION
## Why
Add platform admin console shell and user directory (#200).

## Changes
- Add web-pages-admin library with AdminGuard, sidebar, and read-only user list/search/detail via PlatformAdminApi
- Wire thin /admin route wrappers in the Next.js app and register the path alias

## Validation
- Generated from 1 commit(s) on `feat/200-admin-shell-guard-directory`.
- Compared against base branch `main`.
