### PR TITLE
test(admin): add lifecycle actions and audit log tests (#203)

### DIFF
--- a/libs/web/pages/admin/src/components/AuditLogPageClient.test.tsx
+++ b/libs/web/pages/admin/src/components/AuditLogPageClient.test.tsx
@@ -1,0 +1,185 @@
+/** Mocking rule: place jest.mock calls before any imports */
+/* eslint-disable import/first -- jest.mock must precede application imports */
+
+jest.mock('../lib/apiClient', () => ({
+  createPlatformAdminApi: jest.fn(),
+}));
+
+import type { AdminAuditLogEntry } from '@myorganizer/app-api-client';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { createPlatformAdminApi } from '../lib/apiClient';
+import { formatAuditTimestamp } from '../lib/formatAuditLog';
+
+import { AuditLogPageClient } from './AuditLogPageClient';
+
+const mockListAuditLogs = jest.fn();
+
+const sampleEntries: AdminAuditLogEntry[] = [
+  {
+    id: 'audit-1',
+    action: 'disable',
+    actorUserId: 'actor-1',
+    targetUserId: 'target-1',
+    createdAt: '2026-07-16T12:00:00.000Z',
+  },
+  {
+    id: 'audit-2',
+    action: 'force_logout',
+    actorUserId: 'actor-2',
+    targetUserId: 'target-2',
+    createdAt: '2026-07-15T08:30:00.000Z',
+  },
+  {
+    id: 'audit-3',
+    action: 'resend_verification',
+    actorUserId: 'actor-3',
+    targetUserId: 'target-3',
+    createdAt: '2026-07-14T16:45:00.000Z',
+  },
+];
+
+describe('AuditLogPageClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createPlatformAdminApi as jest.Mock).mockReturnValue({
+      listAuditLogs: mockListAuditLogs,
+    });
+    mockListAuditLogs.mockResolvedValue({ data: sampleEntries });
+  });
+
+  it('shows loading state on mount and calls listAuditLogs with limit 50', async () => {
+    let resolveLoad!: (value: { data: AdminAuditLogEntry[] }) => void;
+    const pendingLoad = new Promise<{ data: AdminAuditLogEntry[] }>(
+      (resolve) => {
+        resolveLoad = resolve;
+      },
+    );
+    mockListAuditLogs.mockReturnValue(pendingLoad);
+
+    render(<AuditLogPageClient />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Admin Audit Log' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+
+    resolveLoad({ data: sampleEntries });
+
+    await waitFor(() => {
+      expect(mockListAuditLogs).toHaveBeenCalledWith({ limit: 50 });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders table headers and rows with actor, target, and action labels', async () => {
+    render(<AuditLogPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Disable')).toBeInTheDocument();
+    });
+
+    expect(mockListAuditLogs).toHaveBeenCalledWith({ limit: 50 });
+    expect(screen.getByText('Time')).toBeInTheDocument();
+    expect(screen.getByText('Action')).toBeInTheDocument();
+    expect(screen.getByText('Actor')).toBeInTheDocument();
+    expect(screen.getByText('Target')).toBeInTheDocument();
+
+    expect(screen.getByText('actor-1')).toBeInTheDocument();
+    expect(screen.getByText('target-1')).toBeInTheDocument();
+    expect(screen.getByText('Force logout')).toBeInTheDocument();
+    expect(screen.getByText('actor-2')).toBeInTheDocument();
+    expect(screen.getByText('target-2')).toBeInTheDocument();
+    expect(screen.getByText('Resend verification')).toBeInTheDocument();
+    expect(screen.getByText('actor-3')).toBeInTheDocument();
+    expect(screen.getByText('target-3')).toBeInTheDocument();
+  });
+
+  it('formats timestamps with the same Intl options as formatAuditTimestamp', async () => {
+    const timestamp = '2026-07-16T12:00:00.000Z';
+    mockListAuditLogs.mockResolvedValue({
+      data: [
+        {
+          id: 'audit-ts',
+          action: 'enable',
+          actorUserId: 'actor-ts',
+          targetUserId: 'target-ts',
+          createdAt: timestamp,
+        },
+      ],
+    });
+
+    render(<AuditLogPageClient />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(formatAuditTimestamp(timestamp)),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when the API returns no entries', async () => {
+    mockListAuditLogs.mockResolvedValue({ data: [] });
+
+    render(<AuditLogPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No audit log entries yet.')).toBeInTheDocument();
+    });
+
+    expect(mockListAuditLogs).toHaveBeenCalledWith({ limit: 50 });
+    expect(screen.queryByText('Time')).not.toBeInTheDocument();
+  });
+
+  it('shows an error message when listAuditLogs rejects', async () => {
+    mockListAuditLogs.mockRejectedValue(new Error('Network error'));
+
+    render(<AuditLogPageClient />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Unable to load audit log. Please try again.'),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockListAuditLogs).toHaveBeenCalledWith({ limit: 50 });
+    expect(screen.queryByText('Time')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disable')).not.toBeInTheDocument();
+  });
+
+  it('does not surface vault or secret operational fields from bloated entries', async () => {
+    const secretFieldValues = [
+      'SECRET_VAULT_BLOB',
+      'ya29.secret-token',
+      'should-never-appear',
+      'mk-secret',
+    ] as const;
+
+    const bloatedEntry = {
+      ...sampleEntries[0],
+      vaultCiphertext: 'SECRET_VAULT_BLOB',
+      youtubeOAuthToken: 'ya29.secret-token',
+      password: 'should-never-appear',
+      masterKey: 'mk-secret',
+    } as AdminAuditLogEntry;
+
+    mockListAuditLogs.mockResolvedValue({ data: [bloatedEntry] });
+
+    const { container } = render(<AuditLogPageClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Disable')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('actor-1')).toBeInTheDocument();
+    expect(screen.getByText('target-1')).toBeInTheDocument();
+
+    for (const secretValue of secretFieldValues) {
+      expect(container.textContent).not.toContain(secretValue);
+    }
+  });
+});

--- a/libs/web/pages/admin/src/components/UserLifecycleActions.test.tsx
+++ b/libs/web/pages/admin/src/components/UserLifecycleActions.test.tsx
@@ -1,0 +1,307 @@
+/** Mocking rule: place jest.mock calls before any imports */
+/* eslint-disable import/first -- jest.mock must precede application imports */
+
+jest.mock('../lib/apiClient', () => ({
+  createPlatformAdminApi: jest.fn(),
+}));
+
+jest.mock('@myorganizer/web-ui', () => {
+  const actual = jest.requireActual('@myorganizer/web-ui');
+
+  return {
+    ...actual,
+    useToast: jest.fn(),
+  };
+});
+
+import type { AdminUserIdentity } from '@myorganizer/app-api-client';
+import { useToast } from '@myorganizer/web-ui';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { createPlatformAdminApi } from '../lib/apiClient';
+
+import { UserLifecycleActions } from './UserLifecycleActions';
+
+const mockDisableUser = jest.fn();
+const mockEnableUser = jest.fn();
+const mockForceLogoutUser = jest.fn();
+const mockResendVerification = jest.fn();
+const mockPromoteUser = jest.fn();
+const mockDemoteUser = jest.fn();
+const mockToast = jest.fn();
+const mockOnUserUpdated = jest.fn();
+
+const activeUser: AdminUserIdentity = {
+  id: 'u-active',
+  name: 'Active User',
+  email: 'active@example.com',
+  firstName: 'Active',
+  lastName: 'User',
+  role: 'user',
+  disabled: false,
+  emailVerified: false,
+};
+
+const disabledUser: AdminUserIdentity = {
+  ...activeUser,
+  id: 'u-disabled',
+  name: 'Disabled User',
+  disabled: true,
+};
+
+const platformAdmin: AdminUserIdentity = {
+  id: 'u-admin',
+  name: 'Platform Admin',
+  email: 'admin@example.com',
+  firstName: 'Platform',
+  lastName: 'Admin',
+  role: 'platform_admin',
+  disabled: false,
+  emailVerified: true,
+};
+
+function createAxiosError(message: string, status: number) {
+  return Object.assign(new Error(message), {
+    isAxiosError: true,
+    response: { status, data: { message } },
+  });
+}
+
+function renderUserLifecycleActions(user: AdminUserIdentity) {
+  return render(
+    <UserLifecycleActions user={user} onUserUpdated={mockOnUserUpdated} />,
+  );
+}
+
+function openAction(actionLabel: string) {
+  fireEvent.click(screen.getByRole('button', { name: actionLabel }));
+}
+
+function confirmDialog(confirmLabel: string) {
+  fireEvent.click(screen.getByRole('button', { name: confirmLabel }));
+}
+
+describe('UserLifecycleActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useToast as jest.Mock).mockReturnValue({ toast: mockToast });
+    (createPlatformAdminApi as jest.Mock).mockReturnValue({
+      disableUser: mockDisableUser,
+      enableUser: mockEnableUser,
+      forceLogoutUser: mockForceLogoutUser,
+      resendVerification: mockResendVerification,
+      promoteUser: mockPromoteUser,
+      demoteUser: mockDemoteUser,
+    });
+  });
+
+  it('shows Disable, Force logout, Resend verification, and Promote for an active user', () => {
+    renderUserLifecycleActions(activeUser);
+
+    expect(
+      screen.getByRole('heading', { name: 'Actions' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Disable' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Force logout' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Resend verification' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Promote' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Enable' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Demote' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Enable and hides Disable for a disabled user', () => {
+    renderUserLifecycleActions(disabledUser);
+
+    expect(screen.getByRole('button', { name: 'Enable' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Disable' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Demote and hides Promote for a platform admin', () => {
+    renderUserLifecycleActions(platformAdmin);
+
+    expect(screen.getByRole('button', { name: 'Demote' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Promote' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides Resend verification when email is verified', () => {
+    renderUserLifecycleActions({ ...activeUser, emailVerified: true });
+
+    expect(
+      screen.queryByRole('button', { name: 'Resend verification' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the user after confirmation', async () => {
+    const updatedUser = { ...activeUser, disabled: true };
+    mockDisableUser.mockResolvedValue({ data: updatedUser });
+
+    renderUserLifecycleActions(activeUser);
+    openAction('Disable');
+    expect(
+      screen.getByRole('heading', { name: 'Disable user?' }),
+    ).toBeInTheDocument();
+    confirmDialog('Disable user');
+
+    await waitFor(() => {
+      expect(mockDisableUser).toHaveBeenCalledWith({ userId: activeUser.id });
+    });
+    expect(mockOnUserUpdated).toHaveBeenCalledWith(updatedUser);
+    expect(mockToast).toHaveBeenCalledWith({ title: 'User disabled' });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: 'Disable user?' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('enables the user after confirmation', async () => {
+    const updatedUser = { ...disabledUser, disabled: false };
+    mockEnableUser.mockResolvedValue({ data: updatedUser });
+
+    renderUserLifecycleActions(disabledUser);
+    openAction('Enable');
+    confirmDialog('Enable user');
+
+    await waitFor(() => {
+      expect(mockEnableUser).toHaveBeenCalledWith({ userId: disabledUser.id });
+    });
+    expect(mockOnUserUpdated).toHaveBeenCalledWith(updatedUser);
+    expect(mockToast).toHaveBeenCalledWith({ title: 'User enabled' });
+  });
+
+  it('forces logout after confirmation', async () => {
+    const updatedUser = { ...activeUser };
+    mockForceLogoutUser.mockResolvedValue({ data: updatedUser });
+
+    renderUserLifecycleActions(activeUser);
+    openAction('Force logout');
+    confirmDialog('Force logout');
+
+    await waitFor(() => {
+      expect(mockForceLogoutUser).toHaveBeenCalledWith({
+        userId: activeUser.id,
+      });
+    });
+    expect(mockOnUserUpdated).toHaveBeenCalledWith(updatedUser);
+    expect(mockToast).toHaveBeenCalledWith({ title: 'User sessions revoked' });
+  });
+
+  it('resends verification after confirmation without updating parent user state', async () => {
+    mockResendVerification.mockResolvedValue({
+      data: { message: 'Verification email sent successfully' },
+    });
+
+    renderUserLifecycleActions(activeUser);
+    openAction('Resend verification');
+    confirmDialog('Resend email');
+
+    await waitFor(() => {
+      expect(mockResendVerification).toHaveBeenCalledWith({
+        userId: activeUser.id,
+      });
+    });
+    expect(mockOnUserUpdated).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Verification email sent successfully',
+    });
+  });
+
+  it('promotes the user after confirmation', async () => {
+    const updatedUser = { ...activeUser, role: 'platform_admin' as const };
+    mockPromoteUser.mockResolvedValue({ data: updatedUser });
+
+    renderUserLifecycleActions(activeUser);
+    openAction('Promote');
+    confirmDialog('Promote user');
+
+    await waitFor(() => {
+      expect(mockPromoteUser).toHaveBeenCalledWith({ userId: activeUser.id });
+    });
+    expect(mockOnUserUpdated).toHaveBeenCalledWith(updatedUser);
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'User promoted to Platform Admin',
+    });
+  });
+
+  it('demotes the user after confirmation', async () => {
+    const updatedUser = { ...platformAdmin, role: 'user' as const };
+    mockDemoteUser.mockResolvedValue({ data: updatedUser });
+
+    renderUserLifecycleActions(platformAdmin);
+    openAction('Demote');
+    confirmDialog('Demote user');
+
+    await waitFor(() => {
+      expect(mockDemoteUser).toHaveBeenCalledWith({ userId: platformAdmin.id });
+    });
+    expect(mockOnUserUpdated).toHaveBeenCalledWith(updatedUser);
+    expect(mockToast).toHaveBeenCalledWith({ title: 'User demoted' });
+  });
+
+  it('surfaces last-admin demotion errors in a destructive toast and keeps the dialog open', async () => {
+    mockDemoteUser.mockRejectedValue(
+      createAxiosError('Cannot demote the last Platform Admin', 409),
+    );
+
+    renderUserLifecycleActions(platformAdmin);
+    openAction('Demote');
+    confirmDialog('Demote user');
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        title: 'Action failed',
+        description: 'Cannot demote the last Platform Admin',
+        variant: 'destructive',
+      });
+    });
+    expect(mockOnUserUpdated).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('heading', { name: 'Demote Platform Admin?' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a generic error message when the API rejects a non-axios error', async () => {
+    mockDisableUser.mockRejectedValue(new Error('Network error'));
+
+    renderUserLifecycleActions(activeUser);
+    openAction('Disable');
+    confirmDialog('Disable user');
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        title: 'Action failed',
+        description: 'Action failed. Please try again.',
+        variant: 'destructive',
+      });
+    });
+    expect(mockOnUserUpdated).not.toHaveBeenCalled();
+  });
+
+  it('closes the dialog on cancel without calling the API', () => {
+    renderUserLifecycleActions(activeUser);
+    openAction('Disable');
+    expect(
+      screen.getByRole('heading', { name: 'Disable user?' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockDisableUser).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole('heading', { name: 'Disable user?' }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Why
Add lifecycle actions and audit log tests (#203).

## Changes
- Cover UserLifecycleActions mutations with mocked PlatformAdminApi
- Assert last-admin demotion 409 surfaces destructive toast
- Cover AuditLogPageClient browse flow against mocked listAuditLogs

## Validation
- Generated from 1 commit(s) on `feat/issue-203-mutation-and-audit-ui-tests`.
- Compared against base branch `main`.
