### PR TITLE
test(admin): add AdminGuard and user directory tests (#201)

### DIFF
--- a/libs/web/pages/admin/jest.config.ts
+++ b/libs/web/pages/admin/jest.config.ts
@@ -7,4 +7,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../../../coverage/libs/web/pages/admin',
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
 };

--- a/libs/web/pages/admin/src/components/AdminGuard.test.tsx
+++ b/libs/web/pages/admin/src/components/AdminGuard.test.tsx
@@ -1,0 +1,152 @@
+/** Mocking rule: place jest.mock calls before any imports */
+/* eslint-disable import/first -- jest.mock must precede application imports */
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@myorganizer/auth', () => ({
+  authSession: {},
+  getCurrentUser: jest.fn(),
+  resolveOutboundGuard: jest.fn(),
+}));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import type { AuthUser } from '@myorganizer/auth';
+import { getCurrentUser, resolveOutboundGuard } from '@myorganizer/auth';
+import { useRouter } from 'next/navigation';
+
+import AdminGuard from './AdminGuard';
+
+const mockReplace = jest.fn();
+
+const platformAdminUser: AuthUser = {
+  id: 'admin-1',
+  name: 'Platform Admin',
+  email: 'admin@example.com',
+  firstName: 'Platform',
+  lastName: 'Admin',
+  role: 'platform_admin',
+  disabled: false,
+};
+
+const normalUser: AuthUser = {
+  id: 'user-1',
+  name: 'Normal User',
+  email: 'user@example.com',
+  firstName: 'Normal',
+  lastName: 'User',
+  role: 'user',
+  disabled: false,
+};
+
+describe('AdminGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({
+      replace: mockReplace,
+      push: jest.fn(),
+    });
+  });
+
+  it('renders null while the guard is resolving', () => {
+    (resolveOutboundGuard as jest.Mock).mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    render(
+      <AdminGuard>
+        <div>admin-content</div>
+      </AdminGuard>,
+    );
+
+    expect(screen.queryByText('admin-content')).toBeNull();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('redirects guests to login and does not render children', async () => {
+    (resolveOutboundGuard as jest.Mock).mockResolvedValue({
+      kind: 'redirect_login',
+    });
+
+    render(
+      <AdminGuard>
+        <div>admin-content</div>
+      </AdminGuard>,
+    );
+
+    expect(screen.queryByText('admin-content')).toBeNull();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('redirects authenticated non-admin users to dashboard', async () => {
+    (resolveOutboundGuard as jest.Mock).mockResolvedValue({ kind: 'allow' });
+    (getCurrentUser as jest.Mock).mockReturnValue(normalUser);
+
+    render(
+      <AdminGuard>
+        <div>admin-content</div>
+      </AdminGuard>,
+    );
+
+    expect(screen.queryByText('admin-content')).toBeNull();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  it('redirects to dashboard when allow succeeds but current user is null', async () => {
+    (resolveOutboundGuard as jest.Mock).mockResolvedValue({ kind: 'allow' });
+    (getCurrentUser as jest.Mock).mockReturnValue(null);
+
+    render(
+      <AdminGuard>
+        <div>admin-content</div>
+      </AdminGuard>,
+    );
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/dashboard');
+    });
+
+    expect(screen.queryByText('admin-content')).toBeNull();
+  });
+
+  it('redirects to dashboard when allow succeeds but current user is undefined', async () => {
+    (resolveOutboundGuard as jest.Mock).mockResolvedValue({ kind: 'allow' });
+    (getCurrentUser as jest.Mock).mockReturnValue(undefined);
+
+    render(
+      <AdminGuard>
+        <div>admin-content</div>
+      </AdminGuard>,
+    );
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/dashboard');
+    });
+
+    expect(screen.queryByText('admin-content')).toBeNull();
+  });
+
+  it('renders children for platform admin users without redirecting', async () => {
+    (resolveOutboundGuard as jest.Mock).mockResolvedValue({ kind: 'allow' });
+    (getCurrentUser as jest.Mock).mockReturnValue(platformAdminUser);
+
+    render(
+      <AdminGuard>
+        <div>admin-content</div>
+      </AdminGuard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('admin-content')).toBeTruthy();
+    });
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/libs/web/pages/admin/src/components/UserDetailPageClient.test.tsx
+++ b/libs/web/pages/admin/src/components/UserDetailPageClient.test.tsx
@@ -1,0 +1,220 @@
+/** Mocking rule: place jest.mock calls before any imports */
+/* eslint-disable import/first -- jest.mock must precede application imports */
+
+jest.mock('../lib/apiClient', () => ({
+  createPlatformAdminApi: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('next/link', () => {
+  const React = require('react');
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => React.createElement('a', { href, ...props }, children),
+  };
+});
+
+import type { AdminUserIdentity } from '@myorganizer/app-api-client';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useParams } from 'next/navigation';
+
+import { createPlatformAdminApi } from '../lib/apiClient';
+
+import { UserDetailPageClient } from './UserDetailPageClient';
+
+const mockGetUserById = jest.fn();
+
+const userWithPhone: AdminUserIdentity = {
+  id: 'u-2',
+  name: 'Grace Hopper',
+  email: 'grace@example.com',
+  firstName: 'Grace',
+  lastName: 'Hopper',
+  phone: '+1-555-0100',
+  role: 'user',
+  disabled: true,
+  emailVerified: false,
+};
+
+const userWithoutPhone: AdminUserIdentity = {
+  id: 'u-1',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  role: 'platform_admin',
+  disabled: false,
+  emailVerified: true,
+};
+
+const SENSITIVE_PATTERNS = [
+  /vault/i,
+  /youtube/i,
+  /password/i,
+  /ciphertext/i,
+  /unlock/i,
+  /subscription sync/i,
+  /oauth token/i,
+  /master key/i,
+];
+
+function expectNoSensitiveContent(container: HTMLElement) {
+  const text = container.textContent?.toLowerCase() ?? '';
+
+  for (const pattern of SENSITIVE_PATTERNS) {
+    expect(text).not.toMatch(pattern);
+  }
+}
+
+function expectDefinitionValue(label: string, value: string) {
+  const term = screen.getByText(label);
+  const definition = term.nextElementSibling;
+
+  expect(definition).toHaveTextContent(value);
+}
+
+function createAxios404Error() {
+  return Object.assign(new Error('Not Found'), {
+    isAxiosError: true,
+    response: { status: 404 },
+  });
+}
+
+describe('UserDetailPageClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createPlatformAdminApi as jest.Mock).mockReturnValue({
+      listUsers: jest.fn(),
+      getUserById: mockGetUserById,
+    });
+    (useParams as jest.Mock).mockReturnValue({ userId: 'u-2' });
+    mockGetUserById.mockResolvedValue({ data: userWithPhone });
+  });
+
+  it('loads user detail and renders identity fields', async () => {
+    render(<UserDetailPageClient />);
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockGetUserById).toHaveBeenCalledWith({ userId: 'u-2' });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Grace Hopper' }),
+      ).toBeInTheDocument();
+    });
+    expectDefinitionValue('ID', 'u-2');
+    expectDefinitionValue('Name', 'Grace Hopper');
+    expectDefinitionValue('Email', 'grace@example.com');
+    expectDefinitionValue('First name', 'Grace');
+    expectDefinitionValue('Last name', 'Hopper');
+    expectDefinitionValue('Phone', '+1-555-0100');
+    expectDefinitionValue('Role', 'User');
+    expectDefinitionValue('Disabled', 'Yes');
+    expectDefinitionValue('Email verified', 'No');
+    expect(screen.getByRole('link', { name: 'Back to users' })).toHaveAttribute(
+      'href',
+      '/admin/users',
+    );
+  });
+
+  it('hides the phone field when phone is absent', async () => {
+    (useParams as jest.Mock).mockReturnValue({ userId: 'u-1' });
+    mockGetUserById.mockResolvedValue({ data: userWithoutPhone });
+
+    render(<UserDetailPageClient />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Ada Lovelace' }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Phone')).not.toBeInTheDocument();
+  });
+
+  it('shows User not found when the API returns 404', async () => {
+    mockGetUserById.mockRejectedValue(createAxios404Error());
+
+    render(<UserDetailPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('User not found.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a generic error when getUserById rejects with a non-404 error', async () => {
+    mockGetUserById.mockRejectedValue(new Error('Network error'));
+
+    render(<UserDetailPageClient />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Unable to load user. Please try again.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows User not found when userId is missing and does not call the API', async () => {
+    (useParams as jest.Mock).mockReturnValue({});
+
+    render(<UserDetailPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('User not found.')).toBeInTheDocument();
+    });
+
+    expect(mockGetUserById).not.toHaveBeenCalled();
+  });
+
+  it('does not surface vault, YouTube, or secret operational fields', async () => {
+    const secretFieldValues = [
+      'SECRET_VAULT_BLOB',
+      'ya29.secret-token',
+      'should-never-appear',
+      'mk-secret',
+    ] as const;
+
+    const bloatedUser = {
+      ...userWithPhone,
+      vaultCiphertext: 'SECRET_VAULT_BLOB',
+      youtubeOAuthToken: 'ya29.secret-token',
+      password: 'should-never-appear',
+      masterKey: 'mk-secret',
+    } as AdminUserIdentity;
+
+    mockGetUserById.mockResolvedValue({ data: bloatedUser });
+
+    const { container } = render(<UserDetailPageClient />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Grace Hopper' }),
+      ).toBeInTheDocument();
+    });
+
+    expectDefinitionValue('Email', 'grace@example.com');
+    expectDefinitionValue('Role', 'User');
+    expectDefinitionValue('Phone', '+1-555-0100');
+
+    for (const secretValue of secretFieldValues) {
+      expect(container.textContent).not.toContain(secretValue);
+    }
+
+    expectNoSensitiveContent(container);
+  });
+});

