### PR TITLE
feat(admin): add user lifecycle actions and audit log UI (#202)

### DIFF
--- a/apps/myorganizer/src/app/admin/audit-logs/page.tsx
+++ b/apps/myorganizer/src/app/admin/audit-logs/page.tsx
@@ -1,0 +1,5 @@
+import { AdminAuditLogPage } from '@myorganizer/web-pages/admin';
+
+export default function Page() {
+  return <AdminAuditLogPage />;
+}

--- a/libs/web/pages/admin/AGENTS.md
+++ b/libs/web/pages/admin/AGENTS.md
@@ -2,18 +2,19 @@
 
 ## Scope
 
-Platform Admin console page library for the `/admin` shell, AdminGuard, and User directory (identity fields only).
+Platform Admin console page library for the `/admin` shell, AdminGuard, User directory/detail (identity fields + lifecycle actions), and Admin Audit Log browse UI.
 
 ## Do
 
 - Keep admin chrome separate from the personal dashboard (no vault unlock UI).
-- Use `PlatformAdminApi` list/get endpoints for directory data.
+- Use `PlatformAdminApi` for directory, lifecycle mutations, and audit log list endpoints.
 - Preserve the import path `@myorganizer/web-pages/admin`.
-- Treat directory fields as identity metadata only.
+- Treat directory and audit fields as identity/audit metadata only.
+- Surface lifecycle API success and error feedback (including last-admin rejection on demote).
 
 ## Do Not
 
 - Do not nest admin under `/dashboard` or reuse dashboard sidebar/vault chrome.
 - Do not call removed legacy `/user` CRUD APIs.
 - Do not display, fetch, or imply Vault plaintext or YouTube operational data.
-- Do not add mutation action buttons until the lifecycle UI slice lands.
+- Do not add impersonation or admin-set password flows.

--- a/libs/web/pages/admin/src/components/AdminSidebar.tsx
+++ b/libs/web/pages/admin/src/components/AdminSidebar.tsx
@@ -29,6 +29,7 @@ import {
   ChevronsUpDown,
   Home,
   LogOut,
+  ScrollText,
   Users,
   type LucideIcon,
 } from 'lucide-react';
@@ -49,6 +50,11 @@ const adminNavItems: {
     title: 'Users',
     url: '/admin/users',
     icon: Users,
+  },
+  {
+    title: 'Audit Log',
+    url: '/admin/audit-logs',
+    icon: ScrollText,
   },
 ];
 
