### PR TITLE
chore(agents): update model and tool metadata

### DIFF
--- a/.github/agents/api-sync.agent.md
+++ b/.github/agents/api-sync.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to verify, regenerate, or check drift in the OpenAPI spec or generated API client (libs/app-api-client) after backend contract changes in MyOrganizer.'
 name: 'ApiSync'
 tools: [read, search, execute]
-model: ['Gemini 3 Flash (Preview) (copilot)', 'GPT-5 mini (copilot)', 'GPT-5.3-Codex (copilot)']
+model: ['GPT-5.6 Luna (copilot)']
 user-invocable: true
 argument-hint: "Optional: 'check' (default) or 'regenerate'"
 ---

--- a/.github/agents/audit.agent.md
+++ b/.github/agents/audit.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to audit, scan, review, or check the codebase for issues like unused exports, `any` usage, missing tests, OWASP Top 10 risks, Nx module boundary violations, or dead code. Read-only — returns a prioritized list.'
 name: 'Audit'
 tools: [read, search, execute]
-model: ['Kimi K2.7 Code (Preview) (copilot)', 'Claude Haiku 4.5 (copilot)', 'GPT-5.3-Codex (copilot)']
+model: ['Kimi K2.7 Code (copilot)', 'Gemini 3.6 Flash (copilot)']
 user-invocable: true
 argument-hint: "Audit scope (project, library, or 'full repo') and focus area"
 ---

--- a/.github/agents/commit.agent.md
+++ b/.github/agents/commit.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged or unstaged changes. Read-only — produces the message text only and does not create the commit.'
 name: 'Commit'
 tools: [read, search, execute]
-model: ['GPT-5 mini (copilot)', 'MAI-Code-1-Flash (copilot)']
+model: ['GPT-5.6 Luna (copilot)', 'MAI-Code-1-Flash (copilot)']
 user-invocable: true
 argument-hint: 'Optional: scope hint or area of change'
 ---

--- a/.github/agents/component-builder.agent.md
+++ b/.github/agents/component-builder.agent.md
@@ -1,8 +1,8 @@
 ---
 description: 'Use when creating or editing a React component in the MyOrganizer web app. Accepts a Structured Spec from the main agent, reads project guidelines, and writes the component following docs/ui/GUIDELINES.md and TECH_STACK.md. Always prefers the compound/composition pattern.'
 name: 'ComponentBuilder'
-tools: [read, search, edit, create]
-model: ['GPT-5 mini (copilot)', 'Kimi K2.7 Code (Preview) (copilot)', 'MAI-Code-1-Flash (copilot)', 'Claude Haiku 4.5 (copilot)']
+tools: [read, edit, search, todo]
+model: ['Gemini 3.6 Flash (copilot)', 'GPT-5.6 Luna (copilot)']
 user-invocable: false
 argument-hint: 'Structured Spec block (Component Name, Target Path, Action, Props Interface, State, Zod Schema, Composition)'
 ---

--- a/.github/agents/component-reviewer.agent.md
+++ b/.github/agents/component-reviewer.agent.md
@@ -2,7 +2,7 @@
 description: 'Automatically runs after ComponentBuilder completes. Reviews the written component against docs/ui/GUIDELINES.md, checks for side-effects, performance, memory, and design issues, and scans direct importers for breakage. Produces a report only — never edits files.'
 name: 'ComponentReviewer'
 tools: [read, search]