--- a/libs/web/pages/admin/src/components/UserDirectoryPageClient.test.tsx
+++ b/libs/web/pages/admin/src/components/UserDirectoryPageClient.test.tsx
@@ -1,0 +1,241 @@
+/** Mocking rule: place jest.mock calls before any imports */
+/* eslint-disable import/first -- jest.mock must precede application imports */
+
+jest.mock('../lib/apiClient', () => ({
+  createPlatformAdminApi: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('next/link', () => {
+  const React = require('react');
+
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => React.createElement('a', { href, ...props }, children),
+  };
+});
+
+import type { AdminUserIdentity } from '@myorganizer/app-api-client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRouter } from 'next/navigation';
+
+import { createPlatformAdminApi } from '../lib/apiClient';
+
+import { UserDirectoryPageClient } from './UserDirectoryPageClient';
+
+const mockListUsers = jest.fn();
+const mockPush = jest.fn();
+
+const sampleUsers: AdminUserIdentity[] = [
+  {
+    id: 'u-1',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    role: 'platform_admin',
+    disabled: false,
+    emailVerified: true,
+  },
+  {
+    id: 'u-2',
+    name: 'Grace Hopper',
+    email: 'grace@example.com',
+    firstName: 'Grace',
+    lastName: 'Hopper',
+    phone: '+1-555-0100',
+    role: 'user',
+    disabled: true,
+    emailVerified: false,
+  },
+];
+
+const SENSITIVE_PATTERNS = [
+  /vault/i,
+  /youtube/i,
+  /password/i,
+  /ciphertext/i,
+  /unlock/i,
+  /subscription sync/i,
+  /oauth token/i,
+  /master key/i,
+];
+
+function expectNoSensitiveContent(container: HTMLElement) {
+  const text = container.textContent?.toLowerCase() ?? '';
+
+  for (const pattern of SENSITIVE_PATTERNS) {
+    expect(text).not.toMatch(pattern);
+  }
+}
+
+describe('UserDirectoryPageClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createPlatformAdminApi as jest.Mock).mockReturnValue({
+      listUsers: mockListUsers,
+      getUserById: jest.fn(),
+    });
+    (useRouter as jest.Mock).mockReturnValue({
+      push: mockPush,
+      replace: jest.fn(),
+    });
+    mockListUsers.mockResolvedValue({ data: sampleUsers });
+  });
+
+  it('loads users on mount and renders identity columns', async () => {
+    render(<UserDirectoryPageClient />);
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockListUsers).toHaveBeenCalledWith({ q: undefined });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    });
+    expect(screen.getByText('ada@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Grace Hopper')).toBeInTheDocument();
+    expect(screen.getByText('grace@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Platform Admin')).toBeInTheDocument();
+    expect(screen.getByText('User')).toBeInTheDocument();
+    expect(screen.getAllByText('Yes')).toHaveLength(2);
+    expect(screen.getAllByText('No')).toHaveLength(2);
+    expect(screen.getAllByRole('link', { name: 'View' })).toHaveLength(2);
+  });
+
+  it('shows empty state when the API returns no users', async () => {
+    mockListUsers.mockResolvedValue({ data: [] });
+
+    render(<UserDirectoryPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No users found.')).toBeInTheDocument();
+    });
+
+    expect(mockListUsers).toHaveBeenCalledWith({ q: undefined });
+  });
+
+  it('shows an error message when listUsers rejects', async () => {
+    mockListUsers.mockRejectedValue(new Error('Network error'));
+
+    render(<UserDirectoryPageClient />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Unable to load users. Please try again.'),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+  });
+
+  it('submits search with a trimmed query', async () => {
+    render(<UserDirectoryPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    });
+
+    mockListUsers.mockClear();
+
+    fireEvent.change(screen.getByLabelText('Search users'), {
+      target: { value: '  grace  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      expect(mockListUsers).toHaveBeenCalledWith({ q: 'grace' });
+    });
+  });
+
+  it('treats whitespace-only search as no query', async () => {
+    render(<UserDirectoryPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Search users'), {
+      target: { value: 'grace' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      expect(mockListUsers).toHaveBeenCalledWith({ q: 'grace' });
+    });
+
+    mockListUsers.mockClear();
+
+    fireEvent.change(screen.getByLabelText('Search users'), {
+      target: { value: '   ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      expect(mockListUsers).toHaveBeenCalledWith({ q: undefined });
+    });
+  });
+
+  it('navigates to user detail when a table row is clicked', async () => {
+    render(<UserDirectoryPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Grace Hopper')).toBeInTheDocument();
+    });
+
+    const row = screen.getByText('Grace Hopper').closest('tr');
+    expect(row).not.toBeNull();
+    fireEvent.click(row as HTMLTableRowElement);
+
+    expect(mockPush).toHaveBeenCalledWith('/admin/users/u-2');
+  });
+
+  it('does not surface vault, YouTube, or secret operational fields', async () => {
+    const secretFieldValues = [
+      'SECRET_VAULT_BLOB',
+      'ya29.secret-token',
+      'should-never-appear',
+      'mk-secret',
+    ] as const;
+
+    const bloatedUser = {
+      ...sampleUsers[0],
+      vaultCiphertext: 'SECRET_VAULT_BLOB',
+      youtubeOAuthToken: 'ya29.secret-token',
+      password: 'should-never-appear',
+      masterKey: 'mk-secret',
+    } as AdminUserIdentity;
+
+    mockListUsers.mockResolvedValue({ data: [bloatedUser] });
+
+    const { container } = render(<UserDirectoryPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('ada@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Platform Admin')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+
+    for (const secretValue of secretFieldValues) {
+      expect(container.textContent).not.toContain(secretValue);
+    }
+
+    expectNoSensitiveContent(container);
+  });
+});

--- a/libs/web/pages/admin/src/lib/isPlatformAdmin.test.ts
+++ b/libs/web/pages/admin/src/lib/isPlatformAdmin.test.ts
@@ -1,0 +1,31 @@
+import type { AuthUser } from '@myorganizer/auth';
+
+import { isPlatformAdmin } from './isPlatformAdmin';
+
+const baseUser: AuthUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  firstName: 'Test',
+  lastName: 'User',
+  role: 'user',
+  disabled: false,
+};
+
+describe('isPlatformAdmin', () => {
+  it('returns true when role is platform_admin', () => {
+    expect(isPlatformAdmin({ ...baseUser, role: 'platform_admin' })).toBe(true);
+  });
+
+  it('returns false when role is user', () => {
+    expect(isPlatformAdmin({ ...baseUser, role: 'user' })).toBe(false);
+  });
+
+  it('returns false when user is null', () => {
+    expect(isPlatformAdmin(null)).toBe(false);
+  });
+
+  it('returns false when user is undefined', () => {
+    expect(isPlatformAdmin(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why
Add AdminGuard and user directory tests (#201).

## Changes
- Enable jest-dom in web-pages-admin Jest setup
- Cover AdminGuard guest/login, user/dashboard, and platform_admin access
- Add isPlatformAdmin role helper unit tests
- Cover user directory list, search, detail, 404, and error states
- Assert identity-only UI excludes vault, YouTube, and secret fields

## Validation
- Generated from 1 commit(s) on `feat/201-admin-guard-directory-tests`.
- Compared against base branch `main`.