@@ -146,7 +152,7 @@ export function AdminSidebar({ ...props }: AdminSidebarProps) {
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Directory</SidebarGroupLabel>
+          <SidebarGroupLabel>Admin</SidebarGroupLabel>
           <SidebarMenu>
             {adminNavItems.map((item) => (
               <SidebarMenuItem key={item.title}>

--- a/libs/web/pages/admin/src/components/AuditLogPageClient.tsx
+++ b/libs/web/pages/admin/src/components/AuditLogPageClient.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { AdminAuditLogEntry } from '@myorganizer/app-api-client';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@myorganizer/web-ui';
+import { useCallback, useEffect, useState } from 'react';
+
+import { createPlatformAdminApi } from '../lib/apiClient';
+import { formatAuditAction, formatAuditTimestamp } from '../lib/formatAuditLog';
+
+export function AuditLogPageClient() {
+  const [entries, setEntries] = useState<AdminAuditLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadAuditLogs = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const api = createPlatformAdminApi();
+      const response = await api.listAuditLogs({ limit: 50 });
+      setEntries(response.data);
+    } catch {
+      setError('Unable to load audit log. Please try again.');
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAuditLogs();
+  }, [loadAuditLogs]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <h1 className="text-2xl font-semibold tracking-tight">Admin Audit Log</h1>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No audit log entries yet.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Time</TableHead>
+              <TableHead>Action</TableHead>
+              <TableHead>Actor</TableHead>
+              <TableHead>Target</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.map((entry) => (
+              <TableRow key={entry.id}>
+                <TableCell>{formatAuditTimestamp(entry.createdAt)}</TableCell>
+                <TableCell>{formatAuditAction(entry.action)}</TableCell>
+                <TableCell>{entry.actorUserId}</TableCell>
+                <TableCell>{entry.targetUserId}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/libs/web/pages/admin/src/components/UserDetailPageClient.tsx
+++ b/libs/web/pages/admin/src/components/UserDetailPageClient.tsx
@@ -13,6 +13,7 @@ import {
   formatUserDisplayName,
   formatUserRole,
 } from '../lib/formatUserIdentity';
+import { UserLifecycleActions } from './UserLifecycleActions';
 
 interface UserIdentityFieldProps {
   label: string;
@@ -109,6 +110,8 @@ export function UserDetailPageClient() {
               value={formatBooleanLabel(user.emailVerified)}
             />
           </dl>
+
+          <UserLifecycleActions user={user} onUserUpdated={setUser} />
         </>
       ) : null}
     </div>

--- a/libs/web/pages/admin/src/components/UserLifecycleActions.tsx
+++ b/libs/web/pages/admin/src/components/UserLifecycleActions.tsx
@@ -1,0 +1,363 @@
+'use client';
+
+import type { AdminUserIdentity } from '@myorganizer/app-api-client';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  useToast,
+} from '@myorganizer/web-ui';
+import { isAxiosError } from 'axios';
+import { useCallback, useMemo, useState } from 'react';
+import type { MouseEvent } from 'react';
+
+import { createPlatformAdminApi } from '../lib/apiClient';
+import { formatUserDisplayName } from '../lib/formatUserIdentity';
+
+type LifecycleAction =
+  | 'disable'
+  | 'enable'
+  | 'forceLogout'
+  | 'resendVerification'
+  | 'promote'
+  | 'demote';
+
+interface UserLifecycleActionsProps {
+  user: AdminUserIdentity;
+  onUserUpdated: (user: AdminUserIdentity) => void;
+}
+
+interface LifecycleConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  isLoading?: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}
+
+interface ActionDefinition {
+  id: LifecycleAction;
+  label: string;
+  loadingLabel: string;
+  confirmTitle: string;
+  confirmDescription: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  variant: 'default' | 'destructive' | 'outline';
+  isVisible: (user: AdminUserIdentity) => boolean;
+}
+
+const ACTION_DEFINITIONS: ActionDefinition[] = [
+  {
+    id: 'disable',
+    label: 'Disable',
+    loadingLabel: 'Disabling…',
+    confirmTitle: 'Disable user?',
+    confirmDescription:
+      'This will prevent the user from signing in until they are re-enabled.',
+    confirmLabel: 'Disable user',
+    destructive: true,
+    variant: 'destructive',
+    isVisible: (targetUser) => !targetUser.disabled,
+  },
+  {
+    id: 'enable',
+    label: 'Enable',
+    loadingLabel: 'Enabling…',
+    confirmTitle: 'Enable user?',
+    confirmDescription: 'This will allow the user to sign in again.',
+    confirmLabel: 'Enable user',
+    variant: 'outline',
+    isVisible: (targetUser) => targetUser.disabled,
+  },
+  {
+    id: 'forceLogout',
+    label: 'Force logout',
+    loadingLabel: 'Revoking…',
+    confirmTitle: 'Force logout?',
+    confirmDescription:
+      'This will revoke all active sessions for this user immediately.',
+    confirmLabel: 'Force logout',
+    variant: 'outline',
+    isVisible: () => true,
+  },
+  {
+    id: 'resendVerification',
+    label: 'Resend verification',
+    loadingLabel: 'Sending…',
+    confirmTitle: 'Resend verification email?',
+    confirmDescription: 'This will send a new verification email to the user.',
+    confirmLabel: 'Resend email',
+    variant: 'outline',
+    isVisible: (targetUser) => !targetUser.emailVerified,
+  },
+  {
+    id: 'promote',
+    label: 'Promote',
+    loadingLabel: 'Promoting…',
+    confirmTitle: 'Promote to Platform Admin?',
+    confirmDescription:
+      'This will grant Platform Admin privileges to this user.',
+    confirmLabel: 'Promote user',
+    variant: 'outline',
+    isVisible: (targetUser) => targetUser.role !== 'platform_admin',
+  },
+  {
+    id: 'demote',
+    label: 'Demote',
+    loadingLabel: 'Demoting…',
+    confirmTitle: 'Demote Platform Admin?',
+    confirmDescription:
+      'This will remove Platform Admin privileges from this user.',
+    confirmLabel: 'Demote user',
+    destructive: true,
+    variant: 'destructive',
+    isVisible: (targetUser) => targetUser.role === 'platform_admin',
+  },
+];
+
+function getApiErrorMessage(err: unknown): string {
+  if (isAxiosError(err)) {
+    const data = err.response?.data;
+
+    if (
+      data &&
+      typeof data === 'object' &&
+      'message' in data &&
+      typeof data.message === 'string'
+    ) {
+      return data.message;
+    }
+  }
+
+  return 'Action failed. Please try again.';
+}
+
+function getResendSuccessMessage(data: unknown): string {
+  if (
+    data &&
+    typeof data === 'object' &&
+    'message' in data &&
+    typeof data.message === 'string'
+  ) {
+    return data.message;
+  }
+
+  return 'Verification email sent';
+}
+
+function LifecycleConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel,
+  destructive = false,
+  isLoading = false,
+  onClose,
+  onConfirm,
+}: LifecycleConfirmDialogProps) {
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const handleConfirm = useCallback(async () => {
+    await onConfirm();
+  }, [onConfirm]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="w-[calc(100%-2rem)] md:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 pt-2 sm:gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant={destructive ? 'destructive' : 'default'}
+            onClick={handleConfirm}
+            disabled={isLoading}
+          >
+            {isLoading ? 'Working…' : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function UserLifecycleActions({
+  user,
+  onUserUpdated,
+}: UserLifecycleActionsProps) {
+  const { toast } = useToast();
+  const [pendingAction, setPendingAction] = useState<LifecycleAction | null>(
+    null,
+  );
+  const [openAction, setOpenAction] = useState<LifecycleAction | null>(null);
+
+  const visibleActions = useMemo(
+    () => ACTION_DEFINITIONS.filter((action) => action.isVisible(user)),
+    [user],
+  );
+
+  const openActionDefinition = useMemo(
+    () => ACTION_DEFINITIONS.find((action) => action.id === openAction) ?? null,
+    [openAction],
+  );
+
+  const handleCloseDialog = useCallback(() => {
+    if (pendingAction) {
+      return;
+    }
+
+    setOpenAction(null);
+  }, [pendingAction]);
+
+  const handleOpenAction = useCallback((action: LifecycleAction) => {
+    setOpenAction(action);
+  }, []);
+
+  const handleActionButtonClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      const action = event.currentTarget.dataset.action as
+        | LifecycleAction
+        | undefined;
+
+      if (action) {
+        handleOpenAction(action);
+      }
+    },
+    [handleOpenAction],
+  );
+
+  const executeAction = useCallback(
+    async (action: LifecycleAction) => {
+      setPendingAction(action);
+
+      const api = createPlatformAdminApi();
+      const userId = user.id;
+
+      try {
+        switch (action) {
+          case 'disable': {
+            const response = await api.disableUser({ userId });
+            onUserUpdated(response.data);
+            toast({ title: 'User disabled' });
+            break;
+          }
+          case 'enable': {
+            const response = await api.enableUser({ userId });
+            onUserUpdated(response.data);
+            toast({ title: 'User enabled' });
+            break;
+          }
+          case 'forceLogout': {
+            const response = await api.forceLogoutUser({ userId });
+            onUserUpdated(response.data);
+            toast({ title: 'User sessions revoked' });
+            break;
+          }
+          case 'resendVerification': {
+            const response = await api.resendVerification({ userId });
+            toast({ title: getResendSuccessMessage(response.data) });
+            break;
+          }
+          case 'promote': {
+            const response = await api.promoteUser({ userId });
+            onUserUpdated(response.data);
+            toast({ title: 'User promoted to Platform Admin' });
+            break;
+          }
+          case 'demote': {
+            const response = await api.demoteUser({ userId });
+            onUserUpdated(response.data);
+            toast({ title: 'User demoted' });
+            break;
+          }
+        }
+
+        setOpenAction(null);
+      } catch (err) {
+        toast({
+          title: 'Action failed',
+          description: getApiErrorMessage(err),
+          variant: 'destructive',
+        });
+      } finally {
+        setPendingAction(null);
+      }
+    },
+    [onUserUpdated, toast, user.id],
+  );
+
+  const handleConfirmAction = useCallback(async () => {
+    if (!openAction) {
+      return;
+    }
+
+    await executeAction(openAction);
+  }, [executeAction, openAction]);
+
+  const isBusy = pendingAction !== null;
+
+  return (
+    <section className="max-w-xl">
+      <h2 className="mb-3 text-lg font-semibold tracking-tight">Actions</h2>
+      <p className="mb-3 text-sm text-muted-foreground">
+        Manage lifecycle actions for {formatUserDisplayName(user)}.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {visibleActions.map((action) => {
+          const isActive = pendingAction === action.id;
+
+          return (
+            <Button
+              key={action.id}
+              type="button"
+              variant={action.variant}
+              data-action={action.id}
+              disabled={isBusy}
+              onClick={handleActionButtonClick}
+            >
+              {isActive ? action.loadingLabel : action.label}
+            </Button>
+          );
+        })}
+      </div>
+
+      {openActionDefinition ? (
+        <LifecycleConfirmDialog
+          isOpen={openAction !== null}
+          title={openActionDefinition.confirmTitle}
+          description={openActionDefinition.confirmDescription}
+          confirmLabel={openActionDefinition.confirmLabel}
+          destructive={openActionDefinition.destructive}
+          isLoading={pendingAction === openActionDefinition.id}
+          onClose={handleCloseDialog}
+          onConfirm={handleConfirmAction}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/libs/web/pages/admin/src/index.ts
+++ b/libs/web/pages/admin/src/index.ts
@@ -3,3 +3,4 @@ export { AdminSidebar } from './components/AdminSidebar';
 export { default as AdminHomePage } from './pages/AdminHomePage';
 export { default as AdminUsersPage } from './pages/AdminUsersPage';
 export { default as AdminUserDetailPage } from './pages/AdminUserDetailPage';
+export { default as AdminAuditLogPage } from './pages/AdminAuditLogPage';

--- a/libs/web/pages/admin/src/lib/formatAuditLog.ts
+++ b/libs/web/pages/admin/src/lib/formatAuditLog.ts
@@ -1,0 +1,21 @@
+import type { AdminAuditAction } from '@myorganizer/app-api-client';
+
+const AUDIT_ACTION_LABELS: Record<AdminAuditAction, string> = {
+  disable: 'Disable',
+  enable: 'Enable',
+  force_logout: 'Force logout',
+  resend_verification: 'Resend verification',
+  promote: 'Promote',
+  demote: 'Demote',
+};
+
+export function formatAuditAction(action: AdminAuditAction): string {
+  return AUDIT_ACTION_LABELS[action];
+}
+
+export function formatAuditTimestamp(iso: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(iso));
+}

--- a/libs/web/pages/admin/src/pages/AdminAuditLogPage.tsx
+++ b/libs/web/pages/admin/src/pages/AdminAuditLogPage.tsx
@@ -1,0 +1,5 @@
+import { AuditLogPageClient } from '../components/AuditLogPageClient';
+
+export default function AdminAuditLogPage() {
+  return <AuditLogPageClient />;
+}


### PR DESCRIPTION
## Why
Add user lifecycle actions and audit log UI (#202).

## Changes
- Add lifecycle mutation controls on user detail (disable, enable, force logout, resend verification, promote, demote) with confirm dialogs and toast feedback
- Add Admin Audit Log browse page at /admin/audit-logs with sidebar navigation

## Validation
- Generated from 1 commit(s) on `feat/202-admin-mutation-audit-ui`.
- Compared against base branch `main`.