-model: ['GPT-5 mini (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['Claude Sonnet 5 (copilot)', 'Grok 4.5 (copilot)', 'GPT-5.6 Terra (copilot)']
 user-invocable: false
 argument-hint: 'ComponentBuilder Report block'
 ---

--- a/.github/agents/dep-audit.agent.md
+++ b/.github/agents/dep-audit.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to audit dependencies, check for outdated packages, scan for vulnerabilities, or review dependency upgrade risk in MyOrganizer.'
 name: 'DepAudit'
 tools: [read, search, execute]
-model: ['GPT-5.3-Codex (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['Gemini 3.6 Flash (copilot)', 'Claude Haiku 4.5 (copilot)']
 user-invocable: true
 argument-hint: "Optional: 'security' | 'outdated' | 'all' (default)"
 ---

--- a/.github/agents/dep-sync.agent.md
+++ b/.github/agents/dep-sync.agent.md
@@ -2,7 +2,7 @@
 description: 'Synchronise TECH_STACK.md and authoritative files when dependencies are installed, updated, or removed. Proposes changes and requires user confirmation before writing anything.'
 name: 'DepSync'
 tools: [read, search, edit]
-model: ['GPT-5 mini (copilot)', 'Claude Haiku 4.5 (copilot)', 'Gemini 3.5 Flash (copilot)']
+model: ['GPT-5.6 Luna (copilot)']
 user-invocable: true
 argument-hint: 'Optional: "added <package>", "removed <package>", or blank for a full diff'
 ---

--- a/.github/agents/docs.agent.md
+++ b/.github/agents/docs.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to write, update, or expand long-form documentation, READMEs, ADRs, feature docs, or guides under docs/ or library README files in MyOrganizer. Produces Markdown content; main agent decides where to write it.'
 name: 'Docs'
 tools: [read, search]
-model: ['Gemini 3.5 Flash (copilot)', 'Claude Haiku 4.5 (copilot)', 'GPT-5.3-Codex (copilot)']
+model: ['Gemini 3.6 Flash (copilot)']
 user-invocable: true
 argument-hint: 'Topic + target audience + (optional) target file'
 ---

--- a/.github/agents/e2e-planner.agent.md
+++ b/.github/agents/e2e-planner.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to plan, outline, or design Playwright end-to-end tests for a user flow in MyOrganizer. Returns a behavior-first flow matrix and structured test plan; does not write the test file.'
 name: 'E2EPlanner'
 tools: [read, search]
-model: ['Claude Sonnet 5 (copilot)', 'GPT-5.3-Codex (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['Claude Sonnet 5 (copilot)', 'GPT-5.6 Terra (copilot)', 'Grok 4.5 (copilot)']
 user-invocable: true
 argument-hint: "User flow to test (e.g. 'login + create todo')"
 ---

--- a/.github/agents/explore.agent.md
+++ b/.github/agents/explore.agent.md
@@ -2,7 +2,7 @@
 description: 'Read-only codebase exploration specialist for MyOrganizer. Delegate when the main agent would issue 3 or more consecutive file read/search operations to locate something in the codebase.'
 name: 'CodeExplorer'
 tools: [read, search]
-model: ['Gemini 3.5 Flash (copilot)', 'GPT-5 mini (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['GPT-5.6 Luna (copilot)']
 user-invocable: false
 argument-hint: 'Explore Request with Goal (required) + optional Known Locations, Search Hints, Out of Scope, Expected Output'
 ---

--- a/.github/agents/issue-creator.agent.md
+++ b/.github/agents/issue-creator.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to create a GitHub issue and you need a focused workflow for duplicate detection, mandatory detail collection, label validation, and safe issue creation in MyOrganizer.'
 name: 'IssueCreator'
 tools: [read, search, execute]
-model: ['MAI-Code-1-Flash (copilot)', 'GPT-5 mini (copilot)', 'Kimi K2.7 Code (Preview) (copilot)']
+model: ['GPT-5.6 Luna (copilot)']
 user-invocable: true
 argument-hint: 'Issue request details: task/bug context, title, body details, labels, and scope'
 ---

--- a/.github/agents/preflight-check.agent.md
+++ b/.github/agents/preflight-check.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to validate, check, or confirm that the repo is ready to cut a release in MyOrganizer. Returns a structured pass/fail checklist.'
 name: 'PreflightCheck'
 tools: [execute]
-model: ['GPT-5 mini (copilot)', 'Gemini 3.5 Flash (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['GPT-5.6 Luna (copilot)']
 user-invocable: true
 argument-hint: 'Optional: target version (e.g. v1.3.0) for version-consistency check'
 ---

--- a/.github/agents/release-notes.agent.md
+++ b/.github/agents/release-notes.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to draft release notes, CHANGELOG entries, or summarize commits between two refs/tags for MyOrganizer.'
 name: 'ReleaseNotes'
 tools: [read, search, execute]
-model: ['GPT-5 mini (copilot)', 'Gemini 3.5 Flash (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['GPT-5.6 Luna (copilot)']
 user-invocable: true
 argument-hint: '<from-ref>..<to-ref> (defaults to last tag..HEAD)'
 ---

--- a/.github/agents/research.agent.md
+++ b/.github/agents/research.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to research, look up, investigate, or summarize external documentation, libraries, standards, RFCs, security advisories, or web content. Produces a structured brief with citations.'
 name: 'Research'
 tools: [web, read, search]
-model: ['Gemini 3.1 Pro (Preview) (copilot)', 'GPT-5.3-Codex (copilot)', 'Kimi K2.7 Code (Preview) (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['Gemini 3.6 Flash (copilot)']
 user-invocable: true
 argument-hint: 'Question or topic to research'
 ---

--- a/.github/agents/storybook-curator.agent.md
+++ b/.github/agents/storybook-curator.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when creating or updating Storybook stories for MyOrganizer UI components. This agent must analyze requirement quality before editing, challenge incomplete or weak requests, and deliver UX/a11y-aware stories.'
 name: 'StorybookCurator'
 tools: [read, search, edit]
-model: ['Gemini 3.5 Flash (copilot)', 'Claude Haiku 4.5 (copilot)', 'GPT-5 mini (copilot)']
+model: ['Gemini 3.6 Flash (copilot)']
 user-invocable: true
 argument-hint: 'Requirement summary + component/story paths + expected states'
 ---

--- a/.github/agents/test-reviewer.agent.md
+++ b/.github/agents/test-reviewer.agent.md
@@ -2,7 +2,7 @@
 description: 'Use after TestScaffold to gate test files before execution. Runs tsc --noEmit and eslint, then verifies the behavior matrix and checklist items against the actual file. Returns APPROVED or REJECTED with an annotated checklist and required revisions.'
 name: 'TestReviewer'
 tools: [read, search, execute]
-model: ['Gemini 3.5 Flash (copilot)', 'GPT-5.3-Codex (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['Claude Sonnet 5 (copilot)']
 user-invocable: false
 argument-hint: 'Full TestScaffold output including file path, behavior matrix, coverage map, and review checklist'
 ---

--- a/.github/agents/test-runner.agent.md
+++ b/.github/agents/test-runner.agent.md
@@ -2,7 +2,7 @@
 description: 'Executes Jest unit and integration tests after TestReviewer approval. Detects hangs via ps aux check after 1-minute silence, retries one-at-a-time if needed, and returns a structured verdict. Never executes E2E tests — applies needs-e2e-review label instead.'
 name: 'TestRunner'
 tools: [read, execute]
-model: ['Gemini 3.5 Flash (copilot)', 'GPT-5.3-Codex (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['Kimi K2.7 Code (copilot)']
 user-invocable: false
 argument-hint: 'TestReviewer-approved output including verdict, file path, project name, and annotated checklist'
 ---

--- a/.github/agents/test-scaffold.agent.md
+++ b/.github/agents/test-scaffold.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when creating or updating MyOrganizer test suites: Jest unit tests, Jest integration tests, React hook/component integration tests, or Playwright E2E specs. This agent edits test files directly after reading the implementation, building a behavior matrix, and validating that each test matches real behavior.'
 name: 'TestScaffold'
 tools: [read, search, edit, execute]
-model: ['Gemini 3.5 Flash (copilot)', 'GPT-5.3-Codex (copilot)', 'Claude Haiku 4.5 (copilot)']
+model: ['Gemini 3.6 Flash (copilot)']
 user-invocable: true
 argument-hint: 'Requirement summary + project + source/test paths + behavior matrix + test type'
 ---

--- a/.github/agents/version-bump.agent.md
+++ b/.github/agents/version-bump.agent.md
@@ -2,7 +2,7 @@
 description: 'Use when the user asks to determine, suggest, or propose the next semantic version number based on commit history in MyOrganizer.'
 name: 'VersionBump'
 tools: [execute]
-model: ['GPT-5 mini (copilot)', 'Gemini 3 Flash (Preview) (copilot)', 'MAI-Code-1-Flash (copilot)']
+model: ['GPT-5.6 Luna (copilot)']
 user-invocable: true
 argument-hint: 'Optional: explicit commit range (defaults to latest-tag..HEAD)'
 ---


### PR DESCRIPTION
## Why
Update model and tool metadata.

## Changes
- Refresh model assignments and tool capabilities across 19 agent definitions.

## Validation
- Generated from 1 commit(s) on `chore/update-agent-metadata`.
- Compared against base branch `main`.
