### PR TITLE
feat(sandcastle): add 1Password dispatch and slice issue filtering

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,6 +1,10 @@
 # Sandcastle environment variables
-# Copy this file to .sandcastle/.env and fill in the values.
-# .env is gitignored — never commit your API key.
+#
+# Preferred local workflow: store these values in a 1Password Environment and
+# run `corepack yarn dispatch-agents:1password` or
+# `corepack yarn dispatch-waves:1password` with OP_ENVIRONMENT_ID set.
+# Do not copy secrets into this file or create .sandcastle/.env unless you need
+# the legacy dotenv workflow.
 
 # Optional: default agent provider for dispatch.
 # Supported values: claude, cursor, copilot
@@ -16,7 +20,7 @@ SANDCASTLE_COPILOT_MODEL=claude-sonnet-4.5
 # Required for Claude Code agents.
 # Provide one of:
 # CLAUDE_CODE_OAUTH_TOKEN=your-token-here
-ANTHROPIC_API_KEY=your-key-here
+# ANTHROPIC_API_KEY=your-key-here
 
 # Required for Cursor agents.
 # CURSOR_API_KEY=your-cursor-api-key

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -121,10 +121,11 @@ function getArgValue(name: string): string | undefined {
 function printHelp(): void {
   console.log(`
 Usage:
-  yarn dispatch-agents --prd <issue-number> [--agent claude|cursor|copilot] [--model <model>]
+  yarn dispatch-agents --prd <issue-number> [--issue <slice-number>] [--agent claude|cursor|copilot] [--model <model>]
 
 Flags:
   --prd <issue-number>   PRD issue number to dispatch
+  --issue <slice-number> Dispatch only this slice issue
   --agent <name>         Agent provider to use (default: SANDCASTLE_AGENT or claude)
   --model <model>        Override the model for this run (default: env/provider routing)
   --help                 Show this help text
@@ -147,12 +148,18 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
 const prdValue = getArgValue('prd');
 if (!prdValue) {
   fail(
-    'Usage: yarn dispatch-agents --prd <issue-number> [--agent claude|cursor|copilot] [--model <model>]',
+    'Usage: yarn dispatch-agents --prd <issue-number> [--issue <slice-number>] [--agent claude|cursor|copilot] [--model <model>]',
   );
 }
 
 const prdNumber = parseInt(prdValue, 10);
 if (isNaN(prdNumber)) fail('--prd must be a number.');
+
+const issueValue = getArgValue('issue');
+const issueNumber = issueValue ? parseInt(issueValue, 10) : undefined;
+if (issueValue && isNaN(issueNumber as number)) {
+  fail('--issue must be a number.');
+}
 
 const agentFlag = getArgValue('agent');
 const modelFlag = getArgValue('model');
@@ -225,6 +232,7 @@ const allIssues = ghJson<Issue[]>([
 const slices = allIssues.filter(
   (i) =>
     i.body?.includes(`PRD: #${prdNumber}`) &&
+    (issueNumber === undefined || i.number === issueNumber) &&
     // Skip slices already merged into the feature branch so re-runs are
     // idempotent — only undone work in the wave is re-dispatched.
     !i.labels.some((l) => l.name === 'status:done'),
@@ -232,8 +240,11 @@ const slices = allIssues.filter(
 
 if (slices.length === 0) {
   fail(
-    `No open AFK slice issues found for PRD #${prdNumber}.\n` +
-      `Run /to-issues ${prdNumber} to create them first.`,
+    issueNumber === undefined
+      ? `No open AFK slice issues found for PRD #${prdNumber}.\n` +
+          `Run /to-issues ${prdNumber} to create them first.`
+      : `Slice issue #${issueNumber} was not found as an open AFK slice for PRD #${prdNumber}.\n` +
+          `Check its labels and PRD reference before retrying.`,
   );
 }
 

--- a/docs/sandcastle/RUNBOOK.md
+++ b/docs/sandcastle/RUNBOOK.md
@@ -26,9 +26,19 @@ pipeline.
 1. **Toolchain:** Node 22 + corepack (`corepack enable` → provides `yarn` pinned to 4.13.0).
 2. **Docker:** a running Docker engine the dispatch shell can reach (`docker info` works).
 3. **Auth:** `gh auth status` green and `git config user.name/.email` set, for the dispatch host.
-4. **Secrets:** `cp .sandcastle/.env.example .sandcastle/.env` and set `ANTHROPIC_API_KEY`
-   (`GH_TOKEN` optional; otherwise the host's `gh` session is used). The launcher loads
-   `.sandcastle/.env` itself.
+4. **Secrets:** Prefer a 1Password Environment. Install the 1Password CLI, enable its
+   desktop-app integration, and copy the Environment ID from **Developer > View
+   Environments**. Then run dispatch with `OP_ENVIRONMENT_ID`:
+   ```bash
+   export OP_ENVIRONMENT_ID=<your-1password-environment-id>
+   corepack yarn dispatch-agents:1password --prd <issue-number>
+   # or:
+   corepack yarn dispatch-waves:1password --prd <issue-number>
+   ```
+   The CLI authenticates through the unlocked 1Password desktop app and injects the
+   Environment variables only into the dispatch process. Do not put API keys in
+   `.sandcastle/.env`. The legacy dotenv workflow remains available for local-only
+   setups, but `.sandcastle/.env` is ignored and must never be committed.
 5. The `sandcastle:myorganizer` image builds automatically on first run if missing. It
    already bakes in Claude Code, Cursor, and GitHub Copilot CLI so the `--agent` flag only
    switches which provider Sandcastle launches.
@@ -78,6 +88,12 @@ Provider switching is optional: the default agent can live in `.sandcastle/.env`
 (`SANDCASTLE_CLAUDE_MODEL`, `SANDCASTLE_CURSOR_MODEL`, `SANDCASTLE_COPILOT_MODEL`), and
 `--model` always overrides them for a single run. Claude keeps the existing complexity-based
 model routing when no override is set.
+
+With 1Password Environments, put the same variable names in the Environment instead. For
+example, use `SANDCASTLE_AGENT`, `SANDCASTLE_CLAUDE_MODEL`, and the provider credential
+(`ANTHROPIC_API_KEY`, `CURSOR_API_KEY`, or `COPILOT_GITHUB_TOKEN`) as Environment variables.
+1Password Environments are currently beta functionality, and 1Password notes that
+`op run --environment` may take longer to start on Apple silicon Macs.
 
 **Integration is local-only** (see `docs/adr/0010`). The feature branch `feat/<slug>` is created
 from `origin/main` **locally and is never pushed**. Slices run **one by one**: each branches off

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "agents:sync:check": "node tools/scripts/sync-subagents.mjs --check",
     "dispatch-agents": "npx tsx .sandcastle/main.mts",
     "dispatch-waves": "npx tsx .sandcastle/dispatch-waves.mts",
+    "dispatch-agents:1password": "op run --environment \"$OP_ENVIRONMENT_ID\" -- corepack yarn dispatch-agents",
+    "dispatch-waves:1password": "op run --environment \"$OP_ENVIRONMENT_ID\" -- corepack yarn dispatch-waves",
     "nx": "nx",
     "postinstall": "husky"
   },


### PR DESCRIPTION
## Why
Add 1Password dispatch and slice issue filtering.

## Changes
- Add 1Password Environment-backed dispatch scripts and runbook guidance
- Support dispatching a single slice issue with --issue

## Validation
- Generated from 1 commit(s) on `feat/sandcastle-1password-dispatch`.
- Compared against base branch `main`.
