### PR TITLE
feat(groceries): add trip board catalog flows

### DIFF
--- a/docs/features/groceries.md
+++ b/docs/features/groceries.md
@@ -39,10 +39,31 @@ Items can be assigned to one of these predefined categories:
 
 Use the **category filter bar** above the item list to show only items in a given category.
 
-### Checking Items Off
+### Catalog Items and List Lines
 
-Click the checkbox next to any item to mark it as collected. Use **Clear Checked** to
-remove all checked items at once.
+Every grocery item you create becomes a **Catalog Item** (its identity: name, category,
+price, notes, image, links). A **List Line** is a lightweight reference — `catalogItemId`
+
+- `checked`/`amount` — that places a Catalog Item onto a specific Grocery List. The same
+  Catalog Item can be a List Line on many lists at once without duplicating its identity.
+
+* **Add From Catalog** on a list lets you pick an existing Catalog Item and add it as a
+  List Line to one or many lists in a single action.
+* **Delete List Line** removes the item from that one list only; the Catalog Item and its
+  lines on other lists are untouched.
+* **Delete From Catalog** permanently removes the Catalog Item and every List Line that
+  references it, across every list. This requires typing the item's name to confirm.
+
+### Trip Lifecycle (Checking Items Off)
+
+Click the checkbox next to any line to mark it as bought on the current trip (`checked`).
+Checked lines stay visible on the list.
+
+- **Uncheck All** clears the checked state on every line without removing any lines or
+  Catalog Items — use it to reset a list for a new trip.
+- **Remove Checked From List** removes the finished (checked) lines from the current list
+  only, with an undo affordance immediately after. It never deletes the underlying Catalog
+  Items, and other lists referencing the same items are unaffected.
 
 ### Vault Backup
 
@@ -63,22 +84,17 @@ Despite E2EE, the server retains limited metadata: the blob type identifier (`'g
 ## Vault Blob Schema (developer reference)
 
 ```typescript
-// Stored as an encrypted GroceryList[] array
-interface GroceryList {
-  id: string; // UUID v4
-  name: string; // Required, user-defined list name
-  items: GroceryItem[];
-  createdAt: string; // ISO 8601
-  updatedAt: string; // ISO 8601
+// Stored as an encrypted GroceriesVaultPayload
+interface GroceriesVaultPayload {
+  catalog: CatalogItem[]; // Item identities, shared across lists
+  lists: GroceryList[];
 }
 
-interface GroceryItem {
+interface CatalogItem {
   id: string; // UUID v4
   name: string; // Required
-  amount?: string; // Free text, e.g. "2", "500g", "1 dozen"
-  price?: number; // Optional — for budget tracking (in user's local currency)
   category: GroceryCategoryType; // Defaults to 'other'
-  checked: boolean; // Shopping-list checked state
+  price?: number; // Optional — for budget tracking (in user's local currency)
   notes?: string; // Optional free text notes
   imageUrl?: string; // Optional external image URL (display only, no uploads)
   links?: string[]; // Optional array of external links
@@ -86,13 +102,33 @@ interface GroceryItem {
   updatedAt: string; // ISO 8601
 }
 
+interface GroceryList {
+  id: string; // UUID v4
+  name: string; // Required, user-defined list name
+  lines: ListLine[]; // References into `catalog` for this list
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+
+interface ListLine {
+  id: string; // UUID v4
+  catalogItemId: string; // References CatalogItem.id
+  checked: boolean; // Bought-on-this-trip state
+  amount?: string; // Free text, e.g. "2", "500g", "1 dozen"
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+
 type GroceryCategoryType = 'produce' | 'dairy' | 'meat' | 'seafood' | 'bakery' | 'frozen' | 'beverages' | 'snacks' | 'condiments' | 'household' | 'personal-care' | 'other';
 ```
+
+A Catalog Item's name/category/price/etc. are resolved by looking up `ListLine.catalogItemId`
+in `catalog` — a `ListLine` itself never carries a copy of that data.
 
 ## Architecture
 
 - **Page library**: `@myorganizer/web-pages/groceries` ([libs/web/pages/groceries/](../../libs/web/pages/groceries/))
-- **Shared types**: `@myorganizer/core` → `GroceryList`, `GroceryItem`, `GroceryCategoryType`
+- **Shared types**: `@myorganizer/core` → `GroceriesVaultPayload`, `CatalogItem`, `GroceryList`, `ListLine`, `GroceryCategoryType`
 - **Vault normalization**: `@myorganizer/web-vault` → `normalizeGroceries` ([libs/web-vault/src/lib/vault/groceriesNormalization.ts](../../libs/web-vault/src/lib/vault/groceriesNormalization.ts))
 - **Vault blob type**: `'groceries'` (registered in `VaultRecordType`, `VaultBlobType`)
 - **Route**: `/groceries` ([apps/myorganizer/src/app/groceries/page.tsx](../../apps/myorganizer/src/app/groceries/page.tsx))
@@ -147,6 +183,7 @@ interface DialogState {
 ```typescript
 interface GroceryListSelectorProps {
   lists: GroceryList[];
+  catalog: CatalogItem[]; // resolves each line's category/name for progress + dominant-category display
   selectedListIds: string[];
   onSelectLists: (ids: string[]) => void;
   onRenameList: (id: string) => void;
@@ -199,48 +236,98 @@ interface DeleteListConfirmDialogProps {
 
 Wraps the groceries page to catch React render errors and show a fallback UI.
 
+### AddExistingItemDialog
+
+```typescript
+interface AddExistingItemDialogProps {
+  isOpen: boolean;
+  catalog: CatalogItem[];
+  lists: GroceryList[];
+  currentListId: string;
+  onClose: () => void;
+  onAdd: (catalogItemId: string, listIds: string[], amount?: string) => Promise<void>;
+  isLoading?: boolean;
+}
+```
+
+Search/select an existing Catalog Item, choose one or many target lists, optionally set an
+amount, and add it as a List Line to every selected list (skipping lists that already have
+a line for that item).
+
+### DeleteCatalogItemDialog
+
+```typescript
+interface DeleteCatalogItemDialogProps {
+  isOpen: boolean;
+  catalogItem: CatalogItem | null;
+  affectedListCount: number; // other lists (besides the current one) with a matching line
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  isLoading?: boolean;
+}
+```
+
+Strong confirmation: the destructive action stays disabled until the user types the Catalog
+Item's exact name. Confirming permanently deletes the Catalog Item and every List Line that
+references it, across all lists.
+
 ---
 
 ## `useGroceriesVault` Hook
 
-**Location:** `@myorganizer/web-pages/groceries` → `src/groceries-page/hooks/useGroceriesVault.ts`
+**Location:** `@myorganizer/web-pages/groceries` → `src/shared/hooks/useGroceriesVault.ts`
 
 ```typescript
 const vault = useGroceriesVault({ masterKeyBytes });
 ```
 
-**Return type:**
+**Key mutations (partial list):**
 
 ```typescript
-interface UseGroceriesVaultReturn {
+interface UseGroceriesVaultResult {
+  catalog: CatalogItem[];
   lists: GroceryList[];
   loading: boolean;
   error: string | null;
-  selectedListId: string | null;
 
   createList: (name: string) => Promise<void>;
   renameList: (id: string, newName: string) => Promise<void>;
   deleteList: (id: string) => Promise<void>;
-  persistLists: (lists: GroceryList[]) => Promise<void>; // low-level direct save
 
-  setError: (error: string | null) => void;
-  setSelectedListId: (id: string | null) => void;
+  // Catalog membership
+  addCatalogItemAndLine: (listId: string, item: NewCatalogItemInput) => Promise<void>; // create-or-reuse a Catalog Item by name, add a line to one list
+  addItemToLists: (item: NewCatalogItemInput, listIds: string[]) => Promise<void>; // create-or-reuse a Catalog Item, add a line to many lists
+  addExistingCatalogItemToLists: (catalogItemId: string, listIds: string[], amount?: string) => Promise<string[]>; // resolves with the ids of lists that actually received a new line
+  deleteListLine: (listId: string, lineId: string) => Promise<void>; // list-only removal
+  deleteCatalogItem: (catalogItemId: string) => Promise<void>; // cascades off every list
+
+  // Trip lifecycle
+  toggleLineChecked: (listId: string, lineId: string) => Promise<void>;
+  uncheckAllLines: (listId: string) => Promise<void>;
+  removeCheckedLines: (listId: string) => Promise<ListLine[]>; // returns removed lines for undo
+  restoreLines: (listId: string, lines: ListLine[]) => Promise<void>; // undo affordance
 }
 ```
 
-Errors are caught internally and stored in `vault.error`. All mutations are idempotent — safe to retry. On load error the user can retry by refreshing; on save error the previous state is preserved.
+Errors are caught internally and stored in `vault.error`. On load error the user can retry
+by refreshing; on save error the previous state is preserved. `addItemToLists` and
+`addExistingCatalogItemToLists` silently skip any target list that already has a line for
+the same Catalog Item (no duplicate identity per list) — callers should surface the actual
+added-list count to the user. None of `deleteListLine`, `uncheckAllLines`, or
+`removeCheckedLines` ever remove a Catalog Item — only `deleteCatalogItem` does, and it
+always cascades to every referencing List Line.
 
 ---
 
 ## Vault Utilities
 
-**Location:** `src/groceries-page/utils/vault.ts`
+**Location:** `src/shared/utils/vault.ts`
 
 | Function                        | Description                                                                |
 | ------------------------------- | -------------------------------------------------------------------------- |
 | `getVaultErrorMessage(error)`   | Converts caught errors to user-friendly strings                            |
 | `validateGroceryListName(name)` | Validates 1–100 chars with whitespace trimming                             |
-| `createEmptyGroceryList(name)`  | Factory: returns a new `GroceryList` with a UUID v4 id and empty `items[]` |
+| `createEmptyGroceryList(name)`  | Factory: returns a new `GroceryList` with a UUID v4 id and empty `lines[]` |
 
 ---
 
@@ -248,7 +335,7 @@ Errors are caught internally and stored in `vault.error`. All mutations are idem
 
 When the `GroceryList` or `GroceryItem` shape needs to change:
 
-1. Update the types in `libs/core/src/lib/types/` (`GroceryList`, `GroceryItem`, `GroceryCategoryType`)
+1. Update the types in `libs/core/src/lib/types/` (`GroceriesVaultPayload`, `CatalogItem`, `GroceryList`, `ListLine`, `GroceryCategoryType`)
 2. Update `GroceryListSchema` in `libs/web-vault/src/lib/vault/groceriesNormalization.ts`
 3. Add a migration step inside `normalizeGroceries()` for the shape change
 4. Existing vault blobs auto-migrate on next load — `normalizeGroceries()` returns `changed: true` and the hook re-persists the updated blob

--- a/libs/core/src/lib/constants/grocery.ts
+++ b/libs/core/src/lib/constants/grocery.ts
@@ -16,13 +16,15 @@ export const GROCERY_PREDEFINED_CATEGORIES = [
 export type GroceryCategoryType =
   (typeof GROCERY_PREDEFINED_CATEGORIES)[number];
 
-export interface GroceryItem {
+/**
+ * CatalogItem — Durable grocery identity owned by the user.
+ * Lives in the vault catalog; referenced by multiple ListLines.
+ */
+export interface CatalogItem {
   id: string; // UUID v4
   name: string; // Required
-  amount?: string; // Free text, e.g. "2", "500g", "1 dozen"
-  price?: number; // Optional — for budget tracking (in user's local currency)
   category: GroceryCategoryType; // Defaults to 'other'
-  checked: boolean; // Shopping-list checked state
+  price?: number; // Optional default price for budget tracking
   notes?: string; // Optional free text notes
   imageUrl?: string; // Optional external image URL (display only, no uploads)
   links?: string[]; // Optional array of external links
@@ -30,10 +32,53 @@ export interface GroceryItem {
   updatedAt: string; // ISO 8601
 }
 
+/**
+ * ListLine — A grocery list's reference to a CatalogItem for a trip.
+ * Carries trip-local state (checked, quantity/amount).
+ */
+export interface ListLine {
+  id: string; // UUID v4 — unique line ID
+  catalogItemId: string; // Reference to CatalogItem.id
+  checked: boolean; // Checked state for this trip
+  amount?: string; // Trip-specific quantity, e.g. "2", "500g", "1 dozen"
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+
+/**
+ * GroceryList — A named trip-oriented collection of ListLines.
+ */
 export interface GroceryList {
   id: string; // UUID v4
   name: string; // Required, user-defined list name
-  items: GroceryItem[];
+  lines: ListLine[]; // References to catalog items
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
+}
+
+/**
+ * GroceriesVaultPayload — The complete vault payload for groceries.
+ * Separates durable catalog from trip-oriented lists.
+ */
+export interface GroceriesVaultPayload {
+  catalog: CatalogItem[];
+  lists: GroceryList[];
+}
+
+/**
+ * @deprecated Use CatalogItem and ListLine instead.
+ * Kept for backward compatibility during migration.
+ */
+export interface GroceryItem {
+  id: string;
+  name: string;
+  amount?: string;
+  price?: number;
+  category: GroceryCategoryType;
+  checked: boolean;
+  notes?: string;
+  imageUrl?: string;
+  links?: string[];
+  createdAt: string;
+  updatedAt: string;
 }

--- a/libs/vault-core/src/lib/types.ts
+++ b/libs/vault-core/src/lib/types.ts
@@ -1,5 +1,6 @@
 export type VaultRecordType =
   | 'addresses'
+  | 'groceries'
   | 'mobileNumbers'
   | 'subscriptions'
   | 'tasks';

--- a/libs/web-vault/src/lib/vault/groceriesNormalization.spec.ts
+++ b/libs/web-vault/src/lib/vault/groceriesNormalization.spec.ts
@@ -1,4 +1,5 @@
 import { normalizeGroceries } from './groceriesNormalization';
+import type { GroceriesVaultPayload } from '@myorganizer/core';
 
 describe('normalizeGroceries', () => {
   beforeEach(() => {
@@ -11,128 +12,202 @@ describe('normalizeGroceries', () => {
   });
 
   describe('null/undefined input', () => {
-    it('should return empty list for null without marking changed', () => {
-      expect(normalizeGroceries(null)).toEqual({ value: [], changed: false });
+    it('should return empty payload for null without marking changed', () => {
+      const result = normalizeGroceries(null);
+      expect(result).toEqual({
+        value: { catalog: [], lists: [] },
+        changed: false,
+      });
     });
 
-    it('should return empty list for undefined without marking changed', () => {
-      expect(normalizeGroceries(undefined)).toEqual({
-        value: [],
+    it('should return empty payload for undefined without marking changed', () => {
+      const result = normalizeGroceries(undefined);
+      expect(result).toEqual({
+        value: { catalog: [], lists: [] },
         changed: false,
       });
     });
   });
 
-  describe('non-array input', () => {
-    it('should return empty list for non-array and mark changed', () => {
-      expect(normalizeGroceries({})).toEqual({ value: [], changed: true });
-      expect(normalizeGroceries('string')).toEqual({
-        value: [],
+  describe('unrecognized shape input', () => {
+    it('should return empty payload for empty object and mark changed', () => {
+      const result = normalizeGroceries({});
+      expect(result).toEqual({
+        value: { catalog: [], lists: [] },
         changed: true,
       });
-      expect(normalizeGroceries(123)).toEqual({ value: [], changed: true });
+    });
+
+    it('should return empty payload for string and mark changed', () => {
+      const result = normalizeGroceries('string');
+      expect(result).toEqual({
+        value: { catalog: [], lists: [] },
+        changed: true,
+      });
+    });
+
+    it('should return empty payload for number and mark changed', () => {
+      const result = normalizeGroceries(123);
+      expect(result).toEqual({
+        value: { catalog: [], lists: [] },
+        changed: true,
+      });
+    });
+
+    it('should return empty payload for object with wrong keys and mark changed', () => {
+      const result = normalizeGroceries({ wrongKey: 'value' });
+      expect(result).toEqual({
+        value: { catalog: [], lists: [] },
+        changed: true,
+      });
     });
   });
 
-  describe('empty array', () => {
-    it('should return empty array without marking changed', () => {
-      expect(normalizeGroceries([])).toEqual({ value: [], changed: false });
+  describe('new shape: valid catalog and lists', () => {
+    it('should preserve already-normalized payload without marking changed', () => {
+      const input: GroceriesVaultPayload = {
+        catalog: [
+          {
+            id: 'catalog-1',
+            name: 'Milk',
+            category: 'dairy',
+            price: 3.5,
+            notes: 'Whole milk',
+            imageUrl: 'https://example.com/milk.jpg',
+            links: ['https://store.com/milk'],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+        lists: [
+          {
+            id: 'list-1',
+            name: 'Weekly Shopping',
+            lines: [
+              {
+                id: 'line-1',
+                catalogItemId: 'catalog-1',
+                checked: false,
+                amount: '1L',
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+              },
+            ],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+
+      const result = normalizeGroceries(input);
+      expect(result.value).toEqual(input);
+      expect(result.changed).toBe(false);
     });
-  });
 
-  describe('valid GroceryList', () => {
-    it('should preserve exact normalized data without marking changed', () => {
-      const input = [
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Weekly Shopping',
-          items: [
-            {
-              id: '550e8400-e29b-41d4-a716-446655440001',
-              name: 'Milk',
-              amount: '1L',
-              price: 3.5,
-              category: 'dairy',
-              checked: false,
-              notes: 'Whole milk',
-              imageUrl: 'https://example.com/milk.jpg',
-              links: ['https://store.com/milk'],
-              createdAt: '2026-01-01T00:00:00.000Z',
-              updatedAt: '2026-01-01T00:00:00.000Z',
-            },
-          ],
-          createdAt: '2026-01-01T00:00:00.000Z',
-          updatedAt: '2026-01-01T00:00:00.000Z',
-        },
-      ];
+    it('should generate IDs and timestamps for missing fields', () => {
+      const input = {
+        catalog: [{ name: 'Apples' }],
+        lists: [
+          {
+            name: 'Shopping',
+            lines: [{ catalogItemId: 'will-be-dropped' }],
+          },
+        ],
+      };
 
+      const result = normalizeGroceries(input);
+
+      expect(result.value.catalog).toHaveLength(1);
+      const catalogItem = result.value.catalog[0];
+      expect(typeof catalogItem.id).toBe('string');
+      expect(catalogItem.id.length).toBeGreaterThan(0);
+      expect(catalogItem.name).toBe('Apples');
+      expect(catalogItem.category).toBe('other');
+      expect(catalogItem.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(catalogItem.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+
+      expect(result.value.lists).toHaveLength(1);
+      const list = result.value.lists[0];
+      expect(typeof list.id).toBe('string');
+      expect(list.id.length).toBeGreaterThan(0);
+      expect(list.name).toBe('Shopping');
+      expect(list.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(list.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+
+      // Line with invalid catalogItemId should be dropped
+      expect(list.lines).toHaveLength(0);
+
+      expect(result.changed).toBe(true);
+    });
+
+    it('should normalize empty catalog and lists arrays without marking changed', () => {
+      const input = { catalog: [], lists: [] };
       const result = normalizeGroceries(input);
       expect(result.value).toEqual(input);
       expect(result.changed).toBe(false);
     });
   });
 
-  describe('item missing required fields', () => {
-    it('should generate id for item without id', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Weekly Shopping',
-          items: [{ name: 'Apples' }],
-        },
-      ]);
+  describe('new shape: catalog item validation', () => {
+    it('should drop catalog item without name', () => {
+      const input = {
+        catalog: [{ id: 'catalog-1' }, { id: 'catalog-2', name: 'Valid Item' }],
+        lists: [],
+      };
 
-      expect(res.value).toHaveLength(1);
-      expect(res.value[0].items).toHaveLength(1);
-      expect(typeof res.value[0].items[0].id).toBe('string');
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog).toHaveLength(1);
+      expect(result.value.catalog[0].name).toBe('Valid Item');
+      expect(result.changed).toBe(true);
     });
 
-    it('should reject item without name and drop it', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Weekly Shopping',
-          items: [{ id: '550e8400-e29b-41d4-a716-446655440001' }],
-        },
-      ]);
+    it('should drop catalog item with empty name', () => {
+      const input = {
+        catalog: [{ name: '   ' }, { name: 'Valid Item' }],
+        lists: [],
+      };
 
-      expect(res.value).toHaveLength(1);
-      expect(res.value[0].items).toHaveLength(0);
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog).toHaveLength(1);
+      expect(result.value.catalog[0].name).toBe('Valid Item');
+      expect(result.changed).toBe(true);
     });
-  });
 
-  describe('category validation and coercion', () => {
+    it('should trim whitespace from catalog item names', () => {
+      const input = {
+        catalog: [{ name: '  Milk  ' }],
+        lists: [],
+      };
+
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog[0].name).toBe('Milk');
+      expect(result.changed).toBe(true);
+    });
+
     it('should coerce invalid category to "other"', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              category: 'invalid_category',
-            },
-          ],
-        },
-      ]);
+      const input = {
+        catalog: [
+          { name: 'Item1', category: 'invalid-category' },
+          { name: 'Item2', category: 'dairy' },
+        ],
+        lists: [],
+      };
 
-      expect(res.value[0].items[0].category).toBe('other');
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog[0].category).toBe('other');
+      expect(result.value.catalog[1].category).toBe('dairy');
+      expect(result.changed).toBe(true);
     });
 
-    it('should use default category "other" when not specified', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [{ name: 'Item' }],
-        },
-      ]);
+    it('should default missing category to "other"', () => {
+      const input = {
+        catalog: [{ name: 'Item' }],
+        lists: [],
+      };
 
-      expect(res.value[0].items[0].category).toBe('other');
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog[0].category).toBe('other');
+      expect(result.changed).toBe(true);
     });
 
     it('should accept all valid categories', () => {
@@ -151,357 +226,572 @@ describe('normalizeGroceries', () => {
         'other',
       ];
 
-      for (const category of categories) {
-        const res = normalizeGroceries([
+      const input = {
+        catalog: categories.map((cat) => ({
+          name: `Item-${cat}`,
+          category: cat,
+        })),
+        lists: [],
+      };
+
+      const result = normalizeGroceries(input);
+      result.value.catalog.forEach((item, i) => {
+        expect(item.category).toBe(categories[i]);
+      });
+    });
+
+    it('should remove invalid imageUrl', () => {
+      const input = {
+        catalog: [
+          { name: 'Item1', imageUrl: 'not-a-url' },
+          { name: 'Item2', imageUrl: '' },
+          { name: 'Item3', imageUrl: 'https://example.com/valid.jpg' },
+        ],
+        lists: [],
+      };
+
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog[0].imageUrl).toBeUndefined();
+      expect(result.value.catalog[1].imageUrl).toBeUndefined();
+      expect(result.value.catalog[2].imageUrl).toBe(
+        'https://example.com/valid.jpg',
+      );
+      expect(result.changed).toBe(true);
+    });
+
+    it('should remove links array if any URL is invalid', () => {
+      const input = {
+        catalog: [
+          { name: 'Item1', links: ['https://valid.com', 'not-a-url'] },
           {
-            id: '550e8400-e29b-41d4-a716-446655440000',
-            name: 'Shopping',
-            items: [{ name: 'Item', category }],
+            name: 'Item2',
+            links: ['https://valid1.com', 'https://valid2.com'],
           },
-        ]);
+        ],
+        lists: [],
+      };
 
-        expect(res.value[0].items[0].category).toBe(category);
-      }
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog[0].links).toBeUndefined();
+      expect(result.value.catalog[1].links).toEqual([
+        'https://valid1.com',
+        'https://valid2.com',
+      ]);
+      expect(result.changed).toBe(true);
+    });
+
+    it('should remove negative price', () => {
+      const input = {
+        catalog: [
+          { name: 'Item1', price: -5 },
+          { name: 'Item2', price: 0 },
+          { name: 'Item3', price: 12.99 },
+        ],
+        lists: [],
+      };
+
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog[0].price).toBeUndefined();
+      expect(result.value.catalog[1].price).toBe(0);
+      expect(result.value.catalog[2].price).toBe(12.99);
+      expect(result.changed).toBe(true);
+    });
+
+    it('should preserve optional notes field', () => {
+      const input = {
+        catalog: [{ name: 'Item1', notes: 'Some notes' }, { name: 'Item2' }],
+        lists: [],
+      };
+
+      const result = normalizeGroceries(input);
+      expect(result.value.catalog[0].notes).toBe('Some notes');
+      expect(result.value.catalog[1].notes).toBeUndefined();
     });
   });
 
-  describe('checked field defaults', () => {
-    it('should default checked to false when not specified', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [{ name: 'Item' }],
-        },
-      ]);
+  describe('new shape: list line validation', () => {
+    it('should drop list lines with missing catalogItemId', () => {
+      const input = {
+        catalog: [{ id: 'catalog-1', name: 'Item' }],
+        lists: [
+          {
+            name: 'List',
+            lines: [
+              { checked: false },
+              { catalogItemId: 'catalog-1', checked: true },
+            ],
+          },
+        ],
+      };
 
-      expect(res.value[0].items[0].checked).toBe(false);
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(input);
+      expect(result.value.lists[0].lines).toHaveLength(1);
+      expect(result.value.lists[0].lines[0].catalogItemId).toBe('catalog-1');
+      expect(result.changed).toBe(true);
     });
 
-    it('should preserve checked value when specified', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [{ name: 'Item', checked: true }],
-        },
-      ]);
+    it('should drop list lines with invalid catalogItemId reference', () => {
+      const input = {
+        catalog: [{ id: 'catalog-1', name: 'Item' }],
+        lists: [
+          {
+            name: 'List',
+            lines: [
+              { catalogItemId: 'catalog-1', checked: false },
+              { catalogItemId: 'non-existent', checked: false },
+              { catalogItemId: 'catalog-1', checked: true },
+            ],
+          },
+        ],
+      };
 
-      expect(res.value[0].items[0].checked).toBe(true);
-      expect(res.changed).toBe(true);
-    });
-  });
-
-  describe('optional field handling', () => {
-    it('should remove invalid imageUrl (non-URL string)', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              imageUrl: 'not-a-url',
-            },
-          ],
-        },
-      ]);
-
-      expect(res.value[0].items[0].imageUrl).toBeUndefined();
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(input);
+      expect(result.value.lists[0].lines).toHaveLength(2);
+      expect(result.value.lists[0].lines[0].catalogItemId).toBe('catalog-1');
+      expect(result.value.lists[0].lines[1].catalogItemId).toBe('catalog-1');
+      expect(result.changed).toBe(true);
     });
 
-    it('should convert empty string imageUrl to undefined', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              imageUrl: '',
-            },
-          ],
-        },
-      ]);
+    it('should default checked to false', () => {
+      const input = {
+        catalog: [{ id: 'catalog-1', name: 'Item' }],
+        lists: [
+          {
+            name: 'List',
+            lines: [
+              { catalogItemId: 'catalog-1' },
+              { catalogItemId: 'catalog-1', checked: true },
+            ],
+          },
+        ],
+      };
 
-      expect(res.value[0].items[0].imageUrl).toBeUndefined();
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(input);
+      expect(result.value.lists[0].lines[0].checked).toBe(false);
+      expect(result.value.lists[0].lines[1].checked).toBe(true);
     });
 
-    it('should preserve valid imageUrl', () => {
-      const url = 'https://example.com/image.jpg';
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              imageUrl: url,
-            },
-          ],
-        },
-      ]);
+    it('should preserve optional amount field', () => {
+      const input = {
+        catalog: [{ id: 'catalog-1', name: 'Item' }],
+        lists: [
+          {
+            name: 'List',
+            lines: [
+              { catalogItemId: 'catalog-1', amount: '2 kg' },
+              { catalogItemId: 'catalog-1' },
+            ],
+          },
+        ],
+      };
 
-      expect(res.value[0].items[0].imageUrl).toBe(url);
+      const result = normalizeGroceries(input);
+      expect(result.value.lists[0].lines[0].amount).toBe('2 kg');
+      expect(result.value.lists[0].lines[1].amount).toBeUndefined();
     });
 
-    it('should validate links as URL arrays', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              links: ['https://example.com', 'not-a-url'],
-            },
-          ],
-        },
-      ]);
+    it('should generate IDs and timestamps for list lines', () => {
+      const input = {
+        catalog: [{ id: 'catalog-1', name: 'Item' }],
+        lists: [
+          {
+            name: 'List',
+            lines: [{ catalogItemId: 'catalog-1' }],
+          },
+        ],
+      };
 
-      // Should reject the entire links array if any URL is invalid
-      expect(res.value[0].items[0].links).toBeUndefined();
-      expect(res.changed).toBe(true);
-    });
-
-    it('should preserve valid links array', () => {
-      const links = ['https://example.com', 'https://store.com'];
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              links,
-            },
-          ],
-        },
-      ]);
-
-      expect(res.value[0].items[0].links).toEqual(links);
+      const result = normalizeGroceries(input);
+      const line = result.value.lists[0].lines[0];
+      expect(typeof line.id).toBe('string');
+      expect(line.id.length).toBeGreaterThan(0);
+      expect(line.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(line.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(result.changed).toBe(true);
     });
   });
 
-  describe('price validation', () => {
-    it('should reject negative price', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              price: -5,
-            },
-          ],
-        },
-      ]);
+  describe('new shape: grocery list validation', () => {
+    it('should drop list without name', () => {
+      const input = {
+        catalog: [{ id: 'catalog-1', name: 'Item' }],
+        lists: [{ lines: [] }, { name: 'Valid List', lines: [] }],
+      };
 
-      expect(res.value[0].items[0].price).toBeUndefined();
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(input);
+      expect(result.value.lists).toHaveLength(1);
+      expect(result.value.lists[0].name).toBe('Valid List');
+      expect(result.changed).toBe(true);
     });
 
-    it('should accept zero price', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              price: 0,
-            },
-          ],
-        },
-      ]);
+    it('should drop list with empty name', () => {
+      const input = {
+        catalog: [],
+        lists: [
+          { name: '   ', lines: [] },
+          { name: 'Valid List', lines: [] },
+        ],
+      };
 
-      expect(res.value[0].items[0].price).toBe(0);
+      const result = normalizeGroceries(input);
+      expect(result.value.lists).toHaveLength(1);
+      expect(result.value.lists[0].name).toBe('Valid List');
+      expect(result.changed).toBe(true);
     });
 
-    it('should accept positive price', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              price: 12.99,
-            },
-          ],
-        },
-      ]);
+    it('should trim whitespace from list names', () => {
+      const input = {
+        catalog: [],
+        lists: [{ name: '  Shopping List  ', lines: [] }],
+      };
 
-      expect(res.value[0].items[0].price).toBe(12.99);
+      const result = normalizeGroceries(input);
+      expect(result.value.lists[0].name).toBe('Shopping List');
+      expect(result.changed).toBe(true);
+    });
+
+    it('should handle lists with no lines', () => {
+      const input = {
+        catalog: [{ id: 'catalog-1', name: 'Item' }],
+        lists: [{ name: 'Empty List' }],
+      };
+
+      const result = normalizeGroceries(input);
+      expect(result.value.lists).toHaveLength(1);
+      expect(result.value.lists[0].lines).toEqual([]);
     });
   });
 
-  describe('timestamps', () => {
-    it('should generate ISO 8601 timestamps for missing fields', () => {
-      const res = normalizeGroceries([
+  describe('legacy migration: array of lists with embedded items', () => {
+    it('should migrate legacy array to catalog+lists structure', () => {
+      const legacyInput = [
         {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [{ name: 'Item' }],
-        },
-      ]);
-
-      expect(res.value[0].items[0].createdAt).toBe('2026-01-01T00:00:00.000Z');
-      expect(res.value[0].items[0].updatedAt).toBe('2026-01-01T00:00:00.000Z');
-      expect(res.changed).toBe(true);
-    });
-
-    it('should preserve valid ISO 8601 timestamps', () => {
-      const timestamp = '2025-12-31T12:30:45.000Z';
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          name: 'Shopping',
-          items: [
-            {
-              name: 'Item',
-              createdAt: timestamp,
-              updatedAt: timestamp,
-            },
-          ],
-        },
-      ]);
-
-      expect(res.value[0].items[0].createdAt).toBe(timestamp);
-      expect(res.value[0].items[0].updatedAt).toBe(timestamp);
-    });
-  });
-
-  describe('multiple items and lists', () => {
-    it('should handle multiple lists with multiple items', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
+          id: 'list-1',
           name: 'Weekly Shopping',
           items: [
-            { name: 'Milk', category: 'dairy' },
-            { name: 'Bread', category: 'bakery' },
+            {
+              id: 'item-1',
+              name: 'Milk',
+              amount: '1L',
+              price: 3.5,
+              category: 'dairy',
+              checked: false,
+              notes: 'Whole milk',
+              imageUrl: 'https://example.com/milk.jpg',
+              links: ['https://store.com/milk'],
+              createdAt: '2025-12-01T00:00:00.000Z',
+              updatedAt: '2025-12-01T00:00:00.000Z',
+            },
+          ],
+          createdAt: '2025-12-01T00:00:00.000Z',
+          updatedAt: '2025-12-01T00:00:00.000Z',
+        },
+      ];
+
+      const result = normalizeGroceries(legacyInput);
+
+      // Should have catalog entry
+      expect(result.value.catalog).toHaveLength(1);
+      const catalogItem = result.value.catalog[0];
+      expect(catalogItem.name).toBe('Milk');
+      expect(catalogItem.category).toBe('dairy');
+      expect(catalogItem.price).toBe(3.5);
+      expect(catalogItem.notes).toBe('Whole milk');
+      expect(catalogItem.imageUrl).toBe('https://example.com/milk.jpg');
+      expect(catalogItem.links).toEqual(['https://store.com/milk']);
+      expect(catalogItem.createdAt).toBe('2025-12-01T00:00:00.000Z');
+      expect(catalogItem.updatedAt).toBe('2025-12-01T00:00:00.000Z');
+
+      // Should have list with line referencing catalog
+      expect(result.value.lists).toHaveLength(1);
+      const list = result.value.lists[0];
+      expect(list.id).toBe('list-1');
+      expect(list.name).toBe('Weekly Shopping');
+      expect(list.lines).toHaveLength(1);
+
+      const line = list.lines[0];
+      expect(line.catalogItemId).toBe(catalogItem.id);
+      expect(line.checked).toBe(false);
+      expect(line.amount).toBe('1L');
+      expect(line.createdAt).toBe('2025-12-01T00:00:00.000Z');
+      expect(line.updatedAt).toBe('2025-12-01T00:00:00.000Z');
+
+      expect(result.changed).toBe(true);
+    });
+
+    it('should deduplicate items across multiple lists by item.id', () => {
+      const legacyInput = [
+        {
+          name: 'List 1',
+          items: [
+            { id: 'item-1', name: 'Milk', category: 'dairy', checked: false },
           ],
         },
         {
-          id: '550e8400-e29b-41d4-a716-446655440001',
-          name: 'Dinner Planning',
-          items: [{ name: 'Chicken', category: 'meat' }],
+          name: 'List 2',
+          items: [
+            { id: 'item-1', name: 'Milk', category: 'dairy', checked: true },
+            { id: 'item-2', name: 'Bread', category: 'bakery', checked: false },
+          ],
         },
-      ]);
+      ];
 
-      expect(res.value).toHaveLength(2);
-      expect(res.value[0].items).toHaveLength(2);
-      expect(res.value[1].items).toHaveLength(1);
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(legacyInput);
+
+      // Should have 2 catalog items (item-1 and item-2)
+      expect(result.value.catalog).toHaveLength(2);
+      const milkCatalogId = result.value.catalog.find(
+        (c) => c.name === 'Milk',
+      )?.id;
+      const breadCatalogId = result.value.catalog.find(
+        (c) => c.name === 'Bread',
+      )?.id;
+      expect(milkCatalogId).toBeDefined();
+      expect(breadCatalogId).toBeDefined();
+
+      // List 1 should have 1 line referencing milk
+      expect(result.value.lists[0].lines).toHaveLength(1);
+      expect(result.value.lists[0].lines[0].catalogItemId).toBe(milkCatalogId);
+      expect(result.value.lists[0].lines[0].checked).toBe(false);
+
+      // List 2 should have 2 lines referencing milk and bread
+      expect(result.value.lists[1].lines).toHaveLength(2);
+      expect(result.value.lists[1].lines[0].catalogItemId).toBe(milkCatalogId);
+      expect(result.value.lists[1].lines[0].checked).toBe(true);
+      expect(result.value.lists[1].lines[1].catalogItemId).toBe(breadCatalogId);
+
+      expect(result.changed).toBe(true);
     });
-  });
 
-  describe('item-by-item recovery', () => {
-    it('should drop invalid lists and keep valid ones', () => {
-      const res = normalizeGroceries([
-        null,
+    it('should drop legacy items without name during migration', () => {
+      const legacyInput = [
         {
-          id: '550e8400-e29b-41d4-a716-446655440000',
           name: 'Shopping',
+          items: [
+            { id: 'item-1' }, // no name
+            { id: 'item-2', name: 'Valid Item' },
+          ],
+        },
+      ];
+
+      const result = normalizeGroceries(legacyInput);
+
+      expect(result.value.catalog).toHaveLength(1);
+      expect(result.value.catalog[0].name).toBe('Valid Item');
+      expect(result.value.lists[0].lines).toHaveLength(1);
+      expect(result.changed).toBe(true);
+    });
+
+    it('should drop legacy lists without name during migration', () => {
+      const legacyInput = [
+        {
           items: [{ name: 'Item' }],
         },
-        'invalid',
         {
-          id: '550e8400-e29b-41d4-a716-446655440001',
-          name: 'Another List',
+          name: 'Valid List',
           items: [{ name: 'Another Item' }],
         },
-      ]);
+      ];
 
-      expect(res.value).toHaveLength(2);
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(legacyInput);
+
+      expect(result.value.lists).toHaveLength(1);
+      expect(result.value.lists[0].name).toBe('Valid List');
+      expect(result.changed).toBe(true);
     });
 
-    it('should drop list without name', () => {
-      const res = normalizeGroceries([
+    it('should apply all validation rules during legacy migration', () => {
+      const legacyInput = [
         {
-          id: '550e8400-e29b-41d4-a716-446655440000',
-          items: [{ name: 'Item' }],
-        },
-      ]);
-
-      expect(res.value).toHaveLength(0);
-      expect(res.changed).toBe(true);
-    });
-  });
-
-  describe('unknown fields', () => {
-    it('should strip unknown extra fields from items and mark changed', () => {
-      const res = normalizeGroceries([
-        {
-          id: '550e8400-e29b-41d4-a716-446655440000',
           name: 'Shopping',
           items: [
             {
-              name: 'Item',
-              unknownField: 'should be removed',
-              anotherUnknown: 123,
+              id: 'item-1',
+              name: 'Item1',
+              category: 'invalid',
+              price: -5,
+              imageUrl: 'not-a-url',
+              links: ['https://valid.com', 'invalid'],
+              checked: false,
             },
           ],
         },
-      ]);
+      ];
 
-      const item = res.value[0].items[0];
-      expect('unknownField' in item).toBe(false);
-      expect('anotherUnknown' in item).toBe(false);
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(legacyInput);
+
+      const catalogItem = result.value.catalog[0];
+      expect(catalogItem.category).toBe('other');
+      expect(catalogItem.price).toBeUndefined();
+      expect(catalogItem.imageUrl).toBeUndefined();
+      expect(catalogItem.links).toBeUndefined();
+      expect(result.changed).toBe(true);
     });
 
-    it('should strip unknown fields from lists and mark changed', () => {
-      const res = normalizeGroceries([
+    it('should generate timestamps for legacy items and lists missing them', () => {
+      const legacyInput = [
         {
-          id: '550e8400-e29b-41d4-a716-446655440000',
           name: 'Shopping',
-          items: [],
-          unknownListField: 'should be removed',
+          items: [{ name: 'Item' }],
         },
-      ]);
+      ];
 
-      const list = res.value[0];
-      expect('unknownListField' in list).toBe(false);
-      expect(res.changed).toBe(true);
+      const result = normalizeGroceries(legacyInput);
+
+      const catalogItem = result.value.catalog[0];
+      expect(catalogItem.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(catalogItem.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+
+      const list = result.value.lists[0];
+      expect(list.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(list.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+
+      const line = list.lines[0];
+      expect(line.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(line.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+
+      expect(result.changed).toBe(true);
+    });
+
+    it('should migrate empty legacy array to empty payload', () => {
+      const result = normalizeGroceries([]);
+      expect(result.value).toEqual({ catalog: [], lists: [] });
+      expect(result.changed).toBe(true);
     });
   });
 
-  describe('complex scenarios', () => {
-    it('should normalize all defaults for minimal input', () => {
-      const res = normalizeGroceries([
+  describe('changed flag accuracy', () => {
+    it('should mark changed: false for null/undefined', () => {
+      expect(normalizeGroceries(null).changed).toBe(false);
+      expect(normalizeGroceries(undefined).changed).toBe(false);
+    });
+
+    it('should mark changed: true for unrecognized shapes', () => {
+      expect(normalizeGroceries({}).changed).toBe(true);
+      expect(normalizeGroceries('string').changed).toBe(true);
+      expect(normalizeGroceries(123).changed).toBe(true);
+    });
+
+    it('should mark changed: false for already-normalized new shape', () => {
+      const input: GroceriesVaultPayload = {
+        catalog: [
+          {
+            id: 'catalog-1',
+            name: 'Item',
+            category: 'other',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+        lists: [
+          {
+            id: 'list-1',
+            name: 'List',
+            lines: [],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      };
+      expect(normalizeGroceries(input).changed).toBe(false);
+    });
+
+    it('should mark changed: true for new shape with missing IDs', () => {
+      const input = {
+        catalog: [{ name: 'Item' }],
+        lists: [],
+      };
+      expect(normalizeGroceries(input).changed).toBe(true);
+    });
+
+    it('should mark changed: true for new shape with invalid entries dropped', () => {
+      const input = {
+        catalog: [{ name: 'Valid' }, { id: 'no-name' }],
+        lists: [],
+      };
+      expect(normalizeGroceries(input).changed).toBe(true);
+    });
+
+    it('should mark changed: true for new shape with coerced values', () => {
+      const input = {
+        catalog: [{ name: 'Item', category: 'invalid' }],
+        lists: [],
+      };
+      expect(normalizeGroceries(input).changed).toBe(true);
+    });
+
+    it('should mark changed: true for legacy migration', () => {
+      const input = [
         {
-          name: 'Minimal List',
-          items: [{ name: 'Apples' }],
+          name: 'List',
+          items: [{ name: 'Item', category: 'dairy', checked: false }],
         },
-      ]);
+      ];
+      expect(normalizeGroceries(input).changed).toBe(true);
+    });
+  });
 
-      expect(res.value).toHaveLength(1);
-      const list = res.value[0];
-      expect(typeof list.id).toBe('string');
-      expect(list.name).toBe('Minimal List');
-      expect(list.items).toHaveLength(1);
-      expect(typeof list.createdAt).toBe('string');
-      expect(typeof list.updatedAt).toBe('string');
+  describe('complex multi-list scenarios', () => {
+    it('should handle multiple catalog items and lists with cross-references', () => {
+      const input = {
+        catalog: [
+          { id: 'cat-1', name: 'Milk', category: 'dairy' },
+          { id: 'cat-2', name: 'Bread', category: 'bakery' },
+          { id: 'cat-3', name: 'Apples', category: 'produce' },
+        ],
+        lists: [
+          {
+            name: 'Weekly',
+            lines: [
+              { catalogItemId: 'cat-1', checked: false },
+              { catalogItemId: 'cat-2', checked: true },
+            ],
+          },
+          {
+            name: 'Daily',
+            lines: [
+              { catalogItemId: 'cat-1', checked: false, amount: '2L' },
+              { catalogItemId: 'cat-3', checked: false, amount: '1 kg' },
+            ],
+          },
+        ],
+      };
 
-      const item = list.items[0];
-      expect(typeof item.id).toBe('string');
-      expect(item.name).toBe('Apples');
-      expect(item.category).toBe('other');
-      expect(item.checked).toBe(false);
-      expect(item.amount).toBeUndefined();
-      expect(item.price).toBeUndefined();
-      expect(item.notes).toBeUndefined();
-      expect(item.imageUrl).toBeUndefined();
-      expect(item.links).toBeUndefined();
+      const result = normalizeGroceries(input);
 
-      expect(res.changed).toBe(true);
+      expect(result.value.catalog).toHaveLength(3);
+      expect(result.value.lists).toHaveLength(2);
+      expect(result.value.lists[0].lines).toHaveLength(2);
+      expect(result.value.lists[1].lines).toHaveLength(2);
+
+      // Verify catalog item can be referenced by multiple lists
+      expect(result.value.lists[0].lines[0].catalogItemId).toBe('cat-1');
+      expect(result.value.lists[1].lines[0].catalogItemId).toBe('cat-1');
+    });
+
+    it('should filter out lines referencing deleted catalog items', () => {
+      const input = {
+        catalog: [
+          { id: 'cat-1', name: 'Milk' },
+          { id: 'cat-2' }, // no name, will be dropped
+        ],
+        lists: [
+          {
+            name: 'Shopping',
+            lines: [
+              { catalogItemId: 'cat-1', checked: false },
+              { catalogItemId: 'cat-2', checked: false }, // ref to dropped item
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeGroceries(input);
+
+      expect(result.value.catalog).toHaveLength(1);
+      expect(result.value.lists[0].lines).toHaveLength(1);
+      expect(result.value.lists[0].lines[0].catalogItemId).toBe('cat-1');
+      expect(result.changed).toBe(true);
     });
   });
 });

--- a/libs/web-vault/src/lib/vault/groceriesNormalization.ts
+++ b/libs/web-vault/src/lib/vault/groceriesNormalization.ts
@@ -1,4 +1,11 @@
-import { randomId, type GroceryList } from '@myorganizer/core';
+import {
+  randomId,
+  type GroceriesVaultPayload,
+  type CatalogItem,
+  type ListLine,
+  type GroceryList,
+  type GroceryItem,
+} from '@myorganizer/core';
 import { z } from 'zod';
 
 const VALID_CATEGORIES = [
@@ -35,9 +42,113 @@ function isValidUrl(url: unknown): boolean {
   }
 }
 
-// --- Zod schemas (runtime validation + coercion) ---
+// --- Zod schemas for new shape ---
 
-const GroceryItemSchema = z
+const CatalogItemSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    category: z.string().optional(),
+    price: z.number().optional(),
+    notes: z.string().optional(),
+    imageUrl: z.string().optional(),
+    links: z.array(z.string()).optional(),
+    createdAt: z.string().optional(),
+    updatedAt: z.string().optional(),
+  })
+  .transform((data): CatalogItem | null => {
+    const name = typeof data.name === 'string' ? data.name.trim() : '';
+    if (!name) return null;
+
+    const imageUrl = isValidUrl(data.imageUrl) ? data.imageUrl : undefined;
+    const links =
+      Array.isArray(data.links) && data.links.every(isValidUrl)
+        ? data.links
+        : undefined;
+
+    return {
+      id: data.id || randomId(),
+      name,
+      category: normalizeCategory(data.category),
+      price:
+        typeof data.price === 'number' && data.price >= 0
+          ? data.price
+          : undefined,
+      notes: data.notes,
+      imageUrl,
+      links,
+      createdAt: data.createdAt || new Date().toISOString(),
+      updatedAt: data.updatedAt || new Date().toISOString(),
+    };
+  })
+  .refine((item) => item !== null, {
+    message: 'CatalogItem must have a non-empty name',
+  });
+
+const ListLineSchema = z
+  .object({
+    id: z.string().optional(),
+    catalogItemId: z.string().optional(),
+    checked: z.boolean().optional(),
+    amount: z.string().optional(),
+    createdAt: z.string().optional(),
+    updatedAt: z.string().optional(),
+  })
+  .transform((data): ListLine | null => {
+    if (typeof data.catalogItemId !== 'string' || !data.catalogItemId) {
+      return null;
+    }
+
+    return {
+      id: data.id || randomId(),
+      catalogItemId: data.catalogItemId,
+      checked: data.checked === true,
+      amount: data.amount,
+      createdAt: data.createdAt || new Date().toISOString(),
+      updatedAt: data.updatedAt || new Date().toISOString(),
+    };
+  })
+  .refine((line) => line !== null, {
+    message: 'ListLine must have a valid catalogItemId',
+  });
+
+const GroceryListSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    lines: z.array(z.any()).optional(),
+    createdAt: z.string().optional(),
+    updatedAt: z.string().optional(),
+  })
+  .transform((data): GroceryList | null => {
+    const name = typeof data.name === 'string' ? data.name.trim() : '';
+    if (!name) return null;
+
+    const lines: ListLine[] = [];
+    if (Array.isArray(data.lines)) {
+      for (const lineRaw of data.lines) {
+        const result = ListLineSchema.safeParse(lineRaw);
+        if (result.success && result.data !== null) {
+          lines.push(result.data);
+        }
+      }
+    }
+
+    return {
+      id: data.id || randomId(),
+      name,
+      lines,
+      createdAt: data.createdAt || new Date().toISOString(),
+      updatedAt: data.updatedAt || new Date().toISOString(),
+    };
+  })
+  .refine((list) => list !== null, {
+    message: 'GroceryList must have a non-empty name',
+  });
+
+// --- Legacy schema for migration ---
+
+const LegacyGroceryItemSchema = z
   .object({
     id: z.string().optional(),
     name: z.string().optional(),
@@ -51,13 +162,11 @@ const GroceryItemSchema = z
     createdAt: z.string().optional(),
     updatedAt: z.string().optional(),
   })
-  .transform((data): any => {
-    // Item must have a non-empty name
+  .transform((data): GroceryItem | null => {
     const name = typeof data.name === 'string' ? data.name.trim() : '';
-    if (!name) return null; // Signal to filter out
+    if (!name) return null;
 
     const imageUrl = isValidUrl(data.imageUrl) ? data.imageUrl : undefined;
-
     const links =
       Array.isArray(data.links) && data.links.every(isValidUrl)
         ? data.links
@@ -79,74 +188,152 @@ const GroceryItemSchema = z
       createdAt: data.createdAt || new Date().toISOString(),
       updatedAt: data.updatedAt || new Date().toISOString(),
     };
-  })
-  .refine((item) => item !== null, {
-    message: 'Item must have a non-empty name',
-  });
-
-const GroceryListSchema = z
-  .object({
-    id: z.string().optional(),
-    name: z.string().optional(),
-    items: z.array(z.any()).optional(),
-    createdAt: z.string().optional(),
-    updatedAt: z.string().optional(),
-  })
-  .transform((data) => {
-    // List must have a non-empty name
-    const name = typeof data.name === 'string' ? data.name.trim() : '';
-    if (!name) return null; // Signal to filter out
-
-    // Normalize items individually, dropping invalid ones
-    const items: any[] = [];
-    if (Array.isArray(data.items)) {
-      for (const itemRaw of data.items) {
-        const result = GroceryItemSchema.safeParse(itemRaw);
-        if (result.success && result.data !== null) {
-          items.push(result.data);
-        }
-      }
-    }
-
-    return {
-      id: data.id || randomId(),
-      name,
-      items,
-      createdAt: data.createdAt || new Date().toISOString(),
-      updatedAt: data.updatedAt || new Date().toISOString(),
-    };
-  })
-  .refine((list) => list !== null, {
-    message: 'List must have a non-empty name',
   });
 
 // --- Normalization function ---
 
 export interface NormalizeGroceriesResult {
-  value: GroceryList[];
-  changed: boolean; // true if the blob was migrated/repaired and must be re-saved
+  value: GroceriesVaultPayload;
+  changed: boolean;
+}
+
+function migrateLegacyToNewShape(legacyLists: any[]): {
+  catalog: CatalogItem[];
+  lists: GroceryList[];
+} {
+  const catalog: CatalogItem[] = [];
+  const lists: GroceryList[] = [];
+  const catalogMap = new Map<string, string>(); // item.id -> catalogItem.id
+
+  for (const legacyList of legacyLists) {
+    const listName =
+      typeof legacyList.name === 'string' ? legacyList.name.trim() : '';
+    if (!listName) continue;
+
+    const lines: ListLine[] = [];
+
+    if (Array.isArray(legacyList.items)) {
+      for (const itemRaw of legacyList.items) {
+        const result = LegacyGroceryItemSchema.safeParse(itemRaw);
+        if (!result.success || result.data === null) continue;
+
+        const item = result.data;
+
+        // Check if this item already exists in catalog by ID
+        let catalogItemId = catalogMap.get(item.id);
+
+        if (!catalogItemId) {
+          // Create new catalog item
+          catalogItemId = randomId();
+          catalogMap.set(item.id, catalogItemId);
+
+          catalog.push({
+            id: catalogItemId,
+            name: item.name,
+            category: item.category,
+            price: item.price,
+            notes: item.notes,
+            imageUrl: item.imageUrl,
+            links: item.links,
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt,
+          });
+        }
+
+        // Create list line referencing catalog item
+        lines.push({
+          id: randomId(),
+          catalogItemId,
+          checked: item.checked,
+          amount: item.amount,
+          createdAt: item.createdAt,
+          updatedAt: item.updatedAt,
+        });
+      }
+    }
+
+    lists.push({
+      id: legacyList.id || randomId(),
+      name: listName,
+      lines,
+      createdAt: legacyList.createdAt || new Date().toISOString(),
+      updatedAt: legacyList.updatedAt || new Date().toISOString(),
+    });
+  }
+
+  return { catalog, lists };
 }
 
 export function normalizeGroceries(raw: unknown): NormalizeGroceriesResult {
-  if (!Array.isArray(raw)) {
-    // Unrecognized shape — start fresh
-    return { value: [], changed: raw != null };
+  // Handle null/undefined — return fresh empty payload
+  if (raw == null) {
+    return {
+      value: { catalog: [], lists: [] },
+      changed: false,
+    };
   }
 
-  // Normalize each list, dropping invalid ones
-  const normalized: GroceryList[] = [];
+  // Check if new shape: { catalog: [...], lists: [...] }
+  if (
+    typeof raw === 'object' &&
+    !Array.isArray(raw) &&
+    'catalog' in raw &&
+    'lists' in raw
+  ) {
+    const payload = raw as any;
 
-  for (const entry of raw) {
-    const result = GroceryListSchema.safeParse(entry);
-    if (result.success && result.data !== null) {
-      normalized.push(result.data as GroceryList);
+    // Normalize catalog
+    const catalog: CatalogItem[] = [];
+    if (Array.isArray(payload.catalog)) {
+      for (const itemRaw of payload.catalog) {
+        const result = CatalogItemSchema.safeParse(itemRaw);
+        if (result.success && result.data !== null) {
+          catalog.push(result.data);
+        }
+      }
     }
+
+    // Build valid catalog ID set for reference validation
+    const validCatalogIds = new Set(catalog.map((item) => item.id));
+
+    // Normalize lists
+    const lists: GroceryList[] = [];
+    if (Array.isArray(payload.lists)) {
+      for (const listRaw of payload.lists) {
+        const result = GroceryListSchema.safeParse(listRaw);
+        if (result.success && result.data !== null) {
+          // Filter out lines with invalid catalog references
+          const validLines = result.data.lines.filter((line) =>
+            validCatalogIds.has(line.catalogItemId),
+          );
+          lists.push({
+            ...result.data,
+            lines: validLines,
+          });
+        }
+      }
+    }
+
+    const changed =
+      catalog.length !== (payload.catalog?.length || 0) ||
+      lists.length !== (payload.lists?.length || 0) ||
+      JSON.stringify({ catalog, lists }) !== JSON.stringify(raw);
+
+    return { value: { catalog, lists }, changed };
   }
 
-  // Check if we had to make changes (coercion, defaults, or dropping invalid entries)
-  const changed =
-    normalized.length !== raw.length ||
-    JSON.stringify(normalized) !== JSON.stringify(raw);
+  // Legacy shape: array of lists with embedded items
+  if (Array.isArray(raw)) {
+    const { catalog, lists } = migrateLegacyToNewShape(raw);
+    return {
+      value: { catalog, lists },
+      changed: true,
+    };
+  }
 
-  return { value: normalized, changed };
+  // Unrecognized shape — start fresh
+  return {
+    value: { catalog: [], lists: [] },
+    changed: true,
+  };
 }

--- a/libs/web-vault/src/lib/vault/groceriesNormalization.ts
+++ b/libs/web-vault/src/lib/vault/groceriesNormalization.ts
@@ -5,6 +5,7 @@ import {
   type ListLine,
   type GroceryList,
   type GroceryItem,
+  type GroceryCategoryType,
 } from '@myorganizer/core';
 import { z } from 'zod';
 
@@ -24,9 +25,12 @@ const VALID_CATEGORIES = [
 ] as const;
 
 // Helper to validate and coerce category
-function normalizeCategory(value: unknown): string {
-  if (typeof value === 'string' && VALID_CATEGORIES.includes(value as any)) {
-    return value;
+function normalizeCategory(value: unknown): GroceryCategoryType {
+  if (
+    typeof value === 'string' &&
+    (VALID_CATEGORIES as readonly string[]).includes(value)
+  ) {
+    return value as GroceryCategoryType;
   }
   return 'other';
 }

--- a/libs/web/pages/groceries/src/groceries-list-detail/GroceriesListDetailClient.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/GroceriesListDetailClient.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { GroceryList } from '@myorganizer/core';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -21,10 +20,6 @@ export function GroceriesListDetailClient({
   const router = useRouter();
   const vault = useGroceriesVault({ masterKeyBytes });
 
-  const handleListUpdated = useCallback(
-    (updated: GroceryList) => void updated,
-    [],
-  );
   const handleClose = useCallback(() => {
     router.push('/dashboard/groceries');
   }, [router]);
@@ -83,11 +78,14 @@ export function GroceriesListDetailClient({
       </Link>
       <GroceryListView
         list={list}
-        masterKeyBytes={masterKeyBytes}
-        onListUpdated={handleListUpdated}
+        catalog={vault.catalog}
         onClose={handleClose}
-        persistLists={vault.persistLists}
-        allLists={vault.lists}
+        onToggleChecked={vault.toggleLineChecked}
+        onUncheckAll={vault.uncheckAllLines}
+        onRemoveChecked={vault.removeCheckedLines}
+        onRestoreLines={vault.restoreLines}
+        onDeleteLine={vault.deleteListLine}
+        onAddItem={vault.addCatalogItemAndLine}
       />
     </div>
   );

--- a/libs/web/pages/groceries/src/groceries-list-detail/GroceriesListDetailClient.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/GroceriesListDetailClient.tsx
@@ -79,6 +79,7 @@ export function GroceriesListDetailClient({
       <GroceryListView
         list={list}
         catalog={vault.catalog}
+        allLists={vault.lists}
         onClose={handleClose}
         onToggleChecked={vault.toggleLineChecked}
         onUncheckAll={vault.uncheckAllLines}
@@ -86,6 +87,8 @@ export function GroceriesListDetailClient({
         onRestoreLines={vault.restoreLines}
         onDeleteLine={vault.deleteListLine}
         onAddItem={vault.addCatalogItemAndLine}
+        onAddExistingItem={vault.addExistingCatalogItemToLists}
+        onDeleteFromCatalog={vault.deleteCatalogItem}
       />
     </div>
   );

--- a/libs/web/pages/groceries/src/groceries-list-detail/GroceriesListDetailClient.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/GroceriesListDetailClient.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import type { ListLine } from '@myorganizer/core';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
+import type { CatalogItemEditChanges } from './components/CatalogItemEditDialog';
 
 import { useGroceriesVault } from '../shared/hooks';
+import type { AddCatalogItemAndLineInput } from '../shared/hooks';
+import type { UpdateListLineInput } from '../shared/hooks';
 import { GroceryListView } from './components';
 
 interface GroceriesListDetailClientProps {
@@ -23,6 +27,53 @@ export function GroceriesListDetailClient({
   const handleClose = useCallback(() => {
     router.push('/dashboard/groceries');
   }, [router]);
+
+  const handleToggleChecked = useCallback(
+    (currentListId: string, lineId: string) =>
+      vault.toggleLineChecked(currentListId, lineId),
+    [vault.toggleLineChecked],
+  );
+  const handleUncheckAll = useCallback(
+    (currentListId: string) => vault.uncheckAllLines(currentListId),
+    [vault.uncheckAllLines],
+  );
+  const handleRemoveChecked = useCallback(
+    (currentListId: string) => vault.removeCheckedLines(currentListId),
+    [vault.removeCheckedLines],
+  );
+  const handleRestoreLines = useCallback(
+    (currentListId: string, lines: ListLine[]) =>
+      vault.restoreLines(currentListId, lines),
+    [vault.restoreLines],
+  );
+  const handleDeleteLine = useCallback(
+    (currentListId: string, lineId: string) =>
+      vault.deleteListLine(currentListId, lineId),
+    [vault.deleteListLine],
+  );
+  const handleAddItem = useCallback(
+    (currentListId: string, input: AddCatalogItemAndLineInput) =>
+      vault.addCatalogItemAndLine(currentListId, input),
+    [vault.addCatalogItemAndLine],
+  );
+  const handleAddExistingItem = useCallback(
+    (catalogItemId: string, listIds: string[], amount?: string) =>
+      vault.addExistingCatalogItemToLists(catalogItemId, listIds, amount),
+    [vault.addExistingCatalogItemToLists],
+  );
+  const handleDeleteFromCatalog = useCallback(
+    (catalogItemId: string) => vault.deleteCatalogItem(catalogItemId),
+    [vault.deleteCatalogItem],
+  );
+  const handleUpdateCatalogItem = useCallback(
+    (changes: CatalogItemEditChanges) => vault.updateCatalogItem(changes),
+    [vault.updateCatalogItem],
+  );
+  const handleUpdateListLine = useCallback(
+    (currentListId: string, changes: UpdateListLineInput) =>
+      vault.updateListLine(currentListId, changes),
+    [vault.updateListLine],
+  );
 
   if (vault.loading) {
     return (
@@ -81,14 +132,16 @@ export function GroceriesListDetailClient({
         catalog={vault.catalog}
         allLists={vault.lists}
         onClose={handleClose}
-        onToggleChecked={vault.toggleLineChecked}
-        onUncheckAll={vault.uncheckAllLines}
-        onRemoveChecked={vault.removeCheckedLines}
-        onRestoreLines={vault.restoreLines}
-        onDeleteLine={vault.deleteListLine}
-        onAddItem={vault.addCatalogItemAndLine}
-        onAddExistingItem={vault.addExistingCatalogItemToLists}
-        onDeleteFromCatalog={vault.deleteCatalogItem}
+        onToggleChecked={handleToggleChecked}
+        onUncheckAll={handleUncheckAll}
+        onRemoveChecked={handleRemoveChecked}
+        onRestoreLines={handleRestoreLines}
+        onDeleteLine={handleDeleteLine}
+        onAddItem={handleAddItem}
+        onAddExistingItem={handleAddExistingItem}
+        onDeleteFromCatalog={handleDeleteFromCatalog}
+        onUpdateCatalogItem={handleUpdateCatalogItem}
+        onUpdateListLine={handleUpdateListLine}
       />
     </div>
   );

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/AddExistingItemDialog.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/AddExistingItemDialog.spec.tsx
@@ -1,0 +1,324 @@
+/*
+  Tests for AddExistingItemDialog component.
+  - Mocks @myorganizer/web-ui Dialog/DialogContent/Button/Input/Label/Checkbox/cn
+  - Mocks lucide-react icons
+  - Covers catalog search/filter, single-select semantics, list toggling,
+    submit-button gating, submit argument shape, cancel, and re-open reset
+*/
+
+/** Mocking rule: place jest.mock calls before any imports */
+jest.mock('@myorganizer/web-ui', () => {
+  const React = require('react');
+
+  function Dialog({ open, onOpenChange, children }: any) {
+    if (!open) return null;
+    return (
+      <div data-testid="dialog-root">
+        <div
+          data-testid="dialog-backdrop"
+          onClick={() => onOpenChange?.(false)}
+        />
+        {children}
+      </div>
+    );
+  }
+
+  const DialogContent = ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  );
+
+  function Button({ children, onClick, disabled, type, variant }: any) {
+    return (
+      <button
+        type={type}
+        data-variant={variant}
+        onClick={onClick}
+        disabled={disabled}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  function Input(props: any) {
+    const { className, ...rest } = props;
+    return <input className={className} {...rest} />;
+  }
+
+  function Label({ children, htmlFor, className }: any) {
+    return (
+      <label htmlFor={htmlFor} className={className}>
+        {children}
+      </label>
+    );
+  }
+
+  function Checkbox({ checked, onCheckedChange, disabled, ...rest }: any) {
+    return (
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={() => onCheckedChange?.(!checked)}
+        disabled={disabled}
+        {...rest}
+      />
+    );
+  }
+
+  return {
+    Dialog,
+    DialogContent,
+    Button,
+    Input,
+    Label,
+    Checkbox,
+    cn: (...args: any[]) => args.filter(Boolean).join(' '),
+  };
+});
+
+jest.mock('lucide-react', () => ({
+  Lock: () => <div data-testid="lock-icon" />,
+  Search: () => <div data-testid="search-icon" />,
+}));
+
+import type { CatalogItem, GroceryList } from '@myorganizer/core';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AddExistingItemDialog } from '../components/AddExistingItemDialog';
+
+describe('AddExistingItemDialog', () => {
+  function makeCatalogItem(
+    id: string,
+    name: string,
+    overrides: Partial<CatalogItem> = {},
+  ): CatalogItem {
+    return {
+      id,
+      name,
+      category: 'other',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function makeList(id: string, name: string): GroceryList {
+    return {
+      id,
+      name,
+      lines: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+  }
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    catalog: [
+      makeCatalogItem('c1', 'Milk'),
+      makeCatalogItem('c2', 'Bread'),
+      makeCatalogItem('c3', 'Almond Milk'),
+    ],
+    lists: [makeList('l1', 'Weekly'), makeList('l2', 'Party')],
+    defaultListId: 'l1',
+    onAdd: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders an empty-state message and keeps submit disabled when catalog is empty', () => {
+    render(<AddExistingItemDialog {...defaultProps} catalog={[]} />);
+
+    expect(
+      screen.getByText(/There are no Catalog Items yet/i),
+    ).toBeInTheDocument();
+    const submitButton = screen.getByText('Add to Lists', {
+      selector: 'button',
+    });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('filters the catalog list by case-insensitive substring search', () => {
+    render(<AddExistingItemDialog {...defaultProps} />);
+
+    const search = screen.getByPlaceholderText('Search catalog by name...');
+    fireEvent.change(search, { target: { value: 'milk' } });
+
+    expect(screen.getByText('Milk')).toBeInTheDocument();
+    expect(screen.getByText('Almond Milk')).toBeInTheDocument();
+    expect(screen.queryByText('Bread')).not.toBeInTheDocument();
+  });
+
+  it('supports single-select semantics: selecting a second item deselects the first', () => {
+    render(<AddExistingItemDialog {...defaultProps} />);
+
+    const milkRadio = screen.getByText('Milk').closest('button') as HTMLElement;
+    const breadRadio = screen
+      .getByText('Bread')
+      .closest('button') as HTMLElement;
+
+    fireEvent.click(milkRadio);
+    expect(milkRadio).toHaveAttribute('aria-checked', 'true');
+    expect(breadRadio).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(breadRadio);
+    expect(milkRadio).toHaveAttribute('aria-checked', 'false');
+    expect(breadRadio).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('pre-selects the defaultListId checkbox and allows toggling additional lists', () => {
+    render(<AddExistingItemDialog {...defaultProps} />);
+
+    const weeklyCheckbox = screen.getByLabelText(
+      'Add to Weekly',
+    ) as HTMLInputElement;
+    const partyCheckbox = screen.getByLabelText(
+      'Add to Party',
+    ) as HTMLInputElement;
+
+    expect(weeklyCheckbox.checked).toBe(true);
+    expect(partyCheckbox.checked).toBe(false);
+
+    fireEvent.click(partyCheckbox);
+    expect(partyCheckbox.checked).toBe(true);
+  });
+
+  it('keeps submit disabled until both a catalog item and a list are selected', () => {
+    render(
+      <AddExistingItemDialog {...defaultProps} defaultListId={undefined} />,
+    );
+
+    const submitButton = screen.getByText('Add to Lists', {
+      selector: 'button',
+    });
+    expect(submitButton).toBeDisabled();
+
+    const milkRadio = screen.getByText('Milk').closest('button') as HTMLElement;
+    fireEvent.click(milkRadio);
+    // Catalog item selected, but no list selected yet
+    expect(submitButton).toBeDisabled();
+
+    const weeklyCheckbox = screen.getByLabelText('Add to Weekly');
+    fireEvent.click(weeklyCheckbox);
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it('calls onAdd with exact arguments, converting an empty amount to undefined', async () => {
+    const onAdd = jest.fn().mockResolvedValue(undefined);
+    render(<AddExistingItemDialog {...defaultProps} onAdd={onAdd} />);
+
+    const milkRadio = screen.getByText('Milk').closest('button') as HTMLElement;
+    fireEvent.click(milkRadio);
+
+    const submitButton = screen.getByText('Add to Lists', {
+      selector: 'button',
+    });
+    fireEvent.click(submitButton);
+
+    await Promise.resolve();
+
+    expect(onAdd).toHaveBeenCalledWith('c1', ['l1'], undefined);
+  });
+
+  it('calls onAdd with the typed amount when provided', async () => {
+    const onAdd = jest.fn().mockResolvedValue(undefined);
+    render(<AddExistingItemDialog {...defaultProps} onAdd={onAdd} />);
+
+    const milkRadio = screen.getByText('Milk').closest('button') as HTMLElement;
+    fireEvent.click(milkRadio);
+
+    const amountInput = screen.getByPlaceholderText('e.g. 2, 500g');
+    fireEvent.change(amountInput, { target: { value: '2L' } });
+
+    const submitButton = screen.getByText('Add to Lists', {
+      selector: 'button',
+    });
+    fireEvent.click(submitButton);
+
+    await Promise.resolve();
+
+    expect(onAdd).toHaveBeenCalledWith('c1', ['l1'], '2L');
+  });
+
+  it('calls onClose without calling onAdd when Cancel is clicked', () => {
+    const onClose = jest.fn();
+    const onAdd = jest.fn();
+    render(
+      <AddExistingItemDialog
+        {...defaultProps}
+        onClose={onClose}
+        onAdd={onAdd}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose without calling onAdd when the dialog backdrop triggers onOpenChange(false)', () => {
+    const onClose = jest.fn();
+    const onAdd = jest.fn();
+    render(
+      <AddExistingItemDialog
+        {...defaultProps}
+        onClose={onClose}
+        onAdd={onAdd}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('dialog-backdrop'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('resets search, selection, and lists back to just defaultListId when re-opened', () => {
+    const { rerender } = render(<AddExistingItemDialog {...defaultProps} />);
+
+    const search = screen.getByPlaceholderText('Search catalog by name...');
+    fireEvent.change(search, { target: { value: 'bread' } });
+
+    const breadRadio = screen
+      .getByText('Bread')
+      .closest('button') as HTMLElement;
+    fireEvent.click(breadRadio);
+
+    const partyCheckbox = screen.getByLabelText(
+      'Add to Party',
+    ) as HTMLInputElement;
+    fireEvent.click(partyCheckbox);
+    expect(partyCheckbox.checked).toBe(true);
+
+    // Close then re-open
+    rerender(<AddExistingItemDialog {...defaultProps} isOpen={false} />);
+    rerender(<AddExistingItemDialog {...defaultProps} isOpen={true} />);
+
+    const searchAfterReopen = screen.getByPlaceholderText(
+      'Search catalog by name...',
+    ) as HTMLInputElement;
+    expect(searchAfterReopen.value).toBe('');
+
+    // All items should be visible again (search cleared)
+    expect(screen.getByText('Milk')).toBeInTheDocument();
+    expect(screen.getByText('Bread')).toBeInTheDocument();
+
+    const breadRadioAfterReopen = screen
+      .getByText('Bread')
+      .closest('button') as HTMLElement;
+    expect(breadRadioAfterReopen).toHaveAttribute('aria-checked', 'false');
+
+    const weeklyCheckboxAfterReopen = screen.getByLabelText(
+      'Add to Weekly',
+    ) as HTMLInputElement;
+    const partyCheckboxAfterReopen = screen.getByLabelText(
+      'Add to Party',
+    ) as HTMLInputElement;
+    expect(weeklyCheckboxAfterReopen.checked).toBe(true);
+    expect(partyCheckboxAfterReopen.checked).toBe(false);
+  });
+});

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/AddItemDialog.integration.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/AddItemDialog.integration.spec.tsx
@@ -1,6 +1,11 @@
 /** Mocking rule: place jest.mock calls before any imports */
 jest.mock('@myorganizer/web-ui', () => {
   const React = require('react');
+  const {
+    Controller,
+    FormProvider,
+    useFormContext,
+  } = require('react-hook-form');
 
   // Simple Input that forwards all props to a real input so react-hook-form register works
   function Input(props: any) {
@@ -45,6 +50,78 @@ jest.mock('@myorganizer/web-ui', () => {
   const DialogTitle = ({ children }: any) => <h2>{children}</h2>;
   const DialogDescription = ({ children }: any) => <p>{children}</p>;
   const DialogFooter = ({ children }: any) => <div>{children}</div>;
+
+  // Keep the form primitives close to their production contract: Controller
+  // supplies field props, while the other wrappers expose field state and
+  // accessible ids/validation attributes to their children.
+  const FormFieldContext = React.createContext<{ name?: string }>({});
+  const FormItemContext = React.createContext<{ id?: string }>({});
+
+  function Form(props: any) {
+    return <FormProvider {...props} />;
+  }
+
+  function FormField({ name, render, ...props }: any) {
+    return (
+      <FormFieldContext.Provider value={{ name }}>
+        <Controller name={name} render={render} {...props} />
+      </FormFieldContext.Provider>
+    );
+  }
+
+  function FormItem({ children, ...props }: any) {
+    const id = React.useId();
+    return (
+      <FormItemContext.Provider value={{ id }}>
+        <div {...props}>{children}</div>
+      </FormItemContext.Provider>
+    );
+  }
+
+  function useFormField() {
+    const { name } = React.useContext(FormFieldContext);
+    const { id } = React.useContext(FormItemContext);
+    const { getFieldState, formState } = useFormContext();
+    return {
+      error: name ? getFieldState(name, formState).error : undefined,
+      formItemId: `${id}-form-item`,
+      formDescriptionId: `${id}-form-item-description`,
+      formMessageId: `${id}-form-item-message`,
+    };
+  }
+
+  function FormControl({ children, ...props }: any) {
+    const { error, formItemId, formDescriptionId, formMessageId } =
+      useFormField();
+    return React.cloneElement(React.Children.only(children), {
+      ...props,
+      id: formItemId,
+      'aria-describedby': error
+        ? `${formDescriptionId} ${formMessageId}`
+        : formDescriptionId,
+      'aria-invalid': !!error,
+    });
+  }
+
+  function FormLabel({ children, ...props }: any) {
+    const { formItemId } = useFormField();
+    return (
+      <label htmlFor={formItemId} {...props}>
+        {children}
+      </label>
+    );
+  }
+
+  function FormMessage({ children, ...props }: any) {
+    const { error, formMessageId } = useFormField();
+    const message = error ? String(error.message) : children;
+    if (!message) return null;
+    return (
+      <p id={formMessageId} {...props}>
+        {message}
+      </p>
+    );
+  }
 
   // Minimal Select components to be safe in the environment
   function Select({ value, onValueChange, children, ...props }: any) {
@@ -91,6 +168,12 @@ jest.mock('@myorganizer/web-ui', () => {
     DialogTitle,
     DialogDescription,
     DialogFooter,
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
     Select,
     SelectTrigger,
     SelectValue,
@@ -106,7 +189,7 @@ import React from 'react';
 
 import { AddItemDialog } from '../components/AddItemDialog';
 
-function TestWrapper({ onAdd, onClose, isLoading = false }: any) {
+function TestWrapper({ onAdd, onClose, isLoading = false, catalog = [] }: any) {
   const [open, setOpen] = React.useState(false);
   return (
     <div>
@@ -121,6 +204,7 @@ function TestWrapper({ onAdd, onClose, isLoading = false }: any) {
         }}
         onAdd={onAdd}
         isLoading={isLoading}
+        catalog={catalog}
       />
     </div>
   );
@@ -304,6 +388,76 @@ describe('AddItemDialog integration', () => {
       'e.g. Organic Almond Milk',
     );
     expect((reopened as HTMLInputElement).value).toBe('');
+  });
+
+  it('keeps the dialog open when onAdd rejects and does not treat it as success', async () => {
+    const onAdd = jest.fn().mockRejectedValue(new Error('save failed'));
+    const onClose = jest.fn();
+    const { container } = render(
+      <TestWrapper onAdd={onAdd} onClose={onClose} />,
+    );
+
+    fireEvent.click(screen.getByTestId('open-dialog'));
+    await screen.findByText('Add New Item');
+    fireEvent.change(screen.getByPlaceholderText('e.g. Organic Almond Milk'), {
+      target: { value: 'Milk' },
+    });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+    await waitFor(() => expect(onAdd).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText('Add New Item')).toBeInTheDocument();
+    expect(
+      (
+        screen.getByPlaceholderText(
+          'e.g. Organic Almond Milk',
+        ) as HTMLInputElement
+      ).value,
+    ).toBe('Milk');
+  });
+
+  it('suggests matching catalog items and submits the selected catalog identity', async () => {
+    const onAdd = jest.fn().mockResolvedValue(undefined);
+    const onClose = jest.fn();
+    const { container } = render(
+      <TestWrapper
+        onAdd={onAdd}
+        onClose={onClose}
+        catalog={[
+          {
+            id: 'catalog-milk',
+            name: 'Organic Milk',
+            category: 'dairy',
+            price: 4.5,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('open-dialog'));
+    const name = await screen.findByPlaceholderText('e.g. Organic Almond Milk');
+    fireEvent.change(name, { target: { value: 'milk' } });
+
+    const suggestion = await screen.findByRole('option', {
+      name: /Organic Milk Dairy/i,
+    });
+    fireEvent.click(suggestion);
+    expect((name as HTMLInputElement).value).toBe('Organic Milk');
+
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(onAdd).toHaveBeenCalled());
+    expect(onAdd).toHaveBeenCalledWith({
+      name: 'Organic Milk',
+      category: 'dairy',
+      catalogItemId: 'catalog-milk',
+      amount: undefined,
+      price: 4.5,
+      notes: undefined,
+      imageUrl: undefined,
+      links: undefined,
+    });
   });
 
   it('full submit with all fields calls onAdd with parsed values', async () => {

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/DeleteCatalogItemDialog.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/DeleteCatalogItemDialog.spec.tsx
@@ -1,0 +1,242 @@
+/*
+  Tests for DeleteCatalogItemDialog component.
+  - Mocks @myorganizer/web-ui Dialog compound for predictable behavior
+  - Mocks lucide-react AlertTriangle icon
+  - Covers null-guard rendering, pluralized affected-list-count copy,
+    typed-confirmation gating (including trim behavior), confirm/loading
+    flow, and cancel-resets-input behavior
+*/
+
+/** Mocking rule: place jest.mock calls before any imports */
+jest.mock('@myorganizer/web-ui', () => {
+  const React = require('react');
+
+  function Dialog({ open, onOpenChange, children }: any) {
+    if (!open) return null;
+    return (
+      <div data-testid="dialog-root">
+        <div
+          data-testid="dialog-backdrop"
+          onClick={() => onOpenChange?.(false)}
+        />
+        {children}
+      </div>
+    );
+  }
+
+  const DialogContent = ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  );
+  const DialogHeader = ({ children }: any) => <div>{children}</div>;
+  const DialogTitle = ({ children }: any) => <h2>{children}</h2>;
+  const DialogDescription = ({ children }: any) => <p>{children}</p>;
+  const DialogFooter = ({ children }: any) => <div>{children}</div>;
+
+  function Button({ children, onClick, disabled, type, variant }: any) {
+    return (
+      <button
+        type={type}
+        data-variant={variant}
+        onClick={onClick}
+        disabled={disabled}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  function Input(props: any) {
+    const { className, ...rest } = props;
+    return <input className={className} {...rest} />;
+  }
+
+  function Label({ children, htmlFor, className }: any) {
+    return (
+      <label htmlFor={htmlFor} className={className}>
+        {children}
+      </label>
+    );
+  }
+
+  return {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+    Button,
+    Input,
+    Label,
+  };
+});
+
+jest.mock('lucide-react', () => ({
+  AlertTriangle: () => <div data-testid="alert-icon" />,
+}));
+
+import type { CatalogItem } from '@myorganizer/core';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { DeleteCatalogItemDialog } from '../components/DeleteCatalogItemDialog';
+
+describe('DeleteCatalogItemDialog', () => {
+  function makeCatalogItem(overrides: Partial<CatalogItem> = {}): CatalogItem {
+    return {
+      id: 'cat-1',
+      name: 'Milk',
+      category: 'dairy',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  const defaultProps = {
+    isOpen: true,
+    catalogItem: makeCatalogItem(),
+    affectedListCount: 0,
+    onClose: jest.fn(),
+    onConfirm: jest.fn().mockResolvedValue(undefined),
+    isLoading: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when catalogItem is null even if isOpen is true', () => {
+    render(<DeleteCatalogItemDialog {...defaultProps} catalogItem={null} />);
+
+    expect(screen.queryByTestId('dialog-root')).not.toBeInTheDocument();
+  });
+
+  it('shows the Catalog Item name in the title and the confirmation label', () => {
+    render(<DeleteCatalogItemDialog {...defaultProps} />);
+
+    expect(screen.getByText('Delete "Milk" from Catalog?')).toBeInTheDocument();
+    expect(screen.getByText('Type "Milk" to confirm')).toBeInTheDocument();
+  });
+
+  it('shows "isn\'t currently on any other Grocery List" when affectedListCount is 0', () => {
+    render(<DeleteCatalogItemDialog {...defaultProps} affectedListCount={0} />);
+
+    expect(
+      screen.getByText(/It isn't currently on any other Grocery List\./),
+    ).toBeInTheDocument();
+  });
+
+  it('shows singular copy when affectedListCount is 1', () => {
+    render(<DeleteCatalogItemDialog {...defaultProps} affectedListCount={1} />);
+
+    expect(
+      screen.getByText(/This will also remove it from 1 other Grocery List\./),
+    ).toBeInTheDocument();
+  });
+
+  it('shows plural copy when affectedListCount is greater than 1', () => {
+    render(<DeleteCatalogItemDialog {...defaultProps} affectedListCount={3} />);
+
+    expect(
+      screen.getByText(/This will also remove it from 3 other Grocery Lists\./),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the destructive button disabled until the typed input exactly matches the name', () => {
+    render(<DeleteCatalogItemDialog {...defaultProps} />);
+
+    const input = screen.getByLabelText('Type "Milk" to confirm');
+    const deleteButton = screen.getByText('Delete From Catalog');
+
+    // No input
+    expect(deleteButton).toBeDisabled();
+
+    // Wrong/partial text
+    fireEvent.change(input, { target: { value: 'Mil' } });
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'milk' } });
+    expect(deleteButton).toBeDisabled();
+
+    // Exact match
+    fireEvent.change(input, { target: { value: 'Milk' } });
+    expect(deleteButton).not.toBeDisabled();
+  });
+
+  it('enables the destructive button when the typed input matches after trimming surrounding whitespace', () => {
+    render(<DeleteCatalogItemDialog {...defaultProps} />);
+
+    const input = screen.getByLabelText('Type "Milk" to confirm');
+    const deleteButton = screen.getByText('Delete From Catalog');
+
+    fireEvent.change(input, { target: { value: '  Milk  ' } });
+    expect(deleteButton).not.toBeDisabled();
+  });
+
+  it('calls onConfirm and shows the loading label while confirming, disabling the button', async () => {
+    let resolveConfirm: (() => void) | null = null;
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    render(<DeleteCatalogItemDialog {...defaultProps} onConfirm={onConfirm} />);
+
+    const input = screen.getByLabelText('Type "Milk" to confirm');
+    fireEvent.change(input, { target: { value: 'Milk' } });
+
+    const deleteButton = screen.getByText('Delete From Catalog');
+    fireEvent.click(deleteButton);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(screen.getByText('Deleting...')).toBeInTheDocument();
+      expect(screen.getByText('Deleting...')).toBeDisabled();
+    });
+
+    resolveConfirm!();
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete From Catalog')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClose when Cancel is clicked and clears the input on re-open', () => {
+    const onClose = jest.fn();
+    const { rerender } = render(
+      <DeleteCatalogItemDialog {...defaultProps} onClose={onClose} />,
+    );
+
+    const input = screen.getByLabelText(
+      'Type "Milk" to confirm',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Milk' } });
+    expect(input.value).toBe('Milk');
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // Close then re-open to verify the input was reset
+    rerender(
+      <DeleteCatalogItemDialog
+        {...defaultProps}
+        onClose={onClose}
+        isOpen={false}
+      />,
+    );
+    rerender(
+      <DeleteCatalogItemDialog
+        {...defaultProps}
+        onClose={onClose}
+        isOpen={true}
+      />,
+    );
+
+    const reopenedInput = screen.getByLabelText(
+      'Type "Milk" to confirm',
+    ) as HTMLInputElement;
+    expect(reopenedInput.value).toBe('');
+  });
+});

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/EditItemDialog.integration.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/EditItemDialog.integration.spec.tsx
@@ -147,12 +147,14 @@ const sampleFullItem = {
   id: 'item-1',
   name: 'Organic Bananas',
   checked: true,
-  category: 'produce',
+  category: 'produce' as const,
   amount: '1 dozen',
   price: 3.49,
   notes: 'Get ripe ones',
   imageUrl: 'http://example.com/bananas.jpg',
   links: ['http://a.example', 'http://b.example'],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
 const sampleMinimalItem = {

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/GroceriesListDetailClient.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/GroceriesListDetailClient.spec.tsx
@@ -34,7 +34,11 @@ jest.mock('../components', () => ({
 
 jest.mock('lucide-react', () => ({
   ArrowLeft: ({ className }: Record<string, unknown>) => (
-    <svg data-testid="arrow-left-icon" className={className as string} viewBox="0 0 24 24" />
+    <svg
+      data-testid="arrow-left-icon"
+      className={className as string}
+      viewBox="0 0 24 24"
+    />
   ),
 }));
 
@@ -56,18 +60,20 @@ describe('GroceriesListDetailClient', () => {
     name: string,
     itemCount = 0,
   ): GroceryList {
+    const now = new Date().toISOString();
     return {
       id,
       name,
-      items: Array.from({ length: itemCount }, (_, i) => ({
-        id: `item-${i}`,
-        name: `Item ${i}`,
-        completed: false,
-        quantity: 1,
-        unit: '',
+      lines: Array.from({ length: itemCount }, (_, i) => ({
+        id: `line-${i}`,
+        catalogItemId: `catalog-${i}`,
+        checked: false,
+        amount: '1',
+        createdAt: now,
+        updatedAt: now,
       })),
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      createdAt: now,
+      updatedAt: now,
     };
   }
 
@@ -115,9 +121,7 @@ describe('GroceriesListDetailClient', () => {
         />,
       );
 
-      expect(
-        screen.queryByTestId('grocery-list-view'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('grocery-list-view')).not.toBeInTheDocument();
     });
 
     it('should not render "List not found" message during loading state', () => {
@@ -175,9 +179,7 @@ describe('GroceriesListDetailClient', () => {
       );
 
       expect(
-        screen.getByText(
-          "The grocery list you're looking for doesn't exist.",
-        ),
+        screen.getByText("The grocery list you're looking for doesn't exist."),
       ).toBeInTheDocument();
     });
 
@@ -216,9 +218,7 @@ describe('GroceriesListDetailClient', () => {
         />,
       );
 
-      expect(
-        screen.queryByTestId('grocery-list-view'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('grocery-list-view')).not.toBeInTheDocument();
     });
   });
 
@@ -278,9 +278,7 @@ describe('GroceriesListDetailClient', () => {
         />,
       );
 
-      expect(
-        screen.queryByText('List not found'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('List not found')).not.toBeInTheDocument();
     });
 
     it('should render back link when list is found', () => {

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/GroceriesListDetailClient.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/GroceriesListDetailClient.spec.tsx
@@ -13,7 +13,15 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: ({ href, children, ...props }: Record<string, unknown>) => (
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: import('react').ReactNode;
+    [key: string]: unknown;
+  }) => (
     <a href={href} {...props}>
       {children}
     </a>

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/GroceryListView.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/GroceryListView.spec.tsx
@@ -1,0 +1,507 @@
+/*
+  Tests for GroceryListView component.
+  - This is the first test file for GroceryListView: covers the pre-existing
+    trip lifecycle wiring (toggle/uncheck-all/remove-checked/delete-line) at
+    a basic level, plus the NEW catalog-membership wiring: Add From Catalog
+    (AddExistingItemDialog) and Delete From Catalog (DeleteCatalogItemDialog),
+    including the affectedListCount computation and toast/close behavior.
+  - Mocks the dialog/toolbar/row child components with lightweight testid
+    stubs so this suite is a pure wiring test, not a re-test of those
+    components' own internal behavior (already covered in their own specs).
+  - Mocks @myorganizer/web-ui's useToast/ToastAction the same way sibling
+    vault-adjacent specs in this repo do (see migrationRunner.spec.tsx).
+*/
+
+/** Mocking rule: place jest.mock calls before any imports */
+const mockToast = jest.fn();
+
+jest.mock('@myorganizer/web-ui', () => ({
+  useToast: () => ({ toast: mockToast }),
+  ToastAction: ({ children, onClick }: any) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+
+jest.mock('../components/AddItemDialog', () => ({
+  AddItemDialog: ({ isOpen, onClose, onAdd, isLoading }: any) =>
+    isOpen ? (
+      <div data-testid="add-item-dialog" data-loading={isLoading}>
+        <button
+          data-testid="add-item-submit"
+          onClick={() => onAdd({ name: 'New Item', category: 'other' })}
+        >
+          Submit
+        </button>
+        <button data-testid="add-item-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+jest.mock('../components/AddExistingItemDialog', () => ({
+  AddExistingItemDialog: ({
+    isOpen,
+    onClose,
+    catalog,
+    lists,
+    defaultListId,
+    onAdd,
+    isLoading,
+  }: any) =>
+    isOpen ? (
+      <div
+        data-testid="add-existing-item-dialog"
+        data-catalog-count={catalog.length}
+        data-lists-count={lists.length}
+        data-default-list-id={defaultListId}
+        data-loading={isLoading}
+      >
+        <button
+          data-testid="add-existing-submit"
+          onClick={() => onAdd('cat-1', ['list-a', 'list-b'], '2L')}
+        >
+          Submit
+        </button>
+        <button data-testid="add-existing-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+jest.mock('../components/DeleteCatalogItemDialog', () => ({
+  DeleteCatalogItemDialog: ({
+    isOpen,
+    catalogItem,
+    affectedListCount,
+    onClose,
+    onConfirm,
+    isLoading,
+  }: any) =>
+    isOpen ? (
+      <div
+        data-testid="delete-catalog-item-dialog"
+        data-catalog-item-name={catalogItem?.name}
+        data-catalog-item-id={catalogItem?.id}
+        data-affected-list-count={affectedListCount}
+        data-loading={isLoading}
+      >
+        <button data-testid="delete-catalog-confirm" onClick={onConfirm}>
+          Confirm
+        </button>
+        <button data-testid="delete-catalog-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+jest.mock('../components/TripBoardLifecycleToolbar', () => ({
+  TripBoardLifecycleToolbar: ({
+    checkedCount,
+    onUncheckAll,
+    onRemoveChecked,
+    onAddItem,
+    onAddExisting,
+    isLoading,
+  }: any) => (
+    <div data-testid="toolbar" data-checked-count={checkedCount}>
+      <button data-testid="toolbar-add-item" onClick={onAddItem}>
+        Add Item
+      </button>
+      <button data-testid="toolbar-add-existing" onClick={onAddExisting}>
+        Add From Catalog
+      </button>
+      <button
+        data-testid="toolbar-uncheck-all"
+        onClick={onUncheckAll}
+        disabled={isLoading}
+      >
+        Uncheck All
+      </button>
+      <button
+        data-testid="toolbar-remove-checked"
+        onClick={onRemoveChecked}
+        disabled={isLoading}
+      >
+        Remove Checked
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('../components/TripBoardLineRow', () => ({
+  TripBoardLineRow: ({
+    line,
+    catalogItem,
+    onToggleChecked,
+    onDeleteLine,
+    onDeleteFromCatalog,
+    isLoading,
+  }: any) => (
+    <div data-testid={`line-row-${line.id}`} data-loading={isLoading}>
+      <span>{catalogItem?.name ?? 'Unknown item'}</span>
+      <button
+        data-testid={`toggle-${line.id}`}
+        onClick={() => onToggleChecked(line.id)}
+      >
+        Toggle
+      </button>
+      <button
+        data-testid={`delete-line-${line.id}`}
+        onClick={() => onDeleteLine(line.id)}
+      >
+        Delete Line
+      </button>
+      {catalogItem && (
+        <button
+          data-testid={`delete-from-catalog-${line.id}`}
+          onClick={() => onDeleteFromCatalog(catalogItem.id)}
+        >
+          Delete From Catalog
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+import type { CatalogItem, GroceryList, ListLine } from '@myorganizer/core';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { GroceryListView } from '../components/GroceryListView';
+
+describe('GroceryListView', () => {
+  function makeCatalogItem(
+    id: string,
+    name: string,
+    overrides: Partial<CatalogItem> = {},
+  ): CatalogItem {
+    return {
+      id,
+      name,
+      category: 'other',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function makeLine(
+    id: string,
+    catalogItemId: string,
+    overrides: Partial<ListLine> = {},
+  ): ListLine {
+    return {
+      id,
+      catalogItemId,
+      checked: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function makeList(
+    id: string,
+    name: string,
+    lines: ListLine[] = [],
+  ): GroceryList {
+    return {
+      id,
+      name,
+      lines,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+  }
+
+  function makeBaseProps(overrides: Partial<Record<string, any>> = {}) {
+    return {
+      onClose: jest.fn(),
+      onToggleChecked: jest.fn().mockResolvedValue(undefined),
+      onUncheckAll: jest.fn().mockResolvedValue(undefined),
+      onRemoveChecked: jest.fn().mockResolvedValue([]),
+      onRestoreLines: jest.fn().mockResolvedValue(undefined),
+      onDeleteLine: jest.fn().mockResolvedValue(undefined),
+      onAddItem: jest.fn().mockResolvedValue(undefined),
+      onAddItemToLists: jest.fn().mockResolvedValue(undefined),
+      onAddExistingItem: jest.fn().mockResolvedValue(['list-a', 'list-b']),
+      onDeleteFromCatalog: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /* ============================================
+     Basic trip lifecycle wiring (first test file for this component)
+     ============================================ */
+
+  it('toggles a line via TripBoardLineRow wiring', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const line = makeLine('ln1', 'c1');
+    const list = makeList('list1', 'Weekly', [line]);
+    const props = makeBaseProps();
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[catalogItem]}
+        allLists={[list]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('toggle-ln1'));
+
+    await waitFor(() => {
+      expect(props.onToggleChecked).toHaveBeenCalledWith('list1', 'ln1');
+    });
+  });
+
+  it('unchecks all lines via toolbar wiring', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const line = makeLine('ln1', 'c1', { checked: true });
+    const list = makeList('list1', 'Weekly', [line]);
+    const props = makeBaseProps();
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[catalogItem]}
+        allLists={[list]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('toolbar-uncheck-all'));
+
+    await waitFor(() => {
+      expect(props.onUncheckAll).toHaveBeenCalledWith('list1');
+    });
+  });
+
+  it('removes checked lines via toolbar wiring', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const line = makeLine('ln1', 'c1', { checked: true });
+    const list = makeList('list1', 'Weekly', [line]);
+    const props = makeBaseProps();
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[catalogItem]}
+        allLists={[list]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('toolbar-remove-checked'));
+
+    await waitFor(() => {
+      expect(props.onRemoveChecked).toHaveBeenCalledWith('list1');
+    });
+  });
+
+  it('deletes a line via TripBoardLineRow wiring', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const line = makeLine('ln1', 'c1');
+    const list = makeList('list1', 'Weekly', [line]);
+    const props = makeBaseProps();
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[catalogItem]}
+        allLists={[list]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('delete-line-ln1'));
+
+    await waitFor(() => {
+      expect(props.onDeleteLine).toHaveBeenCalledWith('list1', 'ln1');
+    });
+  });
+
+  /* ============================================
+     NEW: Add From Catalog (AddExistingItemDialog) wiring
+     ============================================ */
+
+  it('opens AddExistingItemDialog from the toolbar and submits to onAddExistingItem, then toasts and closes', async () => {
+    const list = makeList('list1', 'Weekly');
+    const props = makeBaseProps();
+
+    render(
+      <GroceryListView list={list} catalog={[]} allLists={[list]} {...props} />,
+    );
+
+    expect(
+      screen.queryByTestId('add-existing-item-dialog'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('toolbar-add-existing'));
+
+    expect(screen.getByTestId('add-existing-item-dialog')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('add-existing-submit'));
+
+    await waitFor(() => {
+      expect(props.onAddExistingItem).toHaveBeenCalledWith(
+        'cat-1',
+        ['list-a', 'list-b'],
+        '2L',
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('add-existing-item-dialog'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Both requested lists received a line (onAddExistingItem resolved with
+    // ['list-a', 'list-b'], matching the 2 requested list ids)
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Added to lists',
+        description: 'Added to 2 lists.',
+      }),
+    );
+  });
+
+  it('shows the partial-add toast copy when only some of the requested lists actually received a line', async () => {
+    const list = makeList('list1', 'Weekly');
+    const props = makeBaseProps({
+      onAddExistingItem: jest.fn().mockResolvedValue(['list-a']),
+    });
+
+    render(
+      <GroceryListView list={list} catalog={[]} allLists={[list]} {...props} />,
+    );
+
+    fireEvent.click(screen.getByTestId('toolbar-add-existing'));
+    fireEvent.click(screen.getByTestId('add-existing-submit'));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Added to lists',
+          description: 'Added to 1 of 2 lists (already on the rest).',
+        }),
+      );
+    });
+  });
+
+  /* ============================================
+     NEW: Delete From Catalog (DeleteCatalogItemDialog) wiring
+     ============================================ */
+
+  it('opens DeleteCatalogItemDialog with the correct catalogItem and affectedListCount, excluding the current list', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const currentLine = makeLine('ln-current', 'c1');
+    const currentList = makeList('current', 'Current', [currentLine]);
+    const otherList1 = makeList('other1', 'Other 1', [
+      makeLine('ln-other1', 'c1'),
+    ]);
+    const otherList2 = makeList('other2', 'Other 2', [
+      makeLine('ln-other2', 'c2'),
+    ]);
+    const props = makeBaseProps();
+
+    render(
+      <GroceryListView
+        list={currentList}
+        catalog={[catalogItem]}
+        allLists={[currentList, otherList1, otherList2]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('delete-from-catalog-ln-current'));
+
+    const dialog = screen.getByTestId('delete-catalog-item-dialog');
+    expect(dialog).toHaveAttribute('data-catalog-item-id', 'c1');
+    expect(dialog).toHaveAttribute('data-catalog-item-name', 'Milk');
+    // Only otherList1 references c1 among the OTHER lists (otherList2 does not,
+    // and the current list itself is excluded from the count).
+    expect(dialog).toHaveAttribute('data-affected-list-count', '1');
+  });
+
+  it('confirms delete-from-catalog: calls onDeleteFromCatalog, shows success toast naming the item, and closes the dialog', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const line = makeLine('ln1', 'c1');
+    const list = makeList('list1', 'Weekly', [line]);
+    const props = makeBaseProps();
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[catalogItem]}
+        allLists={[list]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('delete-from-catalog-ln1'));
+    fireEvent.click(screen.getByTestId('delete-catalog-confirm'));
+
+    await waitFor(() => {
+      expect(props.onDeleteFromCatalog).toHaveBeenCalledWith('c1');
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('delete-catalog-item-dialog'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Deleted "Milk" from Catalog',
+      }),
+    );
+  });
+
+  it('closes the delete-from-catalog dialog and shows an error toast even when onDeleteFromCatalog rejects', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const line = makeLine('ln1', 'c1');
+    const list = makeList('list1', 'Weekly', [line]);
+    const props = makeBaseProps({
+      onDeleteFromCatalog: jest.fn().mockRejectedValue(new Error('boom')),
+    });
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[catalogItem]}
+        allLists={[list]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('delete-from-catalog-ln1'));
+    fireEvent.click(screen.getByTestId('delete-catalog-confirm'));
+
+    await waitFor(() => {
+      expect(props.onDeleteFromCatalog).toHaveBeenCalledWith('c1');
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('delete-catalog-item-dialog'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Error',
+        variant: 'destructive',
+      }),
+    );
+  });
+});

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/GroceryListView.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/GroceryListView.spec.tsx
@@ -97,6 +97,47 @@ jest.mock('../components/DeleteCatalogItemDialog', () => ({
     ) : null,
 }));
 
+jest.mock('../components/CatalogItemEditDialog', () => ({
+  CatalogItemEditDialog: ({ item, isOpen, onClose, onSave, isLoading }: any) =>
+    isOpen ? (
+      <div data-testid="catalog-item-edit-dialog" data-loading={isLoading}>
+        <button
+          data-testid="catalog-item-edit-submit"
+          onClick={() =>
+            void onSave({
+              id: item.id,
+              name: 'Updated Milk',
+              category: 'dairy',
+              price: 4.5,
+            }).catch(() => undefined)
+          }
+        >
+          Save
+        </button>
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null,
+}));
+
+jest.mock('../components/ListLineEditDialog', () => ({
+  ListLineEditDialog: ({ line, isOpen, onClose, onSave, isLoading }: any) =>
+    isOpen ? (
+      <div data-testid="list-line-edit-dialog" data-loading={isLoading}>
+        <button
+          data-testid="list-line-edit-submit"
+          onClick={() =>
+            void onSave({ id: line.id, amount: '3 cartons' }).catch(
+              () => undefined,
+            )
+          }
+        >
+          Save
+        </button>
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null,
+}));
+
 jest.mock('../components/TripBoardLifecycleToolbar', () => ({
   TripBoardLifecycleToolbar: ({
     checkedCount,
@@ -138,6 +179,8 @@ jest.mock('../components/TripBoardLineRow', () => ({
     onToggleChecked,
     onDeleteLine,
     onDeleteFromCatalog,
+    onEditListLine,
+    onEditCatalogItem,
     isLoading,
   }: any) => (
     <div data-testid={`line-row-${line.id}`} data-loading={isLoading}>
@@ -154,13 +197,27 @@ jest.mock('../components/TripBoardLineRow', () => ({
       >
         Delete Line
       </button>
+      <button
+        data-testid={`edit-line-${line.id}`}
+        onClick={() => onEditListLine(line.id)}
+      >
+        Edit Line
+      </button>
       {catalogItem && (
-        <button
-          data-testid={`delete-from-catalog-${line.id}`}
-          onClick={() => onDeleteFromCatalog(catalogItem.id)}
-        >
-          Delete From Catalog
-        </button>
+        <>
+          <button
+            data-testid={`delete-from-catalog-${line.id}`}
+            onClick={() => onDeleteFromCatalog(catalogItem.id)}
+          >
+            Delete From Catalog
+          </button>
+          <button
+            data-testid={`edit-catalog-${line.id}`}
+            onClick={() => onEditCatalogItem(catalogItem.id)}
+          >
+            Edit Catalog
+          </button>
+        </>
       )}
     </div>
   ),
@@ -228,6 +285,8 @@ describe('GroceryListView', () => {
       onAddItemToLists: jest.fn().mockResolvedValue(undefined),
       onAddExistingItem: jest.fn().mockResolvedValue(['list-a', 'list-b']),
       onDeleteFromCatalog: jest.fn().mockResolvedValue(undefined),
+      onUpdateCatalogItem: jest.fn().mockResolvedValue(undefined),
+      onUpdateListLine: jest.fn().mockResolvedValue(undefined),
       ...overrides,
     };
   }
@@ -503,5 +562,100 @@ describe('GroceryListView', () => {
         variant: 'destructive',
       }),
     );
+  });
+
+  it('keeps the catalog edit dialog open, shows an error toast, and clears loading when the update rejects', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const line = makeLine('ln1', 'c1');
+    const list = makeList('list1', 'Weekly', [line]);
+    const props = makeBaseProps({
+      onUpdateCatalogItem: jest.fn().mockRejectedValue(new Error('boom')),
+    });
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[catalogItem]}
+        allLists={[list]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('edit-catalog-ln1'));
+    fireEvent.click(screen.getByTestId('catalog-item-edit-submit'));
+
+    await waitFor(() => {
+      expect(props.onUpdateCatalogItem).toHaveBeenCalledWith({
+        id: 'c1',
+        name: 'Updated Milk',
+        category: 'dairy',
+        price: 4.5,
+      });
+      expect(screen.getByTestId('catalog-item-edit-dialog')).toHaveAttribute(
+        'data-loading',
+        'false',
+      );
+    });
+    expect(screen.getByTestId('catalog-item-edit-dialog')).toBeInTheDocument();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Error', variant: 'destructive' }),
+    );
+  });
+
+  it('keeps the list-line edit dialog open, shows an error toast, and clears loading when the update rejects', async () => {
+    const catalogItem = makeCatalogItem('c1', 'Milk');
+    const line = makeLine('ln1', 'c1');
+    const list = makeList('list1', 'Weekly', [line]);
+    const props = makeBaseProps({
+      onUpdateListLine: jest.fn().mockRejectedValue(new Error('boom')),
+    });
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[catalogItem]}
+        allLists={[list]}
+        {...props}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('edit-line-ln1'));
+    fireEvent.click(screen.getByTestId('list-line-edit-submit'));
+
+    await waitFor(() => {
+      expect(props.onUpdateListLine).toHaveBeenCalledWith('list1', {
+        id: 'ln1',
+        amount: '3 cartons',
+      });
+      expect(screen.getByTestId('list-line-edit-dialog')).toHaveAttribute(
+        'data-loading',
+        'false',
+      );
+    });
+    expect(screen.getByTestId('list-line-edit-dialog')).toBeInTheDocument();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Error', variant: 'destructive' }),
+    );
+  });
+
+  it('renders the empty-list state with no active or checked lines', () => {
+    const list = makeList('list1', 'Weekly');
+
+    render(
+      <GroceryListView
+        list={list}
+        catalog={[]}
+        allLists={[list]}
+        {...makeBaseProps()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Weekly' })).toBeInTheDocument();
+    expect(
+      screen.getByText('0 active · 0 checked · $0.00 known'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('No items yet')).toBeInTheDocument();
+    expect(screen.getByText('Use Add Item to get started')).toBeInTheDocument();
+    expect(screen.queryByTestId(/^line-row-/)).not.toBeInTheDocument();
   });
 });

--- a/libs/web/pages/groceries/src/groceries-list-detail/__tests__/LinksInput.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/__tests__/LinksInput.spec.tsx
@@ -1,6 +1,7 @@
 /** Mocking rule: place jest.mock calls before any imports */
 jest.mock('@myorganizer/web-ui', () => {
   const React = require('react');
+  const { Controller } = require('react-hook-form');
 
   function Input(props: any) {
     // Render a plain input so react-hook-form register props (name, onChange, ref) work
@@ -13,9 +14,57 @@ jest.mock('@myorganizer/web-ui', () => {
     return <button {...props}>{children}</button>;
   }
 
+  function FormField({ name, render, ...props }: any) {
+    return (
+      <Controller
+        name={name}
+        render={({ field }: any) =>
+          render({
+            field: {
+              ...field,
+              onChange: (event: any) => {
+                field.onChange(event);
+                const links = [...(props.control._formValues.links ?? [])];
+                const index = Number(name.split('.').pop());
+                links[index] = event.target.value;
+                props.control.register('links').onChange({
+                  target: { name: 'links', value: links },
+                });
+              },
+            },
+          })
+        }
+        {...props}
+      />
+    );
+  }
+
+  function FormItem({ children, ...props }: any) {
+    return <div {...props}>{children}</div>;
+  }
+
+  function FormControl({ children, ...props }: any) {
+    return React.cloneElement(React.Children.only(children), {
+      ...props,
+    });
+  }
+
+  function FormLabel({ children, ...props }: any) {
+    return <label {...props}>{children}</label>;
+  }
+
+  function FormMessage({ children, ...props }: any) {
+    return children ? <p {...props}>{children}</p> : null;
+  }
+
   return {
     Input,
     Button,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
   };
 });
 

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/AddExistingItemDialog.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/AddExistingItemDialog.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import type { CatalogItem, GroceryList } from '@myorganizer/core';
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  Input,
+  Label,
+  cn,
+} from '@myorganizer/web-ui';
+import { Lock, Search } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getCategoryEmoji } from '../../shared/constants/categories';
+import { formatMoney } from '../../shared/utils';
+
+interface AddExistingItemDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  catalog: CatalogItem[];
+  lists: GroceryList[];
+  defaultListId?: string;
+  onAdd: (
+    catalogItemId: string,
+    listIds: string[],
+    amount?: string,
+  ) => Promise<void>;
+  isLoading?: boolean;
+}
+
+/**
+ * Lets the user attach an EXISTING Catalog Item as a new List Line to one or
+ * many Grocery Lists at once, without duplicating the Catalog Item's identity.
+ */
+export function AddExistingItemDialog({
+  isOpen,
+  onClose,
+  catalog,
+  lists,
+  defaultListId,
+  onAdd,
+  isLoading = false,
+}: AddExistingItemDialogProps) {
+  const [query, setQuery] = useState('');
+  const [selectedCatalogItemId, setSelectedCatalogItemId] = useState<
+    string | null
+  >(null);
+  const [selectedListIds, setSelectedListIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [amount, setAmount] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setQuery('');
+    setSelectedCatalogItemId(null);
+    setAmount('');
+    setSelectedListIds(new Set(defaultListId ? [defaultListId] : []));
+  }, [isOpen, defaultListId]);
+
+  const filteredCatalog = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return catalog;
+    return catalog.filter((item) => item.name.toLowerCase().includes(trimmed));
+  }, [catalog, query]);
+
+  const handleSelectCatalogItem = useCallback((catalogItemId: string) => {
+    setSelectedCatalogItemId(catalogItemId);
+  }, []);
+
+  const handleToggleList = useCallback((listId: string) => {
+    setSelectedListIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(listId)) {
+        next.delete(listId);
+      } else {
+        next.add(listId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const canSubmit =
+    !isLoading && selectedCatalogItemId !== null && selectedListIds.size > 0;
+
+  const handleSubmit = useCallback(async () => {
+    if (!selectedCatalogItemId || selectedListIds.size === 0) return;
+    try {
+      await onAdd(
+        selectedCatalogItemId,
+        Array.from(selectedListIds),
+        amount || undefined,
+      );
+      onClose();
+    } catch (err) {
+      console.error('Failed to add existing catalog item to lists:', err);
+    }
+  }, [selectedCatalogItemId, selectedListIds, amount, onAdd, onClose]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="w-[calc(100%-2rem)] max-w-xl p-0 gap-0 overflow-hidden">
+        <div className="px-6 py-5 border-b border-border-muted">
+          <div className="flex items-start gap-3 mb-1">
+            <h2 className="text-xl font-semibold text-primary">
+              Add From Catalog
+            </h2>
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-primary-container text-action-cyan rounded-full border border-action-cyan/20 text-[10px] font-bold tracking-wider uppercase shrink-0 mt-0.5">
+              <Lock className="w-3 h-3" />
+              Encrypted Data
+            </span>
+          </div>
+          <p className="text-sm text-on-surface-variant">
+            Attach an existing Catalog Item to one or more Grocery Lists.
+          </p>
+        </div>
+
+        <div className="px-6 py-5 space-y-5 max-h-[60vh] overflow-y-auto">
+          {catalog.length === 0 ? (
+            <div className="rounded-lg border border-outline-variant bg-surface-container-low p-6 text-center">
+              <p className="text-sm text-on-surface-variant">
+                There are no Catalog Items yet. Use "Add Item" to create one
+                first.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="add-existing-item-search"
+                  className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide"
+                >
+                  Catalog Item
+                </Label>
+                <div className="relative">
+                  <Search className="absolute left-3 top-2.5 h-4 w-4 text-on-surface-variant" />
+                  <Input
+                    id="add-existing-item-search"
+                    placeholder="Search catalog by name..."
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    disabled={isLoading}
+                    className="pl-9 text-base md:text-sm"
+                  />
+                </div>
+
+                <div
+                  role="radiogroup"
+                  aria-label="Select a Catalog Item"
+                  className="mt-2 max-h-60 overflow-y-auto rounded-lg border border-outline-variant divide-y divide-outline-variant"
+                >
+                  {filteredCatalog.length === 0 ? (
+                    <p className="px-3 py-4 text-sm text-on-surface-variant">
+                      No Catalog Items match "{query}".
+                    </p>
+                  ) : (
+                    filteredCatalog.map((item) => {
+                      const isSelected = item.id === selectedCatalogItemId;
+                      return (
+                        <button
+                          key={item.id}
+                          type="button"
+                          role="radio"
+                          aria-checked={isSelected}
+                          onClick={() => handleSelectCatalogItem(item.id)}
+                          disabled={isLoading}
+                          className={cn(
+                            'flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors disabled:pointer-events-none disabled:opacity-50',
+                            isSelected
+                              ? 'bg-secondary-fixed/20'
+                              : 'hover:bg-surface-container-low',
+                          )}
+                        >
+                          <span
+                            className="text-lg shrink-0 leading-none"
+                            aria-hidden="true"
+                          >
+                            {getCategoryEmoji(item.category)}
+                          </span>
+                          <span className="grow min-w-0 truncate text-sm font-medium text-on-surface">
+                            {item.name}
+                          </span>
+                          {typeof item.price === 'number' && (
+                            <span className="shrink-0 text-xs font-medium text-on-surface-variant">
+                              {formatMoney(item.price)}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide">
+                  Add to Lists
+                </Label>
+                <div className="space-y-2 rounded-lg border border-outline-variant p-3">
+                  {lists.length === 0 ? (
+                    <p className="text-sm text-on-surface-variant">
+                      There are no Grocery Lists yet.
+                    </p>
+                  ) : (
+                    lists.map((list) => (
+                      <label
+                        key={list.id}
+                        className="flex items-center gap-2 text-sm text-on-surface"
+                      >
+                        <Checkbox
+                          checked={selectedListIds.has(list.id)}
+                          onCheckedChange={() => handleToggleList(list.id)}
+                          disabled={isLoading}
+                          aria-label={`Add to ${list.name}`}
+                        />
+                        {list.name}
+                      </label>
+                    ))
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="add-existing-item-amount"
+                  className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide"
+                >
+                  Amount{' '}
+                  <span className="text-xs normal-case font-normal text-text-muted">
+                    (optional)
+                  </span>
+                </Label>
+                <Input
+                  id="add-existing-item-amount"
+                  placeholder="e.g. 2, 500g"
+                  value={amount}
+                  onChange={(event) => setAmount(event.target.value)}
+                  disabled={isLoading}
+                  className="text-base md:text-sm"
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="px-6 py-4 bg-surface-container-low border-t border-border-muted flex items-center justify-end gap-3">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="gap-2"
+          >
+            Add to Lists
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/AddItemDialog.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/AddItemDialog.tsx
@@ -1,57 +1,30 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import type { GroceryCategoryType } from '@myorganizer/core';
-import { GROCERY_PREDEFINED_CATEGORIES } from '@myorganizer/core';
+import type { CatalogItem, GroceryCategoryType } from '@myorganizer/core';
 import {
   Button,
   Dialog,
   DialogContent,
-  Input,
-  Label,
-  cn,
+  DialogDescription,
+  DialogTitle,
+  Form,
 } from '@myorganizer/web-ui';
 import { Info, Lock } from 'lucide-react';
-import { Controller, useForm } from 'react-hook-form';
-import { z } from 'zod';
+import { useCallback, useMemo, useState } from 'react';
+import type { ChangeEvent, KeyboardEvent } from 'react';
+import { useForm } from 'react-hook-form';
 import {
-  CATEGORY_EMOJIS,
-  CATEGORY_LABELS,
-  CATEGORY_ORDER,
-} from '../../shared/constants/categories';
-import { LinksInput } from './LinksInput';
-
-const addItemSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, 'Item name is required')
-    .max(200, 'Item name must be 200 characters or less'),
-  category: z.enum(GROCERY_PREDEFINED_CATEGORIES),
-  amount: z.string().max(50, 'Amount must be 50 characters or less'),
-  price: z
-    .string()
-    .refine(
-      (val) => val === '' || !isNaN(parseFloat(val)),
-      'Price must be a valid number',
-    )
-    .refine((val) => {
-      if (val === '') return true;
-      const num = parseFloat(val);
-      return num >= 0 && num < 100_000;
-    }, 'Price must be between 0 and 99,999'),
-  notes: z.string().max(1000, 'Notes must be 1000 characters or less'),
-  imageUrl: z.string().url('Must be a valid URL').or(z.literal('')),
-  links: z
-    .array(z.string().url('Each link must be a valid URL'))
-    .max(10, 'Maximum 10 links allowed'),
-});
-
-type AddItemFormValues = z.infer<typeof addItemSchema>;
+  AddItemDetailsFields,
+  AddItemMetadataFields,
+  addItemSchema,
+} from './AddItemFormFields';
+import type { AddItemFormValues } from './AddItemFormFields';
 
 export interface AddItemFormResult {
   name: string;
   category: GroceryCategoryType;
+  catalogItemId?: string;
   amount?: string;
   price?: number;
   notes?: string;
@@ -64,21 +37,22 @@ interface AddItemDialogProps {
   onClose: () => void;
   onAdd: (values: AddItemFormResult) => Promise<void>;
   isLoading?: boolean;
+  catalog?: CatalogItem[];
 }
 
-/**
- * Rich "Add New Item" dialog matching the Secure Modernism design.
- * Fields: name (required), category (icon grid), amount, price, notes.
- */
 export function AddItemDialog({
   isOpen,
   onClose,
   onAdd,
   isLoading = false,
+  catalog = [],
 }: AddItemDialogProps) {
+  const [activeSuggestion, setActiveSuggestion] = useState(0);
+  const [selectedCatalogItemId, setSelectedCatalogItemId] = useState<
+    string | undefined
+  >();
   const form = useForm<AddItemFormValues>({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resolver: zodResolver(addItemSchema, undefined, { mode: 'sync' }) as any,
+    resolver: zodResolver(addItemSchema, undefined, { mode: 'sync' }),
     mode: 'onChange',
     defaultValues: {
       name: '',
@@ -91,282 +65,173 @@ export function AddItemDialog({
     },
   });
 
+  const nameValue = form.watch('name');
+  const selectedCategory = form.watch('category');
+  const imageUrl = form.watch('imageUrl');
+  const matchingCatalogItems = useMemo(() => {
+    const query = nameValue.trim().toLowerCase();
+    if (!query) return [];
+    return catalog
+      .filter((item) => item.name.toLowerCase().includes(query))
+      .slice(0, 8);
+  }, [catalog, nameValue]);
+
+  const handleSelectCatalogItem = useCallback(
+    (item: CatalogItem) => {
+      setSelectedCatalogItemId(item.id);
+      form.setValue('name', item.name, { shouldValidate: true });
+      form.setValue('category', item.category, { shouldValidate: true });
+      form.setValue(
+        'price',
+        item.price === undefined ? '' : String(item.price),
+        {
+          shouldValidate: true,
+        },
+      );
+      setActiveSuggestion(0);
+    },
+    [form],
+  );
+
+  const handleNameChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setSelectedCatalogItemId(undefined);
+      setActiveSuggestion(0);
+      form.setValue('name', event.target.value, { shouldValidate: true });
+    },
+    [form],
+  );
+
+  const handleNameKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (matchingCatalogItems.length === 0) return;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveSuggestion((index) =>
+          Math.min(index + 1, matchingCatalogItems.length - 1),
+        );
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveSuggestion((index) => Math.max(index - 1, 0));
+      } else if (
+        event.key === 'Enter' &&
+        matchingCatalogItems[activeSuggestion]
+      ) {
+        event.preventDefault();
+        handleSelectCatalogItem(matchingCatalogItems[activeSuggestion]);
+      } else if (event.key === 'Escape') {
+        setActiveSuggestion(0);
+      }
+    },
+    [activeSuggestion, handleSelectCatalogItem, matchingCatalogItems],
+  );
+
+  const resetForm = useCallback(() => {
+    form.reset();
+    setSelectedCatalogItemId(undefined);
+    setActiveSuggestion(0);
+  }, [form]);
+
   const handleSubmit = form.handleSubmit(async (values) => {
     try {
       await onAdd({
         name: values.name,
         category: values.category,
+        ...(selectedCatalogItemId
+          ? { catalogItemId: selectedCatalogItemId }
+          : {}),
         amount: values.amount || undefined,
-        price: values.price ? parseFloat(values.price) : undefined,
+        price: values.price ? Number(values.price) : undefined,
         notes: values.notes || undefined,
         imageUrl: values.imageUrl || undefined,
         links: values.links?.length ? values.links : undefined,
       });
-      form.reset();
+      resetForm();
       onClose();
     } catch (err) {
       console.error('Failed to add item:', err);
     }
   });
 
-  const handleOpenChange = (open: boolean) => {
-    if (!open) {
-      form.reset();
-      onClose();
-    }
-  };
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        resetForm();
+        onClose();
+      }
+    },
+    [onClose, resetForm],
+  );
 
-  const selectedCategory = form.watch('category');
-  const watchImageUrl = form.watch('imageUrl');
-  const isValidImageUrl = watchImageUrl && watchImageUrl.startsWith('http');
+  const handleCancel = useCallback(() => {
+    handleOpenChange(false);
+  }, [handleOpenChange]);
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="w-[calc(100%-2rem)] max-w-xl p-0 gap-0 overflow-hidden">
-        <form onSubmit={handleSubmit}>
-          {/* Header */}
-          <div className="px-6 py-5 border-b border-border-muted">
-            <div className="flex items-start gap-3 mb-1">
-              <h2 className="text-xl font-semibold text-primary">
-                Add New Item
-              </h2>
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-primary-container text-action-cyan rounded-full border border-action-cyan/20 text-[10px] font-bold tracking-wider uppercase shrink-0 mt-0.5">
-                <Lock className="w-3 h-3" />
-                Encrypted Data
-              </span>
-            </div>
-            <p className="text-sm text-on-surface-variant">
-              Stored securely in your private vault.
-            </p>
-          </div>
-
-          {/* Body */}
-          <div className="px-6 py-5 space-y-5 max-h-[60vh] overflow-y-auto">
-            {/* Item Name */}
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="add-item-name"
-                className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide"
-              >
-                Item Name <span className="text-error">*</span>
-              </Label>
-              <Input
-                id="add-item-name"
-                placeholder="e.g. Organic Almond Milk"
-                {...form.register('name')}
-                disabled={isLoading}
-                maxLength={200}
-                autoFocus
-                className="text-base md:text-sm"
-              />
-              {form.formState.errors.name && (
-                <p className="text-xs text-error">
-                  {form.formState.errors.name.message}
-                </p>
-              )}
+      <DialogContent className="w-[calc(100%-2rem)] max-w-xl gap-0 overflow-hidden p-0">
+        <Form {...form}>
+          <form onSubmit={handleSubmit}>
+            <div className="border-b border-border-muted px-6 py-5">
+              <div className="mb-1 flex items-start gap-3">
+                <DialogTitle className="text-xl font-semibold text-primary">
+                  Add New Item
+                </DialogTitle>
+                <span className="mt-0.5 inline-flex shrink-0 items-center gap-1 rounded-full border border-action-cyan/20 bg-primary-container px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-action-cyan">
+                  <Lock className="h-3 w-3" />
+                  Encrypted Data
+                </span>
+              </div>
+              <DialogDescription className="text-sm text-on-surface-variant">
+                Stored securely in your private vault.
+              </DialogDescription>
             </div>
 
-            {/* Category */}
-            <div className="space-y-1.5">
-              <Label className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide">
-                Category
-              </Label>
-              <Controller
+            <div className="max-h-[60vh] space-y-5 overflow-y-auto px-6 py-5">
+              <AddItemMetadataFields
                 control={form.control}
-                name="category"
-                render={({ field }) => (
-                  <div className="grid grid-cols-4 gap-2">
-                    {CATEGORY_ORDER.map((cat) => (
-                      <button
-                        key={cat}
-                        type="button"
-                        onClick={() => field.onChange(cat)}
-                        className={cn(
-                          'flex flex-col items-center justify-center p-2 rounded-lg transition-all text-center',
-                          selectedCategory === cat
-                            ? 'border-2 border-secondary bg-secondary-fixed/20'
-                            : 'border border-outline-variant bg-surface-bright hover:border-secondary',
-                        )}
-                      >
-                        <span className="text-lg mb-0.5" aria-hidden="true">
-                          {CATEGORY_EMOJIS[cat]}
-                        </span>
-                        <span
-                          className={cn(
-                            'text-[10px] font-medium leading-tight',
-                            selectedCategory === cat
-                              ? 'font-bold text-secondary'
-                              : 'text-on-surface-variant',
-                          )}
-                        >
-                          {CATEGORY_LABELS[cat]}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
+                matchingCatalogItems={matchingCatalogItems}
+                activeSuggestion={activeSuggestion}
+                selectedCategory={selectedCategory}
+                onNameChange={handleNameChange}
+                onNameKeyDown={handleNameKeyDown}
+                onSelectCatalogItem={handleSelectCatalogItem}
+                isLoading={isLoading}
+              />
+              <AddItemDetailsFields
+                control={form.control}
+                imageUrl={imageUrl}
+                isLoading={isLoading}
               />
             </div>
 
-            {/* Amount + Price */}
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-1.5">
-                <Label
-                  htmlFor="add-item-amount"
-                  className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide"
-                >
-                  Quantity / Amount
-                </Label>
-                <Input
-                  id="add-item-amount"
-                  placeholder="e.g. 2, 500g"
-                  {...form.register('amount')}
+            <div className="flex items-center justify-between border-t border-border-muted bg-surface-container-low px-6 py-4">
+              <div className="flex items-center gap-1.5 text-on-surface-variant opacity-60">
+                <Info className="h-3.5 w-3.5" />
+                <span className="text-[11px] font-medium">
+                  Auto-syncs across shared devices
+                </span>
+              </div>
+              <div className="flex gap-3">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={handleCancel}
                   disabled={isLoading}
-                  className="text-base md:text-sm"
-                />
-                {form.formState.errors.amount && (
-                  <p className="text-xs text-error">
-                    {form.formState.errors.amount.message}
-                  </p>
-                )}
-              </div>
-
-              <div className="space-y-1.5">
-                <Label
-                  htmlFor="add-item-price"
-                  className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide"
                 >
-                  Estimated Price
-                </Label>
-                <div className="relative">
-                  <span className="absolute left-3 top-2.5 text-on-surface-variant font-bold text-sm">
-                    $
-                  </span>
-                  <Input
-                    id="add-item-price"
-                    placeholder="0.00"
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    {...form.register('price')}
-                    disabled={isLoading}
-                    className="pl-6 text-base md:text-sm"
-                  />
-                </div>
-                {form.formState.errors.price && (
-                  <p className="text-xs text-error">
-                    {form.formState.errors.price.message}
-                  </p>
-                )}
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isLoading || !form.formState.isValid}
+                  className="gap-2"
+                >
+                  Add to List
+                </Button>
               </div>
             </div>
-
-            {/* Notes */}
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="add-item-notes"
-                className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide"
-              >
-                Notes
-              </Label>
-              <textarea
-                id="add-item-notes"
-                placeholder="Add specific brands, sizes or dietary requirements..."
-                {...form.register('notes')}
-                disabled={isLoading}
-                rows={3}
-                maxLength={1000}
-                className="w-full px-3 py-2 border border-outline-variant rounded-lg text-base md:text-sm resize-none focus:outline-none focus:ring-2 focus:ring-secondary bg-surface-bright"
-              />
-              {form.formState.errors.notes && (
-                <p className="text-xs text-error">
-                  {form.formState.errors.notes.message}
-                </p>
-              )}
-            </div>
-
-            {/* Image URL */}
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="add-item-imageUrl"
-                className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide"
-              >
-                Image URL{' '}
-                <span className="text-xs normal-case font-normal text-text-muted">
-                  (optional)
-                </span>
-              </Label>
-              <Input
-                id="add-item-imageUrl"
-                placeholder="https://example.com/image.jpg"
-                type="url"
-                {...form.register('imageUrl')}
-                disabled={isLoading}
-                className="text-base md:text-sm"
-              />
-              {form.formState.errors.imageUrl && (
-                <p className="text-xs text-error">
-                  {form.formState.errors.imageUrl.message}
-                </p>
-              )}
-              {isValidImageUrl && (
-                <div className="mt-2 rounded-lg overflow-hidden border border-outline-variant">
-                  <img
-                    src={watchImageUrl}
-                    alt="Item preview"
-                    className="max-w-xs max-h-48 rounded"
-                    onError={(e) => {
-                      e.currentTarget.style.display = 'none';
-                    }}
-                  />
-                </div>
-              )}
-            </div>
-
-            {/* Links */}
-            <div className="space-y-1.5">
-              <Label className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide">
-                Links{' '}
-                <span className="text-xs normal-case font-normal text-text-muted">
-                  (optional, max 10)
-                </span>
-              </Label>
-              <LinksInput control={form.control} />
-              {form.formState.errors.links && (
-                <p className="text-xs text-error">
-                  {form.formState.errors.links.message}
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* Footer */}
-          <div className="px-6 py-4 bg-surface-container-low border-t border-border-muted flex items-center justify-between">
-            <div className="flex items-center gap-1.5 text-on-surface-variant opacity-60">
-              <Info className="h-3.5 w-3.5" />
-              <span className="text-[11px] font-medium">
-                Auto-syncs across shared devices
-              </span>
-            </div>
-            <div className="flex gap-3">
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => handleOpenChange(false)}
-                disabled={isLoading}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                disabled={isLoading || !form.formState.isValid}
-                className="gap-2"
-              >
-                Add to List
-              </Button>
-            </div>
-          </div>
-        </form>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/AddItemFormFields.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/AddItemFormFields.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import type { CatalogItem } from '@myorganizer/core';
+import { GROCERY_PREDEFINED_CATEGORIES } from '@myorganizer/core';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  cn,
+} from '@myorganizer/web-ui';
+import type { Control } from 'react-hook-form';
+import { useCallback } from 'react';
+import type {
+  ChangeEvent,
+  KeyboardEvent,
+  MouseEvent,
+  SyntheticEvent,
+} from 'react';
+import { z } from 'zod';
+import { LinksInput } from './LinksInput';
+import {
+  CATEGORY_EMOJIS,
+  CATEGORY_LABELS,
+  CATEGORY_ORDER,
+} from '../../shared/constants/categories';
+
+export const addItemSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Item name is required')
+    .max(200, 'Item name must be 200 characters or less'),
+  category: z.enum(GROCERY_PREDEFINED_CATEGORIES),
+  amount: z
+    .string()
+    .max(50, 'Amount must be 50 characters or less')
+    .refine((value) => {
+      if (value === '') return true;
+      const trimmed = value.trim();
+      const numericPart = trimmed.match(/^\d+(?:[.,]\d+)?/)?.[0];
+      return (
+        /^\d+(?:[.,]\d+)?(?:\s*[a-zA-Z]+(?:\s+[a-zA-Z]+)*)?$/.test(trimmed) &&
+        numericPart !== undefined &&
+        Number.isFinite(Number(numericPart.replace(',', '.'))) &&
+        Number(numericPart.replace(',', '.')) >= 0
+      );
+    }, 'Quantity must be a valid non-negative number or a value such as 500g or 1 dozen'),
+  price: z
+    .string()
+    .refine(
+      (value) =>
+        value === '' ||
+        (/^\+?(?:\d+(?:\.\d*)?|\.\d+)$/.test(value.trim()) &&
+          Number.isFinite(Number(value)) &&
+          Number(value) >= 0),
+      'Price must be a valid number',
+    )
+    .refine(
+      (value) =>
+        value === '' || (Number(value) >= 0 && Number(value) < 100_000),
+      'Price must be between 0 and 99,999',
+    ),
+  notes: z.string().max(1000, 'Notes must be 1000 characters or less'),
+  imageUrl: z.string().url('Must be a valid URL').or(z.literal('')),
+  links: z
+    .array(z.string().url('Each link must be a valid URL'))
+    .max(10, 'Maximum 10 links allowed'),
+});
+
+export type AddItemFormValues = z.infer<typeof addItemSchema>;
+
+interface AddItemMetadataFieldsProps {
+  control: Control<AddItemFormValues>;
+  matchingCatalogItems: CatalogItem[];
+  activeSuggestion: number;
+  selectedCategory: AddItemFormValues['category'];
+  onNameChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onNameKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  onSelectCatalogItem: (item: CatalogItem) => void;
+  isLoading: boolean;
+}
+
+interface CategoryButtonsProps {
+  onChange: (value: AddItemFormValues['category']) => void;
+  selectedCategory: AddItemFormValues['category'];
+  isLoading: boolean;
+}
+
+function CategoryButtons({
+  onChange,
+  selectedCategory,
+  isLoading,
+}: CategoryButtonsProps) {
+  const handleCategoryClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      const category = event.currentTarget.dataset.category;
+      if (category) {
+        onChange(category as AddItemFormValues['category']);
+      }
+    },
+    [onChange],
+  );
+
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {CATEGORY_ORDER.map((cat) => (
+        <button
+          key={cat}
+          type="button"
+          role="radio"
+          aria-checked={selectedCategory === cat}
+          data-category={cat}
+          onClick={handleCategoryClick}
+          disabled={isLoading}
+          className={cn(
+            'flex flex-col items-center justify-center rounded-lg p-2 text-center transition-all',
+            selectedCategory === cat
+              ? 'border-2 border-secondary bg-secondary-fixed/20'
+              : 'border border-outline-variant bg-surface-bright hover:border-secondary',
+          )}
+        >
+          <span className="mb-0.5 text-lg" aria-hidden="true">
+            {CATEGORY_EMOJIS[cat]}
+          </span>
+          <span
+            className={cn(
+              'text-[10px] font-medium leading-tight',
+              selectedCategory === cat
+                ? 'font-bold text-secondary'
+                : 'text-on-surface-variant',
+            )}
+          >
+            {CATEGORY_LABELS[cat]}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function AddItemMetadataFields({
+  control,
+  matchingCatalogItems,
+  activeSuggestion,
+  selectedCategory,
+  onNameChange,
+  onNameKeyDown,
+  onSelectCatalogItem,
+  isLoading,
+}: AddItemMetadataFieldsProps) {
+  const handleSuggestionMouseDown = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+    },
+    [],
+  );
+
+  const handleSuggestionClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      const itemId = event.currentTarget.dataset.catalogItemId;
+      const item = matchingCatalogItems.find(
+        (catalogItem) => catalogItem.id === itemId,
+      );
+      if (item) {
+        onSelectCatalogItem(item);
+      }
+    },
+    [matchingCatalogItems, onSelectCatalogItem],
+  );
+
+  return (
+    <>
+      <FormField
+        control={control}
+        name="name"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+              Item Name <span className="text-error">*</span>
+            </FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                placeholder="e.g. Organic Almond Milk"
+                role="combobox"
+                aria-autocomplete="list"
+                aria-controls="add-item-name-suggestions"
+                aria-expanded={matchingCatalogItems.length > 0}
+                aria-activedescendant={
+                  matchingCatalogItems[activeSuggestion]
+                    ? `catalog-suggestion-${matchingCatalogItems[activeSuggestion].id}`
+                    : undefined
+                }
+                autoComplete="off"
+                onChange={onNameChange}
+                onKeyDown={onNameKeyDown}
+                disabled={isLoading}
+                maxLength={200}
+                autoFocus
+                className="text-base md:text-sm"
+              />
+            </FormControl>
+            {matchingCatalogItems.length > 0 && (
+              <div
+                id="add-item-name-suggestions"
+                role="listbox"
+                aria-label="Existing catalog items"
+                className="rounded-lg border border-outline-variant bg-surface-bright"
+              >
+                {matchingCatalogItems.map((item, index) => (
+                  <button
+                    key={item.id}
+                    id={`catalog-suggestion-${item.id}`}
+                    type="button"
+                    role="option"
+                    aria-selected={index === activeSuggestion}
+                    data-catalog-item-id={item.id}
+                    onMouseDown={handleSuggestionMouseDown}
+                    onClick={handleSuggestionClick}
+                    disabled={isLoading}
+                    className={cn(
+                      'block w-full px-3 py-2 text-left text-sm text-on-surface hover:bg-surface-container-low',
+                      index === activeSuggestion && 'bg-surface-container-low',
+                    )}
+                  >
+                    <span className="font-medium">{item.name}</span>
+                    <span className="ml-2 text-xs text-on-surface-variant">
+                      {CATEGORY_LABELS[item.category]}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="category"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel
+              id="add-item-category-label"
+              className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant"
+            >
+              Category
+            </FormLabel>
+            <div role="radiogroup" aria-labelledby="add-item-category-label">
+              <CategoryButtons
+                onChange={field.onChange}
+                selectedCategory={selectedCategory}
+                isLoading={isLoading}
+              />
+            </div>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}
+
+interface AddItemDetailsFieldsProps {
+  control: Control<AddItemFormValues>;
+  imageUrl: string;
+  isLoading: boolean;
+}
+
+export function AddItemDetailsFields({
+  control,
+  imageUrl,
+  isLoading,
+}: AddItemDetailsFieldsProps) {
+  const handleImageError = useCallback(
+    (event: SyntheticEvent<HTMLImageElement>) => {
+      event.currentTarget.style.display = 'none';
+    },
+    [],
+  );
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-4">
+        <FormField
+          control={control}
+          name="amount"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+                Quantity / Amount
+              </FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder="e.g. 2, 500g"
+                  disabled={isLoading}
+                  className="text-base md:text-sm"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={control}
+          name="price"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+                Estimated Price
+              </FormLabel>
+              <div className="relative">
+                <span className="pointer-events-none absolute left-3 top-2.5 text-sm font-bold text-on-surface-variant">
+                  $
+                </span>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder="0.00"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    disabled={isLoading}
+                    className="pl-6 text-base md:text-sm"
+                  />
+                </FormControl>
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+
+      <FormField
+        control={control}
+        name="notes"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+              Notes
+            </FormLabel>
+            <FormControl>
+              <textarea
+                {...field}
+                placeholder="Add specific brands, sizes or dietary requirements..."
+                disabled={isLoading}
+                rows={3}
+                maxLength={1000}
+                className="w-full resize-none rounded-lg border border-outline-variant bg-surface-bright px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-secondary md:text-sm"
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="imageUrl"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+              Image URL{' '}
+              <span className="text-xs font-normal normal-case text-text-muted">
+                (optional)
+              </span>
+            </FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                placeholder="https://example.com/image.jpg"
+                type="url"
+                disabled={isLoading}
+                className="text-base md:text-sm"
+              />
+            </FormControl>
+            <FormMessage />
+            {imageUrl.startsWith('http') && (
+              <div className="mt-2 overflow-hidden rounded-lg border border-outline-variant">
+                <img
+                  src={imageUrl}
+                  alt="Item preview"
+                  className="max-h-48 max-w-xs rounded"
+                  onError={handleImageError}
+                />
+              </div>
+            )}
+          </FormItem>
+        )}
+      />
+
+      <FormItem>
+        <FormLabel className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+          Links{' '}
+          <span className="text-xs font-normal normal-case text-text-muted">
+            (optional, max 10)
+          </span>
+        </FormLabel>
+        <LinksInput control={control} disabled={isLoading} />
+      </FormItem>
+    </>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/CatalogItemEditDialog.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/CatalogItemEditDialog.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { CatalogItem, GroceryCategoryType } from '@myorganizer/core';
+import { GROCERY_PREDEFINED_CATEGORIES } from '@myorganizer/core';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  cn,
+} from '@myorganizer/web-ui';
+import { Lock } from 'lucide-react';
+import { useCallback, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import {
+  CATEGORY_EMOJIS,
+  CATEGORY_LABELS,
+  CATEGORY_ORDER,
+} from '../../shared/constants/categories';
+import { LinksInput } from './LinksInput';
+
+const catalogItemEditSchema = z.object({
+  name: z.string().trim().min(1, 'Item name is required').max(200),
+  category: z.enum(GROCERY_PREDEFINED_CATEGORIES),
+  price: z
+    .string()
+    .refine(
+      (value) =>
+        value === '' || (Number.isFinite(Number(value)) && Number(value) >= 0),
+      'Price must be a valid number',
+    ),
+  notes: z.string().max(1000),
+  imageUrl: z.string().url('Must be a valid URL').or(z.literal('')),
+  links: z.array(z.string().url('Each link must be a valid URL')).max(10),
+});
+
+type CatalogItemEditFormValues = z.infer<typeof catalogItemEditSchema>;
+
+export interface CatalogItemEditChanges {
+  id: string;
+  name: string;
+  category: GroceryCategoryType;
+  price?: number;
+  notes?: string;
+  imageUrl?: string;
+  links?: string[];
+}
+
+interface CatalogItemEditDialogProps {
+  item: CatalogItem | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (changes: CatalogItemEditChanges) => Promise<void>;
+  isLoading?: boolean;
+}
+
+export function CatalogItemEditDialog({
+  item,
+  isOpen,
+  onClose,
+  onSave,
+  isLoading = false,
+}: CatalogItemEditDialogProps) {
+  const form = useForm<CatalogItemEditFormValues>({
+    resolver: zodResolver(catalogItemEditSchema, undefined, { mode: 'sync' }),
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+      category: 'other',
+      price: '',
+      notes: '',
+      imageUrl: '',
+      links: [],
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      name: item?.name ?? '',
+      category: item?.category ?? 'other',
+      price: item?.price === undefined ? '' : String(item.price),
+      notes: item?.notes ?? '',
+      imageUrl: item?.imageUrl ?? '',
+      links: item?.links ?? [],
+    });
+  }, [form, item?.id]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    if (!item) return;
+    await onSave({
+      id: item.id,
+      name: values.name,
+      category: values.category,
+      price: values.price === '' ? undefined : Number(values.price),
+      notes: values.notes || undefined,
+      imageUrl: values.imageUrl || undefined,
+      links: values.links.length ? values.links : undefined,
+    });
+    onClose();
+  });
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const selectedCategory = form.watch('category');
+
+  return (
+    <Dialog open={isOpen && item !== null} onOpenChange={handleOpenChange}>
+      <DialogContent className="w-[calc(100%-2rem)] max-w-xl gap-0 overflow-hidden p-0">
+        <Form {...form}>
+          <form onSubmit={handleSubmit}>
+            <div className="border-b border-border-muted px-6 py-5">
+              <div className="mb-1 flex items-start gap-3">
+                <DialogTitle className="text-xl font-semibold text-primary">
+                  Edit Catalog Item
+                </DialogTitle>
+                <span className="mt-0.5 inline-flex items-center gap-1 rounded-full border border-action-cyan/20 bg-primary-container px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-action-cyan">
+                  <Lock className="h-3 w-3" /> Encrypted Data
+                </span>
+              </div>
+              <DialogDescription className="text-sm text-on-surface-variant">
+                Changes apply to this Catalog Item and are shared by every
+                Grocery List reference. Stored securely in your private vault.
+              </DialogDescription>
+            </div>
+            <div className="max-h-[60vh] space-y-5 overflow-y-auto px-6 py-5">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Catalog Item Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        autoFocus
+                        disabled={isLoading}
+                        maxLength={200}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="category"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel id="catalog-item-category-label">
+                      Category
+                    </FormLabel>
+                    <div
+                      className="grid grid-cols-4 gap-2"
+                      role="group"
+                      aria-labelledby="catalog-item-category-label"
+                    >
+                      {CATEGORY_ORDER.map((category) => (
+                        <button
+                          key={category}
+                          type="button"
+                          disabled={isLoading}
+                          aria-pressed={selectedCategory === category}
+                          onClick={() => field.onChange(category)}
+                          className={cn(
+                            'rounded-lg p-2 text-center',
+                            selectedCategory === category
+                              ? 'border-2 border-secondary bg-secondary-fixed/20'
+                              : 'border border-outline-variant bg-surface-bright',
+                          )}
+                        >
+                          <span aria-hidden="true">
+                            {CATEGORY_EMOJIS[category]}
+                          </span>
+                          <span className="ml-1 text-xs">
+                            {CATEGORY_LABELS[category]}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="grid grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="price"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Default Price</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          disabled={isLoading}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <FormField
+                control={form.control}
+                name="notes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Notes</FormLabel>
+                    <FormControl>
+                      <textarea
+                        {...field}
+                        rows={3}
+                        maxLength={1000}
+                        disabled={isLoading}
+                        className="w-full resize-none rounded-lg border border-outline-variant bg-surface-bright px-3 py-2"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="imageUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Image URL</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="url" disabled={isLoading} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormItem>
+                <FormLabel>Links</FormLabel>
+                <LinksInput control={form.control} disabled={isLoading} />
+                <FormMessage />
+              </FormItem>
+            </div>
+            <div className="flex justify-end gap-3 border-t border-border-muted bg-surface-container-low px-6 py-4">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={handleClose}
+                disabled={isLoading}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={isLoading || !form.formState.isValid}
+              >
+                Save Catalog Item
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/DeleteCatalogItemDialog.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/DeleteCatalogItemDialog.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import type { CatalogItem } from '@myorganizer/core';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from '@myorganizer/web-ui';
+import { AlertTriangle } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+interface DeleteCatalogItemDialogProps {
+  isOpen: boolean;
+  catalogItem: CatalogItem | null;
+  affectedListCount: number;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  isLoading?: boolean;
+}
+
+/**
+ * Strong-confirmation dialog for the "Delete From Catalog" domain action —
+ * permanently destroys a Catalog Item and every List Line referencing it
+ * across every Grocery List. Requires the user to type the item's exact
+ * name before the destructive action becomes available.
+ */
+export function DeleteCatalogItemDialog({
+  isOpen,
+  catalogItem,
+  affectedListCount,
+  onClose,
+  onConfirm,
+  isLoading = false,
+}: DeleteCatalogItemDialogProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [typedName, setTypedName] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) {
+      setTypedName('');
+    }
+  }, [isOpen]);
+
+  const handleClose = useCallback(() => {
+    setTypedName('');
+    onClose();
+  }, [onClose]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!catalogItem) return;
+    setConfirming(true);
+    try {
+      await onConfirm();
+    } finally {
+      setConfirming(false);
+    }
+  }, [catalogItem, onConfirm]);
+
+  const itemName = catalogItem?.name ?? '';
+  const isOpenWithItem = isOpen && catalogItem !== null;
+
+  const affectedMessage =
+    affectedListCount === 0
+      ? "It isn't currently on any other Grocery List."
+      : `This will also remove it from ${affectedListCount} other Grocery List${
+          affectedListCount === 1 ? '' : 's'
+        }.`;
+
+  const isConfirmMatch = catalogItem !== null && typedName.trim() === itemName;
+
+  return (
+    <Dialog
+      open={isOpenWithItem}
+      onOpenChange={(open) => !open && handleClose()}
+    >
+      <DialogContent className="w-[calc(100%-2rem)] md:max-w-md">
+        <DialogHeader>
+          <div className="mb-4 flex items-center justify-center">
+            <div className="rounded-full bg-error/10 p-3">
+              <AlertTriangle className="h-6 w-6 text-error" />
+            </div>
+          </div>
+          <DialogTitle>Delete "{itemName}" from Catalog?</DialogTitle>
+          <DialogDescription>
+            This action cannot be undone. Deleting this Catalog Item will
+            permanently remove it and every List Line referencing it.{' '}
+            {affectedMessage}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1.5">
+          <Label
+            htmlFor="delete-catalog-item-confirm"
+            className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide"
+          >
+            Type "{itemName}" to confirm
+          </Label>
+          <Input
+            id="delete-catalog-item-confirm"
+            value={typedName}
+            onChange={(event) => setTypedName(event.target.value)}
+            disabled={confirming || isLoading}
+            autoComplete="off"
+            className="text-base md:text-sm"
+          />
+        </div>
+
+        <DialogFooter className="gap-2 pt-2 sm:gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleClose}
+            disabled={confirming || isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={confirming || isLoading || !isConfirmMatch}
+          >
+            {confirming || isLoading ? 'Deleting...' : 'Delete From Catalog'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/GroceryListView.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/GroceryListView.tsx
@@ -1,419 +1,259 @@
 'use client';
 
-import type {
-  GroceryCategoryType,
-  GroceryItem,
-  GroceryList,
-} from '@myorganizer/core';
-import { randomId } from '@myorganizer/core';
-import { Button, useToast } from '@myorganizer/web-ui';
-import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
+import type { CatalogItem, GroceryList, ListLine } from '@myorganizer/core';
+import { ToastAction, useToast } from '@myorganizer/web-ui';
 import { useCallback, useMemo, useState } from 'react';
-import { CategoryFilterBar } from '../../shared/components/CategoryFilterBar';
-import {
-  CATEGORY_LABELS,
-  CATEGORY_ORDER,
-} from '../../shared/constants/categories';
+import type { AddCatalogItemAndLineInput } from '../../shared/hooks';
+import { summarizeListSpend } from '../../shared/utils';
 import type { AddItemFormResult } from './AddItemDialog';
 import { AddItemDialog } from './AddItemDialog';
-import { EditItemDialog } from './EditItemDialog';
-import { GroceryItemRow } from './GroceryItemRow';
+import { TripBoardLifecycleToolbar } from './TripBoardLifecycleToolbar';
+import { TripBoardLineRow } from './TripBoardLineRow';
+import { TripBoardSpendFooter } from './TripBoardSpendFooter';
 
 interface GroceryListViewProps {
   list: GroceryList;
-  masterKeyBytes: Uint8Array;
-  onListUpdated: (updated: GroceryList) => void;
+  catalog: CatalogItem[];
   onClose: () => void;
-  persistLists: (lists: GroceryList[]) => Promise<void>;
-  allLists: GroceryList[];
+  onToggleChecked: (listId: string, lineId: string) => Promise<void>;
+  onUncheckAll: (listId: string) => Promise<void>;
+  onRemoveChecked: (listId: string) => Promise<ListLine[]>;
+  onRestoreLines: (listId: string, lines: ListLine[]) => Promise<void>;
+  onDeleteLine: (listId: string, lineId: string) => Promise<void>;
+  onAddItem: (
+    listId: string,
+    input: AddCatalogItemAndLineInput,
+  ) => Promise<void>;
 }
 
 /**
- * Main grocery list view component
- * Displays and manages items within a selected list
+ * Trip Board detail view — manages the List Lines within a single Grocery
+ * List (Active vs Checked, spend summary, and lifecycle actions).
  */
 export function GroceryListView({
   list,
-  masterKeyBytes,
-  onListUpdated,
-  onClose,
-  persistLists,
-  allLists,
+  catalog,
+  onToggleChecked,
+  onUncheckAll,
+  onRemoveChecked,
+  onRestoreLines,
+  onDeleteLine,
+  onAddItem,
 }: GroceryListViewProps) {
   const { toast } = useToast();
-  const [editingItemId, setEditingItemId] = useState<string | null>(null);
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState<
-    GroceryCategoryType | 'all'
-  >('all');
 
-  const editingItem = list.items.find((item) => item.id === editingItemId);
+  const active = useMemo(
+    () => list.lines.filter((line) => !line.checked),
+    [list.lines],
+  );
+  const checked = useMemo(
+    () => list.lines.filter((line) => line.checked),
+    [list.lines],
+  );
+  const summary = useMemo(
+    () => summarizeListSpend(list.lines, catalog),
+    [list.lines, catalog],
+  );
 
-  /**
-   * Helper: update a single item and refresh updatedAt
-   */
-  const updateItem = (
-    items: GroceryItem[],
-    patch: Partial<GroceryItem> & { id: string },
-  ): GroceryItem[] =>
-    items.map((item) =>
-      item.id === patch.id
-        ? { ...item, ...patch, updatedAt: new Date().toISOString() }
-        : item,
-    );
+  const showErrorToast = useCallback(() => {
+    toast({
+      title: 'Error',
+      description: 'Failed to save your changes. Please try again.',
+      variant: 'destructive',
+    });
+  }, [toast]);
 
-  /**
-   * Persist changes to the vault
-   */
-  const persistChanges = useCallback(
-    async (updatedList: GroceryList) => {
+  const handleToggleChecked = useCallback(
+    async (lineId: string) => {
+      setIsLoading(true);
       try {
-        setIsLoading(true);
-        onListUpdated(updatedList);
-        const nextAllLists = allLists.map((l) =>
-          l.id === updatedList.id ? updatedList : l,
-        );
-        await persistLists(nextAllLists);
+        await onToggleChecked(list.id, lineId);
       } catch (err) {
-        console.error('Failed to persist changes:', err);
-        toast({
-          title: 'Error',
-          description: 'Failed to save your changes. Please try again.',
-          variant: 'destructive',
-        });
+        console.error('Failed to toggle list line:', err);
+        showErrorToast();
       } finally {
         setIsLoading(false);
       }
     },
-    [allLists, onListUpdated, persistLists, toast],
+    [list.id, onToggleChecked, showErrorToast],
   );
 
-  /**
-   * Add a new item to the list
-   */
+  const handleUncheckAll = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      await onUncheckAll(list.id);
+    } catch (err) {
+      console.error('Failed to uncheck all list lines:', err);
+      showErrorToast();
+    } finally {
+      setIsLoading(false);
+    }
+  }, [list.id, onUncheckAll, showErrorToast]);
+
+  const handleRemoveChecked = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const removed = await onRemoveChecked(list.id);
+      if (removed.length === 0) {
+        toast({
+          title: 'No checked items to remove.',
+        });
+        return;
+      }
+      toast({
+        title: 'Checked items removed',
+        description: `${removed.length} Checked Item${removed.length !== 1 ? 's' : ''} removed from this Grocery List.`,
+        action: (
+          <ToastAction
+            altText="Undo"
+            onClick={() => {
+              void onRestoreLines(list.id, removed);
+            }}
+          >
+            Undo
+          </ToastAction>
+        ),
+      });
+    } catch (err) {
+      console.error('Failed to remove checked list lines:', err);
+      showErrorToast();
+    } finally {
+      setIsLoading(false);
+    }
+  }, [list.id, onRemoveChecked, onRestoreLines, showErrorToast, toast]);
+
+  const handleDeleteLine = useCallback(
+    async (lineId: string) => {
+      setIsLoading(true);
+      try {
+        await onDeleteLine(list.id, lineId);
+      } catch (err) {
+        console.error('Failed to delete list line:', err);
+        showErrorToast();
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [list.id, onDeleteLine, showErrorToast],
+  );
+
   const handleAddItem = useCallback(
     async (values: AddItemFormResult) => {
-      const newItem: GroceryItem = {
-        id: randomId(),
-        name: values.name,
-        category: values.category,
-        amount: values.amount,
-        price: values.price,
-        notes: values.notes,
-        imageUrl: values.imageUrl,
-        links: values.links,
-        checked: false,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-
-      const updated: GroceryList = {
-        ...list,
-        items: [...list.items, newItem],
-        updatedAt: new Date().toISOString(),
-      };
-
-      await persistChanges(updated);
-      toast({
-        title: 'Item added',
-        description: `"${values.name}" has been added to your list.`,
-      });
-    },
-    [list, persistChanges, toast],
-  );
-
-  /**
-   * Toggle checked state of an item
-   */
-  const handleToggleChecked = useCallback(
-    async (id: string) => {
-      const item = list.items.find((i) => i.id === id);
-      if (!item) return;
-
-      const patched = updateItem(list.items, {
-        id,
-        checked: !item.checked,
-      });
-
-      const updated: GroceryList = {
-        ...list,
-        items: patched,
-        updatedAt: new Date().toISOString(),
-      };
-
-      await persistChanges(updated);
-    },
-    [list, persistChanges],
-  );
-
-  /**
-   * Edit an existing item
-   */
-  const handleEditItem = useCallback(
-    async (id: string, changes: Partial<GroceryItem>) => {
-      const patched = updateItem(list.items, {
-        id,
-        ...changes,
-      });
-
-      const updated: GroceryList = {
-        ...list,
-        items: patched,
-        updatedAt: new Date().toISOString(),
-      };
-
-      await persistChanges(updated);
-      setEditingItemId(null);
-
-      const itemName = list.items.find((i) => i.id === id)?.name || 'Item';
-      toast({
-        title: 'Item updated',
-        description: `"${itemName}" has been updated.`,
-      });
-    },
-    [list, persistChanges, toast],
-  );
-
-  /**
-   * Delete an item from the list
-   */
-  const handleDeleteItem = useCallback(
-    async (id: string) => {
-      const item = list.items.find((i) => i.id === id);
-      if (!item) return;
-
-      const patched = list.items.filter((i) => i.id !== id);
-
-      const updated: GroceryList = {
-        ...list,
-        items: patched,
-        updatedAt: new Date().toISOString(),
-      };
-
-      await persistChanges(updated);
-
-      toast({
-        title: 'Item deleted',
-        description: `"${item.name}" has been removed from your list.`,
-      });
-    },
-    [list, persistChanges, toast],
-  );
-
-  /**
-   * Clear all checked items
-   */
-  const handleClearChecked = useCallback(async () => {
-    const patched = list.items.filter((i) => !i.checked);
-    const checkedCount = list.items.length - patched.length;
-
-    if (checkedCount === 0) {
-      toast({
-        title: 'No items to clear',
-        description: 'There are no checked items to remove.',
-      });
-      return;
-    }
-
-    const updated: GroceryList = {
-      ...list,
-      items: patched,
-      updatedAt: new Date().toISOString(),
-    };
-
-    await persistChanges(updated);
-
-    toast({
-      title: 'Items cleared',
-      description: `${checkedCount} completed item${checkedCount !== 1 ? 's' : ''} removed.`,
-    });
-  }, [list, persistChanges, toast]);
-
-  // Filter items by selected category
-  const filteredItems = useMemo(() => {
-    return selectedCategory === 'all'
-      ? list.items
-      : list.items.filter((item) => item.category === selectedCategory);
-  }, [list.items, selectedCategory]);
-
-  // Group items by category in the order defined
-  const groupedItems = useMemo(() => {
-    const groups: Record<GroceryCategoryType, GroceryItem[]> = {} as Record<
-      GroceryCategoryType,
-      GroceryItem[]
-    >;
-
-    // Initialize all categories
-    CATEGORY_ORDER.forEach((cat) => {
-      groups[cat] = [];
-    });
-
-    // Group items
-    filteredItems.forEach((item) => {
-      const category = (item.category as GroceryCategoryType) || 'other';
-      if (!groups[category]) {
-        groups[category] = [];
+      setIsLoading(true);
+      try {
+        await onAddItem(list.id, values);
+        setIsAddDialogOpen(false);
+      } catch (err) {
+        console.error('Failed to add item to list:', err);
+        showErrorToast();
+      } finally {
+        setIsLoading(false);
       }
-      groups[category].push(item);
-    });
+    },
+    [list.id, onAddItem, showErrorToast],
+  );
 
-    // Return only non-empty categories in order
-    return CATEGORY_ORDER.filter((cat) => groups[cat].length > 0).map(
-      (cat) => ({
-        category: cat,
-        items: groups[cat],
-      }),
-    );
-  }, [filteredItems]);
+  const handleOpenAddDialog = useCallback(() => {
+    setIsAddDialogOpen(true);
+  }, []);
 
-  const checkedCount = filteredItems.filter((item) => item.checked).length;
-  const hasCheckedItems = checkedCount > 0;
-
-  // Get all categories that have items in this list
-  const categoriesWithItems = useMemo(() => {
-    const cats = new Set<GroceryCategoryType>();
-    list.items.forEach((item) => {
-      cats.add((item.category as GroceryCategoryType) || 'other');
-    });
-    return Array.from(cats);
-  }, [list.items]);
+  const handleCloseAddDialog = useCallback(() => {
+    setIsAddDialogOpen(false);
+  }, []);
 
   return (
-    <div className="space-y-lg px-md">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-md pb-md border-b border-outline-variant">
-        <div className="flex items-center gap-md grow">
-          <button
-            onClick={onClose}
-            className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-secondary hover:bg-secondary-container/20 transition-colors"
-            aria-label="Back to groceries"
-            type="button"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            <span className="hidden sm:inline">Back</span>
-          </button>
-
-          <div>
-            <h2 className="text-lg font-semibold text-on-surface md:text-xl">
-              {list.name}
-            </h2>
-            <p className="text-xs text-on-surface-variant">
-              {list.items.length} item{list.items.length !== 1 ? 's' : ''}
-            </p>
-          </div>
-        </div>
+    <div className="space-y-lg">
+      <div className="space-y-1 pb-md border-b border-outline-variant">
+        <h2 className="text-lg font-semibold text-on-surface md:text-xl">
+          {list.name}
+        </h2>
+        <p className="text-xs text-on-surface-variant">
+          {active.length} active · {checked.length} checked ·{' '}
+          {summary.known ? `$${summary.known.toFixed(2)}` : '$0.00'} known
+        </p>
       </div>
 
-      {/* Add Item Button */}
-      <Button
-        onClick={() => setIsAddDialogOpen(true)}
-        disabled={isLoading}
-        className="w-full gap-2 sm:w-auto"
-      >
-        <Plus className="h-4 w-4" />
-        Add Item
-      </Button>
-
-      {/* Category Filter Tabs */}
-      <div className="-mx-md px-md border-b border-outline-variant">
-        <CategoryFilterBar
-          items={list.items}
-          activeCategory={selectedCategory}
-          onCategoryChange={setSelectedCategory}
-        />
-      </div>
-
-      {/* Action Bar */}
-      {hasCheckedItems && (
-        <div className="flex justify-end">
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={handleClearChecked}
-            disabled={isLoading}
-            className="gap-2"
-          >
-            <Trash2 className="h-4 w-4" />
-            <span>Clear checked ({checkedCount})</span>
-          </Button>
-        </div>
-      )}
-
-      {/* Items List */}
-      {list.items.length === 0 ? (
-        <div className="text-center py-12">
-          <div className="inline-block rounded-full bg-secondary-container p-4 mb-4">
-            <svg
-              className="h-8 w-8 text-on-secondary-container"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"
-              />
-            </svg>
-          </div>
-          <h3 className="text-lg font-semibold text-on-surface mb-2">
-            No items yet
-          </h3>
-          <p className="text-sm text-on-surface-variant mb-6">
-            Add your first item to get started
-          </p>
-        </div>
-      ) : filteredItems.length === 0 ? (
-        <div className="text-center py-8">
-          <p className="text-sm text-on-surface-variant">
-            No items in this category
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-md">
-          {groupedItems.map((group) => (
-            <div key={group.category}>
-              {/* Category Header */}
-              {selectedCategory === 'all' && (
-                <h3 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground px-1 pb-1">
-                  {CATEGORY_LABELS[group.category]}
-                </h3>
-              )}
-
-              {/* Items in this category */}
-              <div className="bg-card border border-border rounded-xl overflow-hidden divide-y divide-border shadow-sm">
-                {group.items.map((item) => (
-                  <GroceryItemRow
-                    key={item.id}
-                    item={item}
-                    onToggleChecked={handleToggleChecked}
-                    onEdit={(id) => setEditingItemId(id)}
-                    onDelete={handleDeleteItem}
-                  />
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Add Item Dialog */}
-      <AddItemDialog
-        isOpen={isAddDialogOpen}
-        onClose={() => setIsAddDialogOpen(false)}
-        onAdd={handleAddItem}
+      <TripBoardLifecycleToolbar
+        checkedCount={checked.length}
+        onUncheckAll={handleUncheckAll}
+        onRemoveChecked={handleRemoveChecked}
+        onAddItem={handleOpenAddDialog}
         isLoading={isLoading}
       />
 
-      {/* Edit Item Dialog — keyed by editingItemId so useForm re-initialises per item */}
-      <EditItemDialog
-        key={editingItemId ?? 'none'}
-        item={editingItem || null}
-        isOpen={editingItemId !== null}
-        onClose={() => setEditingItemId(null)}
-        onSave={(changes) => handleEditItem(changes.id, changes)}
+      {list.lines.length === 0 ? (
+        <div className="text-center py-12">
+          <h3 className="text-lg font-semibold text-on-surface mb-2">
+            No items yet
+          </h3>
+          <p className="text-sm text-on-surface-variant">
+            Use Add Item to get started
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <h3 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground px-1 pb-1">
+              Active ({active.length})
+            </h3>
+            {active.length === 0 ? (
+              <p className="px-1 text-sm text-on-surface-variant">
+                Nothing left in cart
+              </p>
+            ) : (
+              <div className="bg-card border border-border rounded-xl overflow-hidden divide-y divide-border shadow-sm">
+                {active.map((line) => (
+                  <TripBoardLineRow
+                    key={line.id}
+                    line={line}
+                    catalogItem={catalog.find(
+                      (item) => item.id === line.catalogItemId,
+                    )}
+                    onToggleChecked={handleToggleChecked}
+                    onDeleteLine={handleDeleteLine}
+                    isLoading={isLoading}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground px-1 pb-1">
+              Checked ({checked.length}) — visible until removed
+            </h3>
+            {checked.length === 0 ? (
+              <p className="px-1 text-sm text-on-surface-variant">
+                None bought yet
+              </p>
+            ) : (
+              <div className="bg-card border border-border rounded-xl overflow-hidden divide-y divide-border shadow-sm">
+                {checked.map((line) => (
+                  <TripBoardLineRow
+                    key={line.id}
+                    line={line}
+                    catalogItem={catalog.find(
+                      (item) => item.id === line.catalogItemId,
+                    )}
+                    onToggleChecked={handleToggleChecked}
+                    onDeleteLine={handleDeleteLine}
+                    isLoading={isLoading}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <TripBoardSpendFooter summary={summary} />
+
+      <AddItemDialog
+        isOpen={isAddDialogOpen}
+        onClose={handleCloseAddDialog}
+        onAdd={handleAddItem}
         isLoading={isLoading}
       />
     </div>

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/GroceryListView.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/GroceryListView.tsx
@@ -107,6 +107,13 @@ export function GroceryListView({
     }
   }, [list.id, onUncheckAll, showErrorToast]);
 
+  const createUndoHandler = useCallback(
+    (listId: string, lines: ListLine[]) => () => {
+      void onRestoreLines(listId, lines);
+    },
+    [onRestoreLines],
+  );
+
   const handleRemoveChecked = useCallback(async () => {
     setIsLoading(true);
     try {
@@ -123,9 +130,7 @@ export function GroceryListView({
         action: (
           <ToastAction
             altText="Undo"
-            onClick={() => {
-              void onRestoreLines(list.id, removed);
-            }}
+            onClick={createUndoHandler(list.id, removed)}
           >
             Undo
           </ToastAction>
@@ -137,7 +142,7 @@ export function GroceryListView({
     } finally {
       setIsLoading(false);
     }
-  }, [list.id, onRemoveChecked, onRestoreLines, showErrorToast, toast]);
+  }, [createUndoHandler, list.id, onRemoveChecked, showErrorToast, toast]);
 
   const handleDeleteLine = useCallback(
     async (lineId: string) => {
@@ -360,6 +365,7 @@ export function GroceryListView({
         onClose={handleCloseAddDialog}
         onAdd={handleAddItem}
         isLoading={isLoading}
+        catalog={catalog}
       />
 
       <AddExistingItemDialog

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/GroceryListView.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/GroceryListView.tsx
@@ -12,6 +12,9 @@ import { DeleteCatalogItemDialog } from './DeleteCatalogItemDialog';
 import { TripBoardLifecycleToolbar } from './TripBoardLifecycleToolbar';
 import { TripBoardLineRow } from './TripBoardLineRow';
 import { TripBoardSpendFooter } from './TripBoardSpendFooter';
+import { CatalogItemEditDialog } from './CatalogItemEditDialog';
+import type { CatalogItemEditChanges } from './CatalogItemEditDialog';
+import { ListLineEditDialog } from './ListLineEditDialog';
 
 interface GroceryListViewProps {
   list: GroceryList;
@@ -33,6 +36,11 @@ interface GroceryListViewProps {
     amount?: string,
   ) => Promise<string[]>;
   onDeleteFromCatalog: (catalogItemId: string) => Promise<void>;
+  onUpdateCatalogItem: (changes: CatalogItemEditChanges) => Promise<void>;
+  onUpdateListLine: (
+    listId: string,
+    changes: { id: string; amount?: string },
+  ) => Promise<void>;
 }
 
 /**
@@ -51,6 +59,8 @@ export function GroceryListView({
   onAddItem,
   onAddExistingItem,
   onDeleteFromCatalog,
+  onUpdateCatalogItem,
+  onUpdateListLine,
 }: GroceryListViewProps) {
   const { toast } = useToast();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
@@ -58,6 +68,9 @@ export function GroceryListView({
   const [catalogItemPendingDelete, setCatalogItemPendingDelete] =
     useState<CatalogItem | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [linePendingEdit, setLinePendingEdit] = useState<ListLine | null>(null);
+  const [catalogItemPendingEdit, setCatalogItemPendingEdit] =
+    useState<CatalogItem | null>(null);
 
   const active = useMemo(
     () => list.lines.filter((line) => !line.checked),
@@ -236,6 +249,64 @@ export function GroceryListView({
     [catalog],
   );
 
+  const handleUpdateCatalogItem = useCallback(
+    async (changes: CatalogItemEditChanges) => {
+      setIsLoading(true);
+      try {
+        await onUpdateCatalogItem(changes);
+        setCatalogItemPendingEdit(null);
+      } catch (err) {
+        console.error('Failed to update catalog item:', err);
+        showErrorToast();
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [onUpdateCatalogItem, showErrorToast],
+  );
+
+  const handleUpdateListLine = useCallback(
+    async (changes: { id: string; amount?: string }) => {
+      setIsLoading(true);
+      try {
+        await onUpdateListLine(list.id, changes);
+        setLinePendingEdit(null);
+      } catch (err) {
+        console.error('Failed to update list line:', err);
+        showErrorToast();
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [list.id, onUpdateListLine, showErrorToast],
+  );
+
+  const handleEditListLine = useCallback(
+    (lineId: string) => {
+      setLinePendingEdit(list.lines.find((line) => line.id === lineId) ?? null);
+    },
+    [list.lines],
+  );
+
+  const handleEditCatalogItem = useCallback(
+    (catalogItemId: string) => {
+      setCatalogItemPendingEdit(
+        catalog.find((item) => item.id === catalogItemId) ?? null,
+      );
+    },
+    [catalog],
+  );
+
+  const handleCloseCatalogEdit = useCallback(() => {
+    setCatalogItemPendingEdit(null);
+  }, []);
+
+  const handleCloseLineEdit = useCallback(() => {
+    setLinePendingEdit(null);
+  }, []);
+
   const handleCloseDeleteCatalogDialog = useCallback(() => {
     setCatalogItemPendingDelete(null);
   }, []);
@@ -322,6 +393,8 @@ export function GroceryListView({
                     onToggleChecked={handleToggleChecked}
                     onDeleteLine={handleDeleteLine}
                     onDeleteFromCatalog={handleRequestDeleteFromCatalog}
+                    onEditListLine={handleEditListLine}
+                    onEditCatalogItem={handleEditCatalogItem}
                     isLoading={isLoading}
                   />
                 ))}
@@ -349,6 +422,8 @@ export function GroceryListView({
                     onToggleChecked={handleToggleChecked}
                     onDeleteLine={handleDeleteLine}
                     onDeleteFromCatalog={handleRequestDeleteFromCatalog}
+                    onEditListLine={handleEditListLine}
+                    onEditCatalogItem={handleEditCatalogItem}
                     isLoading={isLoading}
                   />
                 ))}
@@ -384,6 +459,26 @@ export function GroceryListView({
         affectedListCount={affectedListCount}
         onClose={handleCloseDeleteCatalogDialog}
         onConfirm={handleConfirmDeleteFromCatalog}
+        isLoading={isLoading}
+      />
+
+      <CatalogItemEditDialog
+        item={catalogItemPendingEdit}
+        isOpen={catalogItemPendingEdit !== null}
+        onClose={handleCloseCatalogEdit}
+        onSave={handleUpdateCatalogItem}
+        isLoading={isLoading}
+      />
+      <ListLineEditDialog
+        line={linePendingEdit}
+        catalogItem={
+          linePendingEdit
+            ? catalog.find((item) => item.id === linePendingEdit.catalogItemId)
+            : undefined
+        }
+        isOpen={linePendingEdit !== null}
+        onClose={handleCloseLineEdit}
+        onSave={handleUpdateListLine}
         isLoading={isLoading}
       />
     </div>

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/GroceryListView.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/GroceryListView.tsx
@@ -5,8 +5,10 @@ import { ToastAction, useToast } from '@myorganizer/web-ui';
 import { useCallback, useMemo, useState } from 'react';
 import type { AddCatalogItemAndLineInput } from '../../shared/hooks';
 import { summarizeListSpend } from '../../shared/utils';
+import { AddExistingItemDialog } from './AddExistingItemDialog';
 import type { AddItemFormResult } from './AddItemDialog';
 import { AddItemDialog } from './AddItemDialog';
+import { DeleteCatalogItemDialog } from './DeleteCatalogItemDialog';
 import { TripBoardLifecycleToolbar } from './TripBoardLifecycleToolbar';
 import { TripBoardLineRow } from './TripBoardLineRow';
 import { TripBoardSpendFooter } from './TripBoardSpendFooter';
@@ -14,6 +16,7 @@ import { TripBoardSpendFooter } from './TripBoardSpendFooter';
 interface GroceryListViewProps {
   list: GroceryList;
   catalog: CatalogItem[];
+  allLists: GroceryList[];
   onClose: () => void;
   onToggleChecked: (listId: string, lineId: string) => Promise<void>;
   onUncheckAll: (listId: string) => Promise<void>;
@@ -24,6 +27,12 @@ interface GroceryListViewProps {
     listId: string,
     input: AddCatalogItemAndLineInput,
   ) => Promise<void>;
+  onAddExistingItem: (
+    catalogItemId: string,
+    listIds: string[],
+    amount?: string,
+  ) => Promise<string[]>;
+  onDeleteFromCatalog: (catalogItemId: string) => Promise<void>;
 }
 
 /**
@@ -33,15 +42,21 @@ interface GroceryListViewProps {
 export function GroceryListView({
   list,
   catalog,
+  allLists,
   onToggleChecked,
   onUncheckAll,
   onRemoveChecked,
   onRestoreLines,
   onDeleteLine,
   onAddItem,
+  onAddExistingItem,
+  onDeleteFromCatalog,
 }: GroceryListViewProps) {
   const { toast } = useToast();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [isAddExistingDialogOpen, setIsAddExistingDialogOpen] = useState(false);
+  const [catalogItemPendingDelete, setCatalogItemPendingDelete] =
+    useState<CatalogItem | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   const active = useMemo(
@@ -163,6 +178,93 @@ export function GroceryListView({
     setIsAddDialogOpen(false);
   }, []);
 
+  const handleOpenAddExistingDialog = useCallback(() => {
+    setIsAddExistingDialogOpen(true);
+  }, []);
+
+  const handleCloseAddExistingDialog = useCallback(() => {
+    setIsAddExistingDialogOpen(false);
+  }, []);
+
+  const handleAddExistingItem = useCallback(
+    async (catalogItemId: string, listIds: string[], amount?: string) => {
+      setIsLoading(true);
+      try {
+        const addedListIds = await onAddExistingItem(
+          catalogItemId,
+          listIds,
+          amount,
+        );
+        setIsAddExistingDialogOpen(false);
+        if (addedListIds.length === 0) {
+          toast({
+            title: 'Already on every selected list.',
+          });
+        } else if (addedListIds.length === listIds.length) {
+          toast({
+            title: 'Added to lists',
+            description: `Added to ${addedListIds.length} list${addedListIds.length !== 1 ? 's' : ''}.`,
+          });
+        } else {
+          toast({
+            title: 'Added to lists',
+            description: `Added to ${addedListIds.length} of ${listIds.length} lists (already on the rest).`,
+          });
+        }
+      } catch (err) {
+        console.error('Failed to add existing catalog item to lists:', err);
+        showErrorToast();
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [onAddExistingItem, showErrorToast, toast],
+  );
+
+  const handleRequestDeleteFromCatalog = useCallback(
+    (catalogItemId: string) => {
+      const item = catalog.find((c) => c.id === catalogItemId);
+      if (item) {
+        setCatalogItemPendingDelete(item);
+      }
+    },
+    [catalog],
+  );
+
+  const handleCloseDeleteCatalogDialog = useCallback(() => {
+    setCatalogItemPendingDelete(null);
+  }, []);
+
+  const handleConfirmDeleteFromCatalog = useCallback(async () => {
+    if (!catalogItemPendingDelete) return;
+    setIsLoading(true);
+    try {
+      await onDeleteFromCatalog(catalogItemPendingDelete.id);
+      toast({
+        title: `Deleted "${catalogItemPendingDelete.name}" from Catalog`,
+      });
+    } catch (err) {
+      console.error('Failed to delete catalog item:', err);
+      showErrorToast();
+    } finally {
+      setIsLoading(false);
+      setCatalogItemPendingDelete(null);
+    }
+  }, [catalogItemPendingDelete, onDeleteFromCatalog, showErrorToast, toast]);
+
+  const affectedListCount = useMemo(() => {
+    if (!catalogItemPendingDelete) return 0;
+    const totalLists = allLists.filter((otherList) =>
+      otherList.lines.some(
+        (line) => line.catalogItemId === catalogItemPendingDelete.id,
+      ),
+    ).length;
+    const includesCurrentList = list.lines.some(
+      (line) => line.catalogItemId === catalogItemPendingDelete.id,
+    );
+    return includesCurrentList ? totalLists - 1 : totalLists;
+  }, [allLists, catalogItemPendingDelete, list.lines]);
+
   return (
     <div className="space-y-lg">
       <div className="space-y-1 pb-md border-b border-outline-variant">
@@ -180,6 +282,7 @@ export function GroceryListView({
         onUncheckAll={handleUncheckAll}
         onRemoveChecked={handleRemoveChecked}
         onAddItem={handleOpenAddDialog}
+        onAddExisting={handleOpenAddExistingDialog}
         isLoading={isLoading}
       />
 
@@ -213,6 +316,7 @@ export function GroceryListView({
                     )}
                     onToggleChecked={handleToggleChecked}
                     onDeleteLine={handleDeleteLine}
+                    onDeleteFromCatalog={handleRequestDeleteFromCatalog}
                     isLoading={isLoading}
                   />
                 ))}
@@ -239,6 +343,7 @@ export function GroceryListView({
                     )}
                     onToggleChecked={handleToggleChecked}
                     onDeleteLine={handleDeleteLine}
+                    onDeleteFromCatalog={handleRequestDeleteFromCatalog}
                     isLoading={isLoading}
                   />
                 ))}
@@ -254,6 +359,25 @@ export function GroceryListView({
         isOpen={isAddDialogOpen}
         onClose={handleCloseAddDialog}
         onAdd={handleAddItem}
+        isLoading={isLoading}
+      />
+
+      <AddExistingItemDialog
+        isOpen={isAddExistingDialogOpen}
+        onClose={handleCloseAddExistingDialog}
+        catalog={catalog}
+        lists={allLists}
+        defaultListId={list.id}
+        onAdd={handleAddExistingItem}
+        isLoading={isLoading}
+      />
+
+      <DeleteCatalogItemDialog
+        isOpen={catalogItemPendingDelete !== null}
+        catalogItem={catalogItemPendingDelete}
+        affectedListCount={affectedListCount}
+        onClose={handleCloseDeleteCatalogDialog}
+        onConfirm={handleConfirmDeleteFromCatalog}
         isLoading={isLoading}
       />
     </div>

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/LinksInput.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/LinksInput.tsx
@@ -1,23 +1,64 @@
 'use client';
 
-import { Button, Input } from '@myorganizer/web-ui';
+import {
+  Button,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+} from '@myorganizer/web-ui';
 import { Plus, Trash2 } from 'lucide-react';
+import { useCallback, type MouseEvent } from 'react';
+import type {
+  ArrayPath,
+  Control,
+  FieldArray,
+  FieldValues,
+  Path,
+} from 'react-hook-form';
 import { useFieldArray } from 'react-hook-form';
 
-interface LinksInputProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  control: any;
+interface LinksFormValues extends FieldValues {
+  links: string[];
 }
 
-/**
- * Dynamic links input component
- * Allows adding/removing up to 10 URL links for grocery items
- */
-export function LinksInput({ control }: LinksInputProps) {
-  const { fields, append, remove } = useFieldArray({
+interface LinksInputProps<TFieldValues extends LinksFormValues> {
+  control: Control<TFieldValues>;
+  disabled?: boolean;
+}
+
+type LinksFieldName<TFieldValues extends LinksFormValues> = 'links' &
+  ArrayPath<TFieldValues>;
+
+type LinkFieldName<TFieldValues extends LinksFormValues> = `links.${number}` &
+  Path<TFieldValues>;
+
+export function LinksInput<TFieldValues extends LinksFormValues>({
+  control,
+  disabled = false,
+}: LinksInputProps<TFieldValues>) {
+  const linksFieldName = 'links' as LinksFieldName<TFieldValues>;
+  const { fields, append, remove } = useFieldArray<
+    TFieldValues,
+    LinksFieldName<TFieldValues>
+  >({
     control,
-    name: 'links',
+    name: linksFieldName,
   });
+
+  const handleAddLink = useCallback(() => {
+    append('' as FieldArray<TFieldValues, LinksFieldName<TFieldValues>>);
+  }, [append]);
+
+  const handleRemoveLink = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      const index = Number(event.currentTarget.dataset.linkIndex);
+      remove(index);
+    },
+    [remove],
+  );
 
   const canAddMore = fields.length < 10;
 
@@ -25,19 +66,34 @@ export function LinksInput({ control }: LinksInputProps) {
     <div className="space-y-3">
       {fields.map((field, index) => (
         <div key={field.id} className="flex gap-2">
-          <Input
-            placeholder="https://example.com"
-            {...control.register(`links.${index}`)}
-            className="flex-1 text-base md:text-sm"
-            type="url"
+          <FormField<TFieldValues, LinkFieldName<TFieldValues>>
+            control={control}
+            name={`links.${index}` as LinkFieldName<TFieldValues>}
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                <FormLabel className="sr-only">Link {index + 1}</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder="https://example.com"
+                    className="flex-1 text-base md:text-sm"
+                    type="url"
+                    disabled={disabled}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
           />
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            onClick={() => remove(index)}
+            onClick={handleRemoveLink}
+            data-link-index={index}
             aria-label={`Remove link ${index + 1}`}
             className="text-destructive hover:text-destructive"
+            disabled={disabled}
           >
             <Trash2 className="w-4 h-4" />
           </Button>
@@ -49,8 +105,9 @@ export function LinksInput({ control }: LinksInputProps) {
           type="button"
           variant="outline"
           size="sm"
-          onClick={() => append('')}
+          onClick={handleAddLink}
           className="gap-2 w-full"
+          disabled={disabled}
         >
           <Plus className="w-4 h-4" />
           Add another link

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/ListLineEditDialog.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/ListLineEditDialog.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { CatalogItem, ListLine } from '@myorganizer/core';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+} from '@myorganizer/web-ui';
+import { Lock } from 'lucide-react';
+import { useCallback, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const listLineEditSchema = z.object({
+  amount: z.string().max(50, 'Amount must be 50 characters or less'),
+});
+type ListLineEditFormValues = z.infer<typeof listLineEditSchema>;
+
+interface ListLineEditDialogProps {
+  line: ListLine | null;
+  catalogItem: CatalogItem | undefined;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (changes: { id: string; amount?: string }) => Promise<void>;
+  isLoading?: boolean;
+}
+
+export function ListLineEditDialog({
+  line,
+  catalogItem,
+  isOpen,
+  onClose,
+  onSave,
+  isLoading = false,
+}: ListLineEditDialogProps) {
+  const form = useForm<ListLineEditFormValues>({
+    resolver: zodResolver(listLineEditSchema, undefined, { mode: 'sync' }),
+    defaultValues: { amount: '' },
+  });
+
+  useEffect(() => {
+    form.reset({ amount: line?.amount ?? '' });
+  }, [form, line?.id]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    if (!line) return;
+    await onSave({ id: line.id, amount: values.amount || undefined });
+    onClose();
+  });
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  return (
+    <Dialog open={isOpen && line !== null} onOpenChange={handleOpenChange}>
+      <DialogContent className="w-[calc(100%-2rem)] max-w-md">
+        <Form {...form}>
+          <form onSubmit={handleSubmit}>
+            <DialogTitle>Edit List Line</DialogTitle>
+            <DialogDescription className="mt-2">
+              Edit trip details for this List Line on the current Grocery List.
+              This does not change the Catalog Item.
+            </DialogDescription>
+            <div className="space-y-4 py-5">
+              <p className="text-sm font-medium text-on-surface">
+                {catalogItem?.name ?? 'Unknown Catalog Item'}
+              </p>
+              <FormField
+                control={form.control}
+                name="amount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Quantity / Amount</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        maxLength={50}
+                        placeholder="e.g. 2, 500g"
+                        disabled={isLoading}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormItem>
+                <FormLabel>Checked state</FormLabel>
+                <p className="text-sm text-on-surface-variant">
+                  {line?.checked ? 'Checked Item' : 'Active List Line'} —
+                  controlled by the row checkbox.
+                </p>
+              </FormItem>
+            </div>
+            <div className="flex items-center justify-between border-t border-border-muted pt-4">
+              <span className="inline-flex items-center gap-1 text-xs text-on-surface-variant">
+                <Lock className="h-3 w-3" /> Stored securely in your private
+                vault.
+              </span>
+              <div className="flex gap-3">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={handleClose}
+                  disabled={isLoading}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isLoading}>
+                  Save List Line
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLifecycleToolbar.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLifecycleToolbar.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Button } from '@myorganizer/web-ui';
+import { Plus, Trash2 } from 'lucide-react';
+
+interface TripBoardLifecycleToolbarProps {
+  checkedCount: number;
+  onUncheckAll: () => void;
+  onRemoveChecked: () => void;
+  onAddItem: () => void;
+  isLoading?: boolean;
+}
+
+export function TripBoardLifecycleToolbar({
+  checkedCount,
+  onUncheckAll,
+  onRemoveChecked,
+  onAddItem,
+  isLoading = false,
+}: TripBoardLifecycleToolbarProps) {
+  const hasCheckedItems = checkedCount > 0;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button onClick={onAddItem} disabled={isLoading} className="gap-2">
+        <Plus className="h-4 w-4" />
+        Add Item
+      </Button>
+
+      <Button
+        variant="outline"
+        onClick={onUncheckAll}
+        disabled={isLoading || !hasCheckedItems}
+      >
+        Uncheck All
+      </Button>
+
+      <Button
+        variant="destructive"
+        onClick={onRemoveChecked}
+        disabled={isLoading || !hasCheckedItems}
+        className="gap-2"
+      >
+        <Trash2 className="h-4 w-4" />
+        Remove Checked ({checkedCount})
+      </Button>
+    </div>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLifecycleToolbar.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLifecycleToolbar.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { Button } from '@myorganizer/web-ui';
-import { Plus, Trash2 } from 'lucide-react';
+import { ListPlus, Plus, Trash2 } from 'lucide-react';
 
 interface TripBoardLifecycleToolbarProps {
   checkedCount: number;
   onUncheckAll: () => void;
   onRemoveChecked: () => void;
   onAddItem: () => void;
+  onAddExisting: () => void;
   isLoading?: boolean;
 }
 
@@ -16,6 +17,7 @@ export function TripBoardLifecycleToolbar({
   onUncheckAll,
   onRemoveChecked,
   onAddItem,
+  onAddExisting,
   isLoading = false,
 }: TripBoardLifecycleToolbarProps) {
   const hasCheckedItems = checkedCount > 0;
@@ -25,6 +27,16 @@ export function TripBoardLifecycleToolbar({
       <Button onClick={onAddItem} disabled={isLoading} className="gap-2">
         <Plus className="h-4 w-4" />
         Add Item
+      </Button>
+
+      <Button
+        variant="outline"
+        onClick={onAddExisting}
+        disabled={isLoading}
+        className="gap-2"
+      >
+        <ListPlus className="h-4 w-4" />
+        Add From Catalog
       </Button>
 
       <Button

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLineRow.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLineRow.tsx
@@ -2,7 +2,7 @@
 
 import type { CatalogItem, ListLine } from '@myorganizer/core';
 import { Checkbox } from '@myorganizer/web-ui';
-import { Trash2 } from 'lucide-react';
+import { Ban, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { getCategoryEmoji } from '../../shared/constants/categories';
 import { formatMoney } from '../../shared/utils';
@@ -12,6 +12,7 @@ interface TripBoardLineRowProps {
   catalogItem: CatalogItem | undefined;
   onToggleChecked: (lineId: string) => void;
   onDeleteLine: (lineId: string) => void;
+  onDeleteFromCatalog: (catalogItemId: string) => void;
   isLoading?: boolean;
 }
 
@@ -20,6 +21,7 @@ export function TripBoardLineRow({
   catalogItem,
   onToggleChecked,
   onDeleteLine,
+  onDeleteFromCatalog,
   isLoading = false,
 }: TripBoardLineRowProps) {
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
@@ -46,6 +48,11 @@ export function TripBoardLineRow({
       setIsConfirmingDelete(true);
     }
   }, [isConfirmingDelete, line.id, onDeleteLine]);
+
+  const handleDeleteFromCatalogClick = useCallback(() => {
+    if (!catalogItem) return;
+    onDeleteFromCatalog(catalogItem.id);
+  }, [catalogItem, onDeleteFromCatalog]);
 
   return (
     <div
@@ -119,6 +126,19 @@ export function TripBoardLineRow({
       >
         <Trash2 className="h-4 w-4" />
       </button>
+
+      {catalogItem && (
+        <button
+          onClick={handleDeleteFromCatalogClick}
+          disabled={isLoading}
+          className="p-1.5 rounded-lg shrink-0 transition-colors disabled:pointer-events-none disabled:opacity-50 hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
+          aria-label={`Delete ${itemName} from catalog`}
+          title="Delete from catalog (all lists)"
+          type="button"
+        >
+          <Ban className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLineRow.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLineRow.tsx
@@ -2,7 +2,7 @@
 
 import type { CatalogItem, ListLine } from '@myorganizer/core';
 import { Checkbox } from '@myorganizer/web-ui';
-import { Ban, Trash2 } from 'lucide-react';
+import { Ban, Pencil, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { getCategoryEmoji } from '../../shared/constants/categories';
 import { formatMoney } from '../../shared/utils';
@@ -13,6 +13,8 @@ interface TripBoardLineRowProps {
   onToggleChecked: (lineId: string) => void;
   onDeleteLine: (lineId: string) => void;
   onDeleteFromCatalog: (catalogItemId: string) => void;
+  onEditListLine: (lineId: string) => void;
+  onEditCatalogItem: (catalogItemId: string) => void;
   isLoading?: boolean;
 }
 
@@ -22,6 +24,8 @@ export function TripBoardLineRow({
   onToggleChecked,
   onDeleteLine,
   onDeleteFromCatalog,
+  onEditListLine,
+  onEditCatalogItem,
   isLoading = false,
 }: TripBoardLineRowProps) {
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
@@ -33,6 +37,14 @@ export function TripBoardLineRow({
   const handleToggle = useCallback(() => {
     onToggleChecked(line.id);
   }, [line.id, onToggleChecked]);
+
+  const handleEditLine = useCallback(() => {
+    onEditListLine(line.id);
+  }, [line.id, onEditListLine]);
+
+  const handleEditCatalog = useCallback(() => {
+    if (catalogItem) onEditCatalogItem(catalogItem.id);
+  }, [catalogItem, onEditCatalogItem]);
 
   useEffect(() => {
     if (!isConfirmingDelete) return;
@@ -109,6 +121,30 @@ export function TripBoardLineRow({
       </div>
 
       <button
+        onClick={handleEditLine}
+        disabled={isLoading}
+        className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-secondary/10 hover:text-secondary disabled:pointer-events-none disabled:opacity-50"
+        aria-label={`Edit List Line for ${itemName}`}
+        title="Edit List Line"
+        type="button"
+      >
+        <Pencil className="h-4 w-4" />
+      </button>
+
+      {catalogItem && (
+        <button
+          onClick={handleEditCatalog}
+          disabled={isLoading}
+          className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-secondary/10 hover:text-secondary disabled:pointer-events-none disabled:opacity-50"
+          aria-label={`Edit Catalog Item ${itemName}`}
+          title="Edit Catalog Item"
+          type="button"
+        >
+          <Pencil className="h-4 w-4" />
+        </button>
+      )}
+
+      <button
         onClick={handleDeleteClick}
         disabled={isLoading}
         className={`p-1.5 rounded-lg shrink-0 transition-colors disabled:pointer-events-none disabled:opacity-50 ${
@@ -117,11 +153,11 @@ export function TripBoardLineRow({
             : 'hover:bg-destructive/10 text-muted-foreground hover:text-destructive'
         }`}
         aria-label={
-          isConfirmingDelete
-            ? `Confirm delete ${itemName}`
-            : `Delete ${itemName}`
+          isConfirmingDelete ? 'Confirm Delete List Line' : 'Delete List Line'
         }
-        title={isConfirmingDelete ? 'Click again to confirm' : 'Delete item'}
+        title={
+          isConfirmingDelete ? 'Click again to confirm' : 'Delete List Line'
+        }
         type="button"
       >
         <Trash2 className="h-4 w-4" />

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLineRow.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardLineRow.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import type { CatalogItem, ListLine } from '@myorganizer/core';
+import { Checkbox } from '@myorganizer/web-ui';
+import { Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { getCategoryEmoji } from '../../shared/constants/categories';
+import { formatMoney } from '../../shared/utils';
+
+interface TripBoardLineRowProps {
+  line: ListLine;
+  catalogItem: CatalogItem | undefined;
+  onToggleChecked: (lineId: string) => void;
+  onDeleteLine: (lineId: string) => void;
+  isLoading?: boolean;
+}
+
+export function TripBoardLineRow({
+  line,
+  catalogItem,
+  onToggleChecked,
+  onDeleteLine,
+  isLoading = false,
+}: TripBoardLineRowProps) {
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+
+  const itemName = catalogItem?.name ?? 'Unknown item';
+  const categoryEmoji = getCategoryEmoji(catalogItem?.category ?? 'other');
+  const hasPrice = typeof catalogItem?.price === 'number';
+
+  const handleToggle = useCallback(() => {
+    onToggleChecked(line.id);
+  }, [line.id, onToggleChecked]);
+
+  useEffect(() => {
+    if (!isConfirmingDelete) return;
+    const timer = setTimeout(() => setIsConfirmingDelete(false), 3000);
+    return () => clearTimeout(timer);
+  }, [isConfirmingDelete]);
+
+  const handleDeleteClick = useCallback(() => {
+    if (isConfirmingDelete) {
+      onDeleteLine(line.id);
+      setIsConfirmingDelete(false);
+    } else {
+      setIsConfirmingDelete(true);
+    }
+  }, [isConfirmingDelete, line.id, onDeleteLine]);
+
+  return (
+    <div
+      data-testid={`list-line-${line.id}`}
+      className={`flex items-center gap-3 px-4 py-3 transition-colors ${
+        line.checked ? 'bg-muted/20' : 'bg-card'
+      }`}
+    >
+      <Checkbox
+        checked={line.checked}
+        onCheckedChange={handleToggle}
+        disabled={isLoading}
+        aria-label={`Toggle ${itemName}`}
+      />
+
+      <span className="text-lg shrink-0 leading-none" aria-hidden="true">
+        {categoryEmoji}
+      </span>
+
+      <div className="flex flex-col min-w-0 grow">
+        <span
+          className={`text-sm font-semibold leading-snug transition-all ${
+            line.checked
+              ? 'line-through text-muted-foreground'
+              : 'text-foreground'
+          }`}
+        >
+          {itemName}
+        </span>
+
+        {(line.amount || hasPrice) && (
+          <div
+            className={`flex items-center gap-1 mt-0.5 transition-all ${
+              line.checked ? 'opacity-50' : ''
+            }`}
+          >
+            {line.amount && (
+              <span className="text-[11px] font-medium text-muted-foreground">
+                {line.amount}
+              </span>
+            )}
+            {line.amount && hasPrice && (
+              <span className="text-[11px] text-muted-foreground select-none">
+                •
+              </span>
+            )}
+            {hasPrice && (
+              <span className="text-[11px] font-medium text-muted-foreground">
+                {formatMoney(catalogItem?.price as number)}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <button
+        onClick={handleDeleteClick}
+        disabled={isLoading}
+        className={`p-1.5 rounded-lg shrink-0 transition-colors disabled:pointer-events-none disabled:opacity-50 ${
+          isConfirmingDelete
+            ? 'bg-destructive/10 text-destructive'
+            : 'hover:bg-destructive/10 text-muted-foreground hover:text-destructive'
+        }`}
+        aria-label={
+          isConfirmingDelete
+            ? `Confirm delete ${itemName}`
+            : `Delete ${itemName}`
+        }
+        title={isConfirmingDelete ? 'Click again to confirm' : 'Delete item'}
+        type="button"
+      >
+        <Trash2 className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardSpendFooter.tsx
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/TripBoardSpendFooter.tsx
@@ -1,0 +1,22 @@
+import { formatMoney, type ListSpendSummary } from '../../shared/utils';
+
+interface TripBoardSpendFooterProps {
+  summary: ListSpendSummary;
+}
+
+export function TripBoardSpendFooter({ summary }: TripBoardSpendFooterProps) {
+  return (
+    <div
+      role="status"
+      className="sticky bottom-0 z-10 flex items-center justify-between gap-3 border-t border-outline-variant bg-surface px-4 py-3 shadow-[0_-2px_8px_rgba(0,0,0,0.06)]"
+    >
+      <span className="text-sm font-semibold text-on-surface">
+        Known spend {formatMoney(summary.known)}
+      </span>
+      <span className="text-xs text-on-surface-variant">
+        {summary.unpricedCount} item{summary.unpricedCount !== 1 ? 's' : ''}{' '}
+        unpriced
+      </span>
+    </div>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/index.ts
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/index.ts
@@ -1,12 +1,15 @@
 export { AddExistingItemDialog } from './AddExistingItemDialog';
 export { AddItemDialog } from './AddItemDialog';
 export type { AddItemFormResult } from './AddItemDialog';
+export { CatalogItemEditDialog } from './CatalogItemEditDialog';
+export type { CatalogItemEditChanges } from './CatalogItemEditDialog';
 export { AddItemInlineForm } from './AddItemInlineForm';
 export { DeleteCatalogItemDialog } from './DeleteCatalogItemDialog';
 export { EditItemDialog } from './EditItemDialog';
 export { GroceryItemRow } from './GroceryItemRow';
 export { GroceryListView } from './GroceryListView';
 export { LinksInput } from './LinksInput';
+export { ListLineEditDialog } from './ListLineEditDialog';
 export { TripBoardLifecycleToolbar } from './TripBoardLifecycleToolbar';
 export { TripBoardLineRow } from './TripBoardLineRow';
 export { TripBoardSpendFooter } from './TripBoardSpendFooter';

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/index.ts
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/index.ts
@@ -5,3 +5,6 @@ export { EditItemDialog } from './EditItemDialog';
 export { GroceryItemRow } from './GroceryItemRow';
 export { GroceryListView } from './GroceryListView';
 export { LinksInput } from './LinksInput';
+export { TripBoardLifecycleToolbar } from './TripBoardLifecycleToolbar';
+export { TripBoardLineRow } from './TripBoardLineRow';
+export { TripBoardSpendFooter } from './TripBoardSpendFooter';

--- a/libs/web/pages/groceries/src/groceries-list-detail/components/index.ts
+++ b/libs/web/pages/groceries/src/groceries-list-detail/components/index.ts
@@ -1,6 +1,8 @@
+export { AddExistingItemDialog } from './AddExistingItemDialog';
 export { AddItemDialog } from './AddItemDialog';
 export type { AddItemFormResult } from './AddItemDialog';
 export { AddItemInlineForm } from './AddItemInlineForm';
+export { DeleteCatalogItemDialog } from './DeleteCatalogItemDialog';
 export { EditItemDialog } from './EditItemDialog';
 export { GroceryItemRow } from './GroceryItemRow';
 export { GroceryListView } from './GroceryListView';

--- a/libs/web/pages/groceries/src/groceries-page/GroceriesPageClient.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/GroceriesPageClient.tsx
@@ -160,6 +160,7 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
           // List selector
           <GroceryListSelector
             lists={vault.lists}
+            catalog={vault.catalog}
             onRenameList={(listId) => {
               const list = vault.lists.find((l) => l.id === listId);
               if (list) {
@@ -177,7 +178,7 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
                   type: 'delete',
                   listId,
                   listName: list.name,
-                  itemCount: list.items.length,
+                  itemCount: list.lines.length,
                 });
               }
             }}

--- a/libs/web/pages/groceries/src/groceries-page/GroceriesPageClient.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/GroceriesPageClient.tsx
@@ -3,12 +3,12 @@
 import { Button, Skeleton } from '@myorganizer/web-ui';
 import { VaultGate } from '@myorganizer/web-vault-ui';
 import { Plus } from 'lucide-react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   CreateListDialog,
   DeleteListConfirmDialog,
-  GroceryListSelector,
   RenameListDialog,
+  TripBoardIndex,
 } from './components';
 import { useGroceriesVault } from '../shared/hooks';
 
@@ -27,6 +27,66 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
   const [dialog, setDialog] = useState<DialogState>({ type: null });
   const vault = useGroceriesVault({ masterKeyBytes });
 
+  const handleOpenCreateDialog = useCallback(() => {
+    setDialog({ type: 'create' });
+  }, []);
+
+  const handleCloseDialog = useCallback(() => {
+    setDialog({ type: null });
+  }, []);
+
+  const handleRenameList = useCallback(
+    (listId: string) => {
+      const list = vault.lists.find((candidate) => candidate.id === listId);
+      if (list) {
+        setDialog({
+          type: 'rename',
+          listId,
+          listName: list.name,
+        });
+      }
+    },
+    [vault.lists],
+  );
+
+  const handleDeleteList = useCallback(
+    (listId: string) => {
+      const list = vault.lists.find((candidate) => candidate.id === listId);
+      if (list) {
+        setDialog({
+          type: 'delete',
+          listId,
+          listName: list.name,
+          itemCount: list.lines.length,
+        });
+      }
+    },
+    [vault.lists],
+  );
+
+  const handleCreateList = useCallback(
+    async (name: string) => {
+      await vault.createList(name);
+      setDialog({ type: null });
+    },
+    [vault.createList],
+  );
+
+  const handleRenameSubmit = useCallback(
+    async (newName: string) => {
+      if (!dialog.listId) return;
+      await vault.renameList(dialog.listId, newName);
+      setDialog({ type: null });
+    },
+    [dialog.listId, vault.renameList],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!dialog.listId) return;
+    await vault.deleteList(dialog.listId);
+    setDialog({ type: null });
+  }, [dialog.listId, vault.deleteList]);
+
   if (vault.loading) {
     return (
       <div
@@ -35,13 +95,11 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
         aria-label="Loading groceries list"
       >
         <div className="mx-auto max-w-6xl p-4 md:p-6">
-          {/* Header skeleton */}
           <div className="mb-6 space-y-2">
             <Skeleton className="h-8 w-48" />
             <Skeleton className="h-4 w-64" />
           </div>
 
-          {/* List cards skeleton */}
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
               <Skeleton key={i} className="h-24 w-full rounded-lg" />
@@ -55,7 +113,6 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
   return (
     <div className="min-h-screen bg-surface">
       <div className="mx-auto max-w-6xl p-4 md:p-6">
-        {/* Error banner */}
         {vault.error && (
           <div
             className="mb-4 flex items-start gap-3 rounded-lg border border-error bg-error-container p-4 text-error md:mb-6"
@@ -89,7 +146,6 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
           </div>
         )}
 
-        {/* Header */}
         <div className="mb-8 flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
           <div>
             <h1 className="text-3xl font-bold text-on-surface md:text-4xl">
@@ -102,7 +158,7 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
           <Button
             size="lg"
             className="w-full gap-2 md:w-auto"
-            onClick={() => setDialog({ type: 'create' })}
+            onClick={handleOpenCreateDialog}
             disabled={vault.loading}
           >
             <Plus className="h-5 w-5" />
@@ -110,19 +166,7 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
           </Button>
         </div>
 
-        {/* Search bar */}
-        <div className="mb-6">
-          <input
-            type="text"
-            placeholder="Search your lists..."
-            aria-label="Search grocery lists by name"
-            className="w-full rounded-lg border border-outline-variant bg-surface-container-lowest px-4 py-3 text-on-surface placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-secondary md:max-w-md"
-          />
-        </div>
-
-        {/* Lists section or selected list view */}
         {vault.lists.length === 0 ? (
-          // Empty state
           <div
             className="rounded-lg border-2 border-dashed border-outline-variant bg-surface-container-low p-8 text-center md:p-12"
             role="status"
@@ -149,52 +193,25 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
             <p className="mt-2 text-on-surface-variant">
               Create your first list to get started organizing your shopping.
             </p>
-            <Button
-              className="mt-6"
-              onClick={() => setDialog({ type: 'create' })}
-            >
+            <Button className="mt-6" onClick={handleOpenCreateDialog}>
               Create Your First List
             </Button>
           </div>
         ) : (
-          // List selector
-          <GroceryListSelector
+          <TripBoardIndex
             lists={vault.lists}
             catalog={vault.catalog}
-            onRenameList={(listId) => {
-              const list = vault.lists.find((l) => l.id === listId);
-              if (list) {
-                setDialog({
-                  type: 'rename',
-                  listId,
-                  listName: list.name,
-                });
-              }
-            }}
-            onDeleteList={(listId) => {
-              const list = vault.lists.find((l) => l.id === listId);
-              if (list) {
-                setDialog({
-                  type: 'delete',
-                  listId,
-                  listName: list.name,
-                  itemCount: list.lines.length,
-                });
-              }
-            }}
+            onRenameList={handleRenameList}
+            onDeleteList={handleDeleteList}
             isLoading={vault.loading}
           />
         )}
       </div>
 
-      {/* Dialogs */}
       <CreateListDialog
         isOpen={dialog.type === 'create'}
-        onClose={() => setDialog({ type: null })}
-        onSubmit={async (name) => {
-          await vault.createList(name);
-          setDialog({ type: null });
-        }}
+        onClose={handleCloseDialog}
+        onSubmit={handleCreateList}
         isLoading={vault.loading}
       />
 
@@ -202,11 +219,8 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
         <RenameListDialog
           isOpen={true}
           currentName={dialog.listName || ''}
-          onClose={() => setDialog({ type: null })}
-          onSubmit={async (newName) => {
-            await vault.renameList(dialog.listId!, newName);
-            setDialog({ type: null });
-          }}
+          onClose={handleCloseDialog}
+          onSubmit={handleRenameSubmit}
           isLoading={vault.loading}
         />
       )}
@@ -216,11 +230,8 @@ function GroceriesInner({ masterKeyBytes }: GroceriesInnerProps) {
           isOpen={true}
           listName={dialog.listName || ''}
           itemCount={dialog.itemCount || 0}
-          onClose={() => setDialog({ type: null })}
-          onConfirm={async () => {
-            await vault.deleteList(dialog.listId!);
-            setDialog({ type: null });
-          }}
+          onClose={handleCloseDialog}
+          onConfirm={handleDeleteConfirm}
           isLoading={vault.loading}
         />
       )}

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/CreateListDialog.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/CreateListDialog.spec.tsx
@@ -6,9 +6,11 @@
 
 /** Mocking rule: place jest.mock calls before any imports */
 jest.mock('@myorganizer/web-ui', () => {
-  const React = require('react');
+  const React = require('react') as typeof import('react');
 
-  const DialogContext = React.createContext<any>(null);
+  const DialogContext = React.createContext<{
+    onOpenChange?: (open: boolean) => void;
+  } | null>(null);
 
   function Dialog({ open, onOpenChange, children }: any) {
     React.useEffect(() => {

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/DeleteListConfirmDialog.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/DeleteListConfirmDialog.spec.tsx
@@ -135,7 +135,7 @@ describe('DeleteListConfirmDialog', () => {
 
     it('should disable all buttons during deletion and re-enable after', async () => {
       const mockOnConfirm = jest.fn(
-        () => new Promise((resolve) => setTimeout(resolve, 100)),
+        () => new Promise<void>((resolve) => setTimeout(resolve, 100)),
       );
       render(
         <DeleteListConfirmDialog {...defaultProps} onConfirm={mockOnConfirm} />,
@@ -343,7 +343,7 @@ describe('DeleteListConfirmDialog', () => {
   describe('Error Handling', () => {
     it('should properly reset state after onConfirm operation completes', async () => {
       // Verify that confirming state is properly reset even after any async operation
-      let resolveConfirmation: (() => void) | null = null;
+      let resolveConfirmation!: () => void;
       const confirmPromise = new Promise<void>((resolve) => {
         resolveConfirmation = resolve;
       });
@@ -365,9 +365,7 @@ describe('DeleteListConfirmDialog', () => {
       });
 
       // Resolve the confirmation
-      if (resolveConfirmation) {
-        resolveConfirmation();
-      }
+      resolveConfirmation();
 
       // After completion, state should reset
       await waitFor(() => {
@@ -378,7 +376,7 @@ describe('DeleteListConfirmDialog', () => {
 
     it('should disable buttons during entire async operation lifecycle', async () => {
       // Verify buttons stay disabled throughout the async flow and are re-enabled when done
-      let resolveConfirmation: (() => void) | null = null;
+      let resolveConfirmation!: () => void;
       const confirmPromise = new Promise<void>((resolve) => {
         resolveConfirmation = resolve;
       });
@@ -404,9 +402,7 @@ describe('DeleteListConfirmDialog', () => {
       });
 
       // Resolve and verify they re-enable
-      if (resolveConfirmation) {
-        resolveConfirmation();
-      }
+      resolveConfirmation();
 
       await waitFor(() => {
         expect(cancelButton).not.toBeDisabled();
@@ -450,7 +446,7 @@ describe('DeleteListConfirmDialog', () => {
 
     it('should not call onConfirm more than once even on rapid clicks', async () => {
       const mockOnConfirm = jest.fn(
-        () => new Promise((resolve) => setTimeout(resolve, 100)),
+        () => new Promise<void>((resolve) => setTimeout(resolve, 100)),
       );
       render(
         <DeleteListConfirmDialog {...defaultProps} onConfirm={mockOnConfirm} />,

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/GroceriesPageClient.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/GroceriesPageClient.spec.tsx
@@ -93,6 +93,37 @@ jest.mock('../components', () => {
     );
   }
 
+  function TripBoardIndex({
+    lists,
+    catalog,
+    onRenameList,
+    onDeleteList,
+    isLoading,
+  }: any) {
+    return (
+      <div data-testid="grocery-list-selector">
+        <input placeholder="Search your lists..." />
+        <div data-testid="lists-count">{lists.length}</div>
+        <div data-testid="catalog-count">{catalog?.length ?? 0}</div>
+        <button
+          data-testid="selector-rename-button"
+          onClick={() => onRenameList('list1')}
+        >
+          Rename
+        </button>
+        <button
+          data-testid="selector-delete-button"
+          onClick={() => onDeleteList('list1')}
+        >
+          Delete
+        </button>
+        <div data-testid="selector-loading">
+          {isLoading ? 'loading' : 'ready'}
+        </div>
+      </div>
+    );
+  }
+
   function CreateListDialog({ isOpen, onClose, onSubmit, isLoading }: any) {
     return (
       <div
@@ -172,6 +203,7 @@ jest.mock('../components', () => {
 
   return {
     GroceryListSelector,
+    TripBoardIndex,
     CreateListDialog,
     RenameListDialog,
     DeleteListConfirmDialog,

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/GroceriesPageClient.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/GroceriesPageClient.spec.tsx
@@ -1089,13 +1089,14 @@ describe('GroceriesPageClient', () => {
 
       fireEvent.click(screen.getByTestId('selector-rename-button'));
 
-      let renameDialog = screen.getByTestId('rename-list-dialog');
+      const renameDialog = screen.getByTestId('rename-list-dialog');
       expect(renameDialog).toHaveAttribute('data-open', 'true');
 
       fireEvent.click(screen.getByTestId('dialog-rename-close'));
 
-      renameDialog = screen.queryByTestId('rename-list-dialog');
-      expect(renameDialog).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('rename-list-dialog'),
+      ).not.toBeInTheDocument();
     });
 
     it('should persist dialog state across renders', async () => {
@@ -1231,7 +1232,7 @@ describe('GroceriesPageClient', () => {
       fireEvent.click(screen.getByTestId('selector-rename-button'));
 
       // Dialog opens with correct name
-      let dialog = screen.getByTestId('rename-list-dialog');
+      const dialog = screen.getByTestId('rename-list-dialog');
       expect(dialog).toHaveAttribute('data-open', 'true');
       expect(dialog).toHaveAttribute('data-current-name', 'Groceries');
 
@@ -1240,8 +1241,9 @@ describe('GroceriesPageClient', () => {
 
       // Dialog closes after submission
       await waitFor(() => {
-        dialog = screen.queryByTestId('rename-list-dialog');
-        expect(dialog).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId('rename-list-dialog'),
+        ).not.toBeInTheDocument();
       });
 
       // vault.renameList was called with correct args
@@ -1266,7 +1268,7 @@ describe('GroceriesPageClient', () => {
       fireEvent.click(screen.getByTestId('selector-delete-button'));
 
       // Dialog opens with correct info
-      let dialog = screen.getByTestId('delete-list-dialog');
+      const dialog = screen.getByTestId('delete-list-dialog');
       expect(dialog).toHaveAttribute('data-open', 'true');
       expect(dialog).toHaveAttribute('data-list-name', 'Groceries');
       expect(dialog).toHaveAttribute('data-item-count', '5');
@@ -1276,8 +1278,9 @@ describe('GroceriesPageClient', () => {
 
       // Dialog closes after deletion
       await waitFor(() => {
-        dialog = screen.queryByTestId('delete-list-dialog');
-        expect(dialog).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId('delete-list-dialog'),
+        ).not.toBeInTheDocument();
       });
 
       // vault.deleteList was called

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/GroceriesPageClient.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/GroceriesPageClient.spec.tsx
@@ -65,6 +65,7 @@ jest.mock('../components', () => {
 
   function GroceryListSelector({
     lists,
+    catalog,
     onRenameList,
     onDeleteList,
     isLoading,
@@ -72,6 +73,7 @@ jest.mock('../components', () => {
     return (
       <div data-testid="grocery-list-selector">
         <div data-testid="lists-count">{lists.length}</div>
+        <div data-testid="catalog-count">{catalog?.length ?? 0}</div>
         <button
           data-testid="selector-rename-button"
           onClick={() => onRenameList('list1')}
@@ -176,7 +178,7 @@ jest.mock('../components', () => {
   };
 });
 
-import type { GroceryList } from '@myorganizer/core';
+import type { CatalogItem, GroceryList } from '@myorganizer/core';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { GroceriesPageClient as GroceriesPage } from '../GroceriesPageClient';
@@ -191,6 +193,7 @@ describe('GroceriesPageClient', () => {
 
   interface VaultState {
     lists: GroceryList[];
+    catalog: CatalogItem[];
     loading: boolean;
     error: string | null;
     selectedListIds: string[];
@@ -204,6 +207,7 @@ describe('GroceriesPageClient', () => {
   function makeVaultState(overrides?: Partial<VaultState>): VaultState {
     return {
       lists: [],
+      catalog: [],
       loading: false,
       error: null,
       selectedListIds: [],
@@ -224,12 +228,12 @@ describe('GroceriesPageClient', () => {
     return {
       id,
       name,
-      items: Array.from({ length: itemCount }, (_, i) => ({
-        id: `item-${i}`,
-        name: `Item ${i}`,
-        completed: false,
-        quantity: 1,
-        unit: '',
+      lines: Array.from({ length: itemCount }, (_, i) => ({
+        id: `line-${i}`,
+        catalogItemId: `catalog-item-${i}`,
+        checked: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
       })),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -422,6 +426,26 @@ describe('GroceriesPageClient', () => {
       render(<GroceriesPage />);
 
       expect(screen.getByTestId('lists-count')).toHaveTextContent('2');
+    });
+
+    it('should pass vault.catalog through to GroceryListSelector', () => {
+      const lists = [makeGroceryList('list1', 'Groceries', 1)];
+      const catalog: CatalogItem[] = [
+        {
+          id: 'catalog-item-0',
+          name: 'Milk',
+          category: 'dairy',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ];
+      mockUseGroceriesVault.mockReturnValue(
+        makeVaultState({ lists, catalog, loading: false }),
+      );
+
+      render(<GroceriesPage />);
+
+      expect(screen.getByTestId('catalog-count')).toHaveTextContent('1');
     });
 
     it('should pass loading state to GroceryListSelector', () => {

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/GroceryListSelector.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/GroceryListSelector.spec.tsx
@@ -5,9 +5,12 @@
 */
 /** Mocking rule: place jest.mock calls before any imports */
 jest.mock('@myorganizer/web-ui', () => {
-  const React = require('react');
+  const React = require('react') as typeof import('react');
 
-  const MenuContext = React.createContext<any>(null);
+  const MenuContext = React.createContext<{
+    isOpen: boolean;
+    toggle: (next?: boolean) => void;
+  } | null>(null);
 
   function DropdownMenu({ open, onOpenChange, children }: any) {
     const [isOpen, setIsOpen] = React.useState(Boolean(open));
@@ -80,18 +83,14 @@ import { GroceryListSelector } from '../components/GroceryListSelector';
 describe('GroceryListSelector', () => {
   const NOW_ISO = '2026-06-04T12:00:00.000Z';
 
-  beforeAll(() => {
+  beforeEach(() => {
+    jest.resetAllMocks();
     jest.useFakeTimers();
-    // @ts-expect-error - Jest global setSystemTime exists on modern Jest
     jest.setSystemTime(new Date(NOW_ISO));
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.useRealTimers();
-  });
-
-  beforeEach(() => {
-    jest.resetAllMocks();
   });
 
   function makeCatalogItem(id: string, category = 'produce'): CatalogItem {
@@ -133,7 +132,10 @@ describe('GroceryListSelector', () => {
   }
 
   it('renders lists with name, item counts, timestamp and progress', async () => {
-    const catalog = [makeCatalogItem('i1'), makeCatalogItem('i2')];
+    const catalog = [
+      { ...makeCatalogItem('i1'), price: 2.5 },
+      makeCatalogItem('i2'),
+    ];
     const lists = [
       makeList({
         id: 'l1',
@@ -163,21 +165,24 @@ describe('GroceryListSelector', () => {
     );
 
     // Names and item counts
-    expect(screen.getByText('Groceries A')).toBeTruthy();
-    expect(screen.getByText('Groceries B')).toBeTruthy();
-    expect(screen.getByText('1 / 2 items')).toBeTruthy();
-    expect(screen.getByText('0 / 0 items')).toBeTruthy();
+    expect(screen.getByText('Groceries A')).not.toBeNull();
+    expect(screen.getByText('Groceries B')).not.toBeNull();
+    expect(screen.getByText('1 / 2 items')).not.toBeNull();
+    expect(screen.getByText('0 / 0 items')).not.toBeNull();
+    expect(
+      screen.getByLabelText('Known spend $2.50; 1 item unpriced'),
+    ).not.toBeNull();
 
     // Relative times (5m ago, 2h ago)
-    expect(screen.getByText(/5m ago/)).toBeTruthy();
-    expect(screen.getByText(/2h ago/)).toBeTruthy();
+    expect(screen.getByText(/5m ago/)).not.toBeNull();
+    expect(screen.getByText(/2h ago/)).not.toBeNull();
 
     // Progress bar for first list should be 50% (1/2)
     const cardA = screen
       .getByText('Groceries A')
       .closest('[role="article"]') as HTMLElement;
     const progressInner = cardA.querySelector('div[style]') as HTMLElement;
-    expect(progressInner).toBeTruthy();
+    expect(progressInner).not.toBeNull();
     expect(progressInner.style.width).toBe('50%');
 
     // Clicking checkbox toggles internal selection (shows border-error shadow-md)
@@ -239,9 +244,9 @@ describe('GroceryListSelector', () => {
 
     const header = screen.getByText('Active Lists');
     // The count is rendered in a span next to header
-    expect(header).toBeTruthy();
+    expect(header).not.toBeNull();
     const countSpan = header.parentElement?.querySelector('span');
-    expect(countSpan).toBeTruthy();
+    expect(countSpan).not.toBeNull();
     expect(countSpan?.textContent).toBe('0');
   });
 
@@ -275,17 +280,23 @@ describe('GroceryListSelector', () => {
     const noItemsCard = screen
       .getByText('No Items')
       .closest('[role="article"]') as HTMLElement;
-    expect(noItemsCard.querySelector('div[style]')!.style.width).toBe('0%');
+    expect(
+      (noItemsCard.querySelector('div[style]') as HTMLElement).style.width,
+    ).toBe('0%');
 
     const s1 = screen
       .getByText('SingleChecked')
       .closest('[role="article"]') as HTMLElement;
-    expect(s1.querySelector('div[style]')!.style.width).toBe('100%');
+    expect((s1.querySelector('div[style]') as HTMLElement).style.width).toBe(
+      '100%',
+    );
 
     const s2 = screen
       .getByText('SingleUnchecked')
       .closest('[role="article"]') as HTMLElement;
-    expect(s2.querySelector('div[style]')!.style.width).toBe('0%');
+    expect((s2.querySelector('div[style]') as HTMLElement).style.width).toBe(
+      '0%',
+    );
   });
 
   it('rename and delete menu items call handlers and do not propagate select click', async () => {
@@ -364,8 +375,8 @@ describe('GroceryListSelector', () => {
     );
 
     // All names are present (including long name prefix)
-    expect(screen.getByText('List 0')).toBeTruthy();
-    expect(screen.getByText(new RegExp(longName.slice(0, 10)))).toBeTruthy();
+    expect(screen.getByText('List 0')).not.toBeNull();
+    expect(screen.getByText(new RegExp(longName.slice(0, 10)))).not.toBeNull();
   });
 
   it('formats relative times: Just now, Xm ago, Xh ago, Xd ago, date for older', () => {
@@ -412,12 +423,12 @@ describe('GroceryListSelector', () => {
       />,
     );
 
-    expect(screen.getByText(/Just now/)).toBeTruthy();
-    expect(screen.getByText(/5m ago/)).toBeTruthy();
-    expect(screen.getByText(/2h ago/)).toBeTruthy();
-    expect(screen.getByText(/3d ago/)).toBeTruthy();
+    expect(screen.getByText(/Just now/)).not.toBeNull();
+    expect(screen.getByText(/5m ago/)).not.toBeNull();
+    expect(screen.getByText(/2h ago/)).not.toBeNull();
+    expect(screen.getByText(/3d ago/)).not.toBeNull();
 
     const oldDate = new Date('2020-01-01T00:00:00.000Z').toLocaleDateString();
-    expect(screen.getByText(new RegExp(oldDate))).toBeTruthy();
+    expect(screen.getByText(new RegExp(oldDate))).not.toBeNull();
   });
 });

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/GroceryListSelector.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/GroceryListSelector.spec.tsx
@@ -73,6 +73,7 @@ jest.mock('@myorganizer/web-ui', () => {
   };
 });
 
+import type { CatalogItem, GroceryList, ListLine } from '@myorganizer/core';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { GroceryListSelector } from '../components/GroceryListSelector';
 
@@ -93,20 +94,51 @@ describe('GroceryListSelector', () => {
     jest.resetAllMocks();
   });
 
-  function makeItem(id: string, checked = false, category = 'produce') {
-    return { id, name: `Item ${id}`, checked, category };
+  function makeCatalogItem(id: string, category = 'produce'): CatalogItem {
+    return {
+      id,
+      name: `Item ${id}`,
+      category: category as CatalogItem['category'],
+      createdAt: NOW_ISO,
+      updatedAt: NOW_ISO,
+    };
   }
 
-  function makeList({ id, name, items, updatedAt }: any) {
-    return { id, name, items, updatedAt };
+  function makeLine(
+    id: string,
+    catalogItemId: string,
+    checked = false,
+  ): ListLine {
+    return {
+      id,
+      catalogItemId,
+      checked,
+      createdAt: NOW_ISO,
+      updatedAt: NOW_ISO,
+    };
+  }
+
+  function makeList({
+    id,
+    name,
+    lines,
+    updatedAt,
+  }: {
+    id: string;
+    name: string;
+    lines: ListLine[];
+    updatedAt: string;
+  }): GroceryList {
+    return { id, name, lines, updatedAt, createdAt: updatedAt };
   }
 
   it('renders lists with name, item counts, timestamp and progress', async () => {
+    const catalog = [makeCatalogItem('i1'), makeCatalogItem('i2')];
     const lists = [
       makeList({
         id: 'l1',
         name: 'Groceries A',
-        items: [makeItem('i1', true), makeItem('i2', false)],
+        lines: [makeLine('ln1', 'i1', true), makeLine('ln2', 'i2', false)],
         updatedAt: new Date(
           new Date(NOW_ISO).getTime() - 5 * 60000,
         ).toISOString(),
@@ -114,17 +146,17 @@ describe('GroceryListSelector', () => {
       makeList({
         id: 'l2',
         name: 'Groceries B',
-        items: [],
+        lines: [],
         updatedAt: new Date(
           new Date(NOW_ISO).getTime() - 2 * 3600000,
         ).toISOString(),
       }),
     ];
 
-    const onSelect = jest.fn();
     render(
       <GroceryListSelector
         lists={lists}
+        catalog={catalog}
         onRenameList={jest.fn()}
         onDeleteList={jest.fn()}
       />,
@@ -158,11 +190,12 @@ describe('GroceryListSelector', () => {
   });
 
   it('shows selected styling when list checkbox is clicked', () => {
+    const catalog = [makeCatalogItem('a')];
     const lists = [
       makeList({
         id: 'sel',
         name: 'Selected List',
-        items: [makeItem('a', true)],
+        lines: [makeLine('ln-a', 'a', true)],
         updatedAt: NOW_ISO,
       }),
     ];
@@ -170,6 +203,7 @@ describe('GroceryListSelector', () => {
     render(
       <GroceryListSelector
         lists={lists}
+        catalog={catalog}
         onRenameList={jest.fn()}
         onDeleteList={jest.fn()}
       />,
@@ -197,8 +231,7 @@ describe('GroceryListSelector', () => {
     render(
       <GroceryListSelector
         lists={[]}
-        selectedListIds={[]}
-        onSelectLists={jest.fn()}
+        catalog={[]}
         onRenameList={jest.fn()}
         onDeleteList={jest.fn()}
       />,
@@ -213,18 +246,19 @@ describe('GroceryListSelector', () => {
   });
 
   it('shows 0% progress for lists with no items and 100%/0% for single item cases', () => {
+    const catalog = [makeCatalogItem('x'), makeCatalogItem('y')];
     const lists = [
-      makeList({ id: 'n', name: 'No Items', items: [], updatedAt: NOW_ISO }),
+      makeList({ id: 'n', name: 'No Items', lines: [], updatedAt: NOW_ISO }),
       makeList({
         id: 's1',
         name: 'SingleChecked',
-        items: [makeItem('x', true)],
+        lines: [makeLine('ln-x', 'x', true)],
         updatedAt: NOW_ISO,
       }),
       makeList({
         id: 's2',
         name: 'SingleUnchecked',
-        items: [makeItem('y', false)],
+        lines: [makeLine('ln-y', 'y', false)],
         updatedAt: NOW_ISO,
       }),
     ];
@@ -232,8 +266,7 @@ describe('GroceryListSelector', () => {
     render(
       <GroceryListSelector
         lists={lists}
-        selectedListIds={[]}
-        onSelectLists={jest.fn()}
+        catalog={catalog}
         onRenameList={jest.fn()}
         onDeleteList={jest.fn()}
       />,
@@ -258,13 +291,13 @@ describe('GroceryListSelector', () => {
   it('rename and delete menu items call handlers and do not propagate select click', async () => {
     const onRename = jest.fn();
     const onDelete = jest.fn();
-    const onSelect = jest.fn();
 
+    const catalog = [makeCatalogItem('a')];
     const lists = [
       makeList({
         id: 'm1',
         name: 'MenuList',
-        items: [makeItem('a')],
+        lines: [makeLine('ln-a', 'a')],
         updatedAt: NOW_ISO,
       }),
     ];
@@ -272,8 +305,7 @@ describe('GroceryListSelector', () => {
     render(
       <GroceryListSelector
         lists={lists}
-        selectedListIds={[]}
-        onSelectLists={onSelect}
+        catalog={catalog}
         onRenameList={onRename}
         onDeleteList={onDelete}
       />,
@@ -295,8 +327,6 @@ describe('GroceryListSelector', () => {
     expect(onRename).toHaveBeenCalledWith('m1');
     // menu should close
     expect(dropdown.dataset.open).toBe('false');
-    // rename should not trigger parent select
-    expect(onSelect).not.toHaveBeenCalled();
 
     // Re-open and Delete
     fireEvent.click(trigger);
@@ -305,15 +335,15 @@ describe('GroceryListSelector', () => {
     fireEvent.click(del);
     expect(onDelete).toHaveBeenCalledWith('m1');
     expect(dropdown.dataset.open).toBe('false');
-    expect(onSelect).not.toHaveBeenCalled();
   });
 
   it('renders many lists and handles very long names without crashing', () => {
+    const catalog = [makeCatalogItem('a')];
     const many = Array.from({ length: 12 }).map((_, i) =>
       makeList({
         id: `L${i}`,
         name: `List ${i}`,
-        items: [makeItem('a')],
+        lines: [makeLine(`ln-${i}`, 'a')],
         updatedAt: NOW_ISO,
       }),
     );
@@ -321,14 +351,13 @@ describe('GroceryListSelector', () => {
     // Add very long name
     const longName = 'L'.repeat(120);
     many.push(
-      makeList({ id: 'long', name: longName, items: [], updatedAt: NOW_ISO }),
+      makeList({ id: 'long', name: longName, lines: [], updatedAt: NOW_ISO }),
     );
 
     render(
       <GroceryListSelector
         lists={many}
-        selectedListIds={[]}
-        onSelectLists={jest.fn()}
+        catalog={catalog}
         onRenameList={jest.fn()}
         onDeleteList={jest.fn()}
       />,
@@ -345,31 +374,31 @@ describe('GroceryListSelector', () => {
       makeList({
         id: 'jn',
         name: 'JustNow',
-        items: [],
+        lines: [],
         updatedAt: new Date(now - 30 * 1000).toISOString(),
       }),
       makeList({
         id: 'm5',
         name: 'FiveMin',
-        items: [],
+        lines: [],
         updatedAt: new Date(now - 5 * 60000).toISOString(),
       }),
       makeList({
         id: 'h2',
         name: 'TwoHour',
-        items: [],
+        lines: [],
         updatedAt: new Date(now - 2 * 3600000).toISOString(),
       }),
       makeList({
         id: 'd3',
         name: 'ThreeDay',
-        items: [],
+        lines: [],
         updatedAt: new Date(now - 3 * 86400000).toISOString(),
       }),
       makeList({
         id: 'old',
         name: 'Old',
-        items: [],
+        lines: [],
         updatedAt: new Date('2020-01-01T00:00:00.000Z').toISOString(),
       }),
     ];
@@ -377,8 +406,7 @@ describe('GroceryListSelector', () => {
     render(
       <GroceryListSelector
         lists={lists}
-        selectedListIds={[]}
-        onSelectLists={jest.fn()}
+        catalog={[]}
         onRenameList={jest.fn()}
         onDeleteList={jest.fn()}
       />,

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/RenameListDialog.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/RenameListDialog.spec.tsx
@@ -203,7 +203,7 @@ describe('RenameListDialog', () => {
 
     it('should disable submit button when submitting is true', async () => {
       const slowSubmit = jest.fn(
-        () => new Promise((resolve) => setTimeout(resolve, 100)),
+        () => new Promise<void>((resolve) => setTimeout(resolve, 100)),
       );
       render(<RenameListDialog {...defaultProps} onSubmit={slowSubmit} />);
 
@@ -306,7 +306,7 @@ describe('RenameListDialog', () => {
 
     it('should show "Saving..." text during submission', async () => {
       const slowSubmit = jest.fn(
-        () => new Promise((resolve) => setTimeout(resolve, 100)),
+        () => new Promise<void>((resolve) => setTimeout(resolve, 100)),
       );
       render(<RenameListDialog {...defaultProps} onSubmit={slowSubmit} />);
 

--- a/libs/web/pages/groceries/src/groceries-page/__tests__/TripBoardIndex.spec.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/__tests__/TripBoardIndex.spec.tsx
@@ -1,0 +1,290 @@
+/** Mocking rule: place jest.mock calls before any imports. */
+jest.mock('@myorganizer/web-ui', () => {
+  const React = require('react') as typeof import('react');
+
+  return {
+    Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+      <input {...props} />
+    ),
+    Label: (props: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+      <label {...props} />
+    ),
+  };
+});
+
+jest.mock('../components/GroceryListSelector', () => ({
+  GroceryListSelector: ({
+    lists,
+    onRenameList,
+    onDeleteList,
+    isLoading,
+  }: {
+    lists: Array<{ id: string; name: string }>;
+    onRenameList: (id: string) => void;
+    onDeleteList: (id: string) => void;
+    isLoading?: boolean;
+  }) => (
+    <section
+      aria-label="Trip cards"
+      data-loading={isLoading ? 'true' : 'false'}
+    >
+      {lists.map((list) => (
+        <article key={list.id}>
+          <h3>{list.name}</h3>
+          <button type="button" onClick={() => onRenameList(list.id)}>
+            Rename {list.name}
+          </button>
+          <button type="button" onClick={() => onDeleteList(list.id)}>
+            Delete {list.name}
+          </button>
+        </article>
+      ))}
+    </section>
+  ),
+}));
+
+import type { CatalogItem, GroceryList, ListLine } from '@myorganizer/core';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { TripBoardIndex } from '../components/TripBoardIndex';
+
+const DATE = '2026-01-01T00:00:00.000Z';
+
+function makeCatalogItem(
+  id: string,
+  name: string,
+  category: CatalogItem['category'] = 'produce',
+  price?: number,
+): CatalogItem {
+  return {
+    id,
+    name,
+    category,
+    ...(price === undefined ? {} : { price }),
+    createdAt: DATE,
+    updatedAt: DATE,
+  };
+}
+
+function makeList(
+  id: string,
+  name: string,
+  catalogItemIds: string[],
+): GroceryList {
+  const lines: ListLine[] = catalogItemIds.map((catalogItemId, index) => ({
+    id: `${id}-line-${index}`,
+    catalogItemId,
+    checked: false,
+    createdAt: DATE,
+    updatedAt: DATE,
+  }));
+  return { id, name, lines, createdAt: DATE, updatedAt: DATE };
+}
+
+describe('TripBoardIndex', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the Staples catalog strip and existing trip cards', () => {
+    const catalog = [makeCatalogItem('milk', 'Milk', 'dairy', 2.5)];
+    const lists = [makeList('weekly', 'Weekly Shop', ['milk'])];
+
+    render(
+      <TripBoardIndex
+        lists={lists}
+        catalog={catalog}
+        onRenameList={jest.fn()}
+        onDeleteList={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Staples' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Milk' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Weekly Shop' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Showing 1 of 1 trip')).toBeInTheDocument();
+  });
+
+  it('case-insensitively searches list names and catalog item names', () => {
+    const catalog = [
+      makeCatalogItem('milk', 'Milk', 'dairy'),
+      makeCatalogItem('bread', 'Bread', 'bakery'),
+    ];
+    const lists = [
+      makeList('weekly', 'Weekly Shop', ['milk']),
+      makeList('hardware', 'Hardware Run', ['bread']),
+    ];
+
+    render(
+      <TripBoardIndex
+        lists={lists}
+        catalog={catalog}
+        onRenameList={jest.fn()}
+        onDeleteList={jest.fn()}
+      />,
+    );
+    const search = screen.getByRole('textbox', {
+      name: 'Search trips and staples',
+    });
+
+    fireEvent.change(search, { target: { value: 'MILK' } });
+
+    expect(screen.getByRole('heading', { name: 'Milk' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Bread' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Weekly Shop' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Hardware Run' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Showing 1 of 2 trips matching “MILK”'),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps a trip whose line references a matching catalog item', () => {
+    const catalog = [
+      makeCatalogItem('apples', 'Green Apples'),
+      makeCatalogItem('coffee', 'Coffee'),
+    ];
+    const lists = [
+      makeList('fruit', 'Fruit Trip', ['apples']),
+      makeList('cafe', 'Cafe Trip', ['coffee']),
+    ];
+
+    render(
+      <TripBoardIndex
+        lists={lists}
+        catalog={catalog}
+        onRenameList={jest.fn()}
+        onDeleteList={jest.fn()}
+      />,
+    );
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'Search trips and staples' }),
+      {
+        target: { value: 'apples' },
+      },
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Fruit Trip' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Cafe Trip' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('browses staples by category and exposes the pressed state', () => {
+    const catalog = [
+      makeCatalogItem('milk', 'Milk', 'dairy'),
+      makeCatalogItem('lettuce', 'Lettuce', 'produce'),
+    ];
+
+    render(
+      <TripBoardIndex
+        lists={[]}
+        catalog={catalog}
+        onRenameList={jest.fn()}
+        onDeleteList={jest.fn()}
+      />,
+    );
+    const dairy = screen.getByRole('button', {
+      name: 'Filter staples by Dairy',
+    });
+
+    fireEvent.click(dairy);
+
+    expect(dairy).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('heading', { name: 'Milk' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Lettuce' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Show all staples' }),
+    ).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows known prices and omits the price for unpriced catalog items', () => {
+    const catalog = [
+      makeCatalogItem('oil', 'Olive Oil', 'condiments', 4),
+      makeCatalogItem('salt', 'Salt', 'condiments'),
+    ];
+
+    render(
+      <TripBoardIndex
+        lists={[]}
+        catalog={catalog}
+        onRenameList={jest.fn()}
+        onDeleteList={jest.fn()}
+      />,
+    );
+
+    expect(
+      within(
+        screen
+          .getByRole('heading', { name: 'Olive Oil' })
+          .closest('article') as HTMLElement,
+      ).getByText('$4.00'),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen
+          .getByRole('heading', { name: 'Salt' })
+          .closest('article') as HTMLElement,
+      ).queryByText(/\$/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reports an empty staple result and the zero-trip search summary', () => {
+    render(
+      <TripBoardIndex
+        lists={[makeList('trip', 'Weekly Shop', [])]}
+        catalog={[makeCatalogItem('milk', 'Milk')]}
+        onRenameList={jest.fn()}
+        onDeleteList={jest.fn()}
+      />,
+    );
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'Search trips and staples' }),
+      {
+        target: { value: 'zzzz' },
+      },
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'No staples match the current filters.',
+    );
+    expect(
+      screen.getByText('Showing 0 of 1 trip matching “zzzz”'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Weekly Shop' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('passes rename and delete callbacks through to the trip-card selector', () => {
+    const onRenameList = jest.fn();
+    const onDeleteList = jest.fn();
+    render(
+      <TripBoardIndex
+        lists={[makeList('trip', 'Weekly Shop', [])]}
+        catalog={[]}
+        onRenameList={onRenameList}
+        onDeleteList={onDeleteList}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Weekly Shop' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Weekly Shop' }));
+
+    expect(onRenameList).toHaveBeenCalledWith('trip');
+    expect(onDeleteList).toHaveBeenCalledWith('trip');
+  });
+});

--- a/libs/web/pages/groceries/src/groceries-page/components/GroceryListSelector.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/components/GroceryListSelector.tsx
@@ -9,7 +9,9 @@ import {
 } from '@myorganizer/web-ui';
 import { MoreVertical, Trash2 } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+import type { ChangeEvent, MouseEvent } from 'react';
+import { formatMoney, summarizeListSpend } from '../../shared/utils';
 
 interface GroceryListSelectorProps {
   lists: GroceryList[];
@@ -19,7 +21,6 @@ interface GroceryListSelectorProps {
   isLoading?: boolean;
 }
 
-// Category icon map for visual variety
 const CATEGORY_ICONS: Record<string, string> = {
   produce: '🥬',
   dairy: '🥛',
@@ -35,7 +36,6 @@ const CATEGORY_ICONS: Record<string, string> = {
   other: '🛒',
 };
 
-// Get category from lines or use default
 function getDominantCategory(
   lines: ListLine[],
   catalog: CatalogItem[],
@@ -52,7 +52,6 @@ function getDominantCategory(
   return Object.entries(counts).sort(([, a], [, b]) => b - a)[0][0];
 }
 
-// Format timestamp to relative time
 function formatRelativeTime(dateString: string): string {
   const date = new Date(dateString);
   const now = new Date();
@@ -79,13 +78,43 @@ export function GroceryListSelector({
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const [selectedListIds, setSelectedListIds] = useState<string[]>([]);
 
-  const handleToggleSelect = (listId: string) => {
-    if (selectedListIds.includes(listId)) {
-      setSelectedListIds(selectedListIds.filter((id) => id !== listId));
-    } else {
-      setSelectedListIds([...selectedListIds, listId]);
-    }
-  };
+  const handleStopPropagation = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+  }, []);
+
+  const createMenuOpenChangeHandler = useCallback(
+    (listId: string) => (open: boolean) => {
+      setOpenMenuId(open ? listId : null);
+    },
+    [],
+  );
+
+  const createMenuActionHandler = useCallback(
+    (action: 'rename' | 'delete', listId: string) => (event: MouseEvent) => {
+      event.stopPropagation();
+      if (action === 'rename') {
+        onRenameList(listId);
+      } else {
+        onDeleteList(listId);
+      }
+      setOpenMenuId(null);
+    },
+    [onDeleteList, onRenameList],
+  );
+
+  const handleToggleSelect = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const listId = event.currentTarget.dataset.listId;
+      if (!listId) return;
+
+      setSelectedListIds((currentIds) =>
+        currentIds.includes(listId)
+          ? currentIds.filter((id) => id !== listId)
+          : [...currentIds, listId],
+      );
+    },
+    [],
+  );
 
   return (
     <div className="space-y-3">
@@ -99,6 +128,7 @@ export function GroceryListSelector({
           const dominantCategory = getDominantCategory(list.lines, catalog);
           const icon = CATEGORY_ICONS[dominantCategory];
           const checkedCount = list.lines.filter((line) => line.checked).length;
+          const spendSummary = summarizeListSpend(list.lines, catalog);
           const isSelected = selectedListIds.includes(list.id);
           const progressPercent =
             list.lines.length > 0
@@ -115,15 +145,14 @@ export function GroceryListSelector({
               } ${isLoading ? 'opacity-60 pointer-events-none' : ''}`}
               role="article"
             >
-              {/* Content */}
               <div className="relative">
-                {/* Header with checkbox and title link and menu */}
                 <div className="mb-3 flex items-start justify-between gap-3">
                   <div className="flex items-center gap-3">
                     <input
                       type="checkbox"
                       checked={isSelected}
-                      onChange={() => handleToggleSelect(list.id)}
+                      data-list-id={list.id}
+                      onChange={handleToggleSelect}
                       className="h-5 w-5 cursor-pointer rounded border-2 border-on-surface-variant accent-error"
                       aria-label={`Select ${list.name} for deletion`}
                       disabled={isLoading}
@@ -133,7 +162,6 @@ export function GroceryListSelector({
                     </div>
                   </div>
 
-                  {/* Title as link - clickable */}
                   <Link
                     href={`/dashboard/groceries/${list.id}`}
                     className="flex-1 rounded-lg px-2 py-1 transition-colors hover:bg-secondary-container/30"
@@ -146,37 +174,26 @@ export function GroceryListSelector({
                     </p>
                   </Link>
 
-                  {/* Context menu */}
                   <DropdownMenu
                     open={openMenuId === list.id}
-                    onOpenChange={(open) =>
-                      setOpenMenuId(open ? list.id : null)
-                    }
+                    onOpenChange={createMenuOpenChangeHandler(list.id)}
                   >
                     <DropdownMenuTrigger
                       className="flex-shrink-0 rounded p-1 opacity-0 transition-opacity hover:bg-surface-container group-hover:opacity-100"
-                      onClick={(e) => e.stopPropagation()}
+                      onClick={handleStopPropagation}
                       aria-label={`More actions for ${list.name}`}
                     >
                       <MoreVertical className="h-4 w-4 text-on-surface-variant" />
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-40">
                       <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onRenameList(list.id);
-                          setOpenMenuId(null);
-                        }}
+                        onClick={createMenuActionHandler('rename', list.id)}
                       >
                         Rename
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         className="text-error focus:bg-error/10 focus:text-error"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onDeleteList(list.id);
-                          setOpenMenuId(null);
-                        }}
+                        onClick={createMenuActionHandler('delete', list.id)}
                       >
                         <Trash2 className="mr-2 h-4 w-4" />
                         Delete
@@ -185,7 +202,6 @@ export function GroceryListSelector({
                   </DropdownMenu>
                 </div>
 
-                {/* Item count and timestamp */}
                 <div className="mb-3 flex items-center justify-between text-xs text-on-surface-variant">
                   <span>
                     {checkedCount} / {list.lines.length} items
@@ -193,7 +209,19 @@ export function GroceryListSelector({
                   <span>Updated {formatRelativeTime(list.updatedAt)}</span>
                 </div>
 
-                {/* Progress bar */}
+                <div
+                  className="mb-3 flex items-center justify-between gap-3 text-xs"
+                  aria-label={`Known spend ${formatMoney(spendSummary.known)}; ${spendSummary.unpricedCount} item${spendSummary.unpricedCount !== 1 ? 's' : ''} unpriced`}
+                >
+                  <span className="font-semibold text-on-surface">
+                    Known spend {formatMoney(spendSummary.known)}
+                  </span>
+                  <span className="text-on-surface-variant">
+                    {spendSummary.unpricedCount} item
+                    {spendSummary.unpricedCount !== 1 ? 's' : ''} unpriced
+                  </span>
+                </div>
+
                 <div className="h-2 overflow-hidden rounded-full bg-surface-container">
                   <div
                     className={`h-full transition-all ${

--- a/libs/web/pages/groceries/src/groceries-page/components/GroceryListSelector.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/components/GroceryListSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { GroceryList } from '@myorganizer/core';
+import type { CatalogItem, GroceryList, ListLine } from '@myorganizer/core';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,6 +13,7 @@ import { useState } from 'react';
 
 interface GroceryListSelectorProps {
   lists: GroceryList[];
+  catalog: CatalogItem[];
   onRenameList: (id: string) => void;
   onDeleteList: (id: string) => void;
   isLoading?: boolean;
@@ -34,10 +35,16 @@ const CATEGORY_ICONS: Record<string, string> = {
   other: '🛒',
 };
 
-// Get category from items or use default
-function getDominantCategory(items: any[]): string {
-  if (items.length === 0) return 'other';
-  const categories = items.map((item) => item.category);
+// Get category from lines or use default
+function getDominantCategory(
+  lines: ListLine[],
+  catalog: CatalogItem[],
+): string {
+  if (lines.length === 0) return 'other';
+  const categories = lines.map((line) => {
+    const catalogItem = catalog.find((item) => item.id === line.catalogItemId);
+    return catalogItem?.category ?? 'other';
+  });
   const counts: Record<string, number> = {};
   for (const cat of categories) {
     counts[cat] = (counts[cat] || 0) + 1;
@@ -64,6 +71,7 @@ function formatRelativeTime(dateString: string): string {
 
 export function GroceryListSelector({
   lists,
+  catalog,
   onRenameList,
   onDeleteList,
   isLoading = false,
@@ -88,13 +96,13 @@ export function GroceryListSelector({
 
       <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
         {lists.map((list) => {
-          const dominantCategory = getDominantCategory(list.items);
+          const dominantCategory = getDominantCategory(list.lines, catalog);
           const icon = CATEGORY_ICONS[dominantCategory];
-          const checkedCount = list.items.filter((item) => item.checked).length;
+          const checkedCount = list.lines.filter((line) => line.checked).length;
           const isSelected = selectedListIds.includes(list.id);
           const progressPercent =
-            list.items.length > 0
-              ? Math.round((checkedCount / list.items.length) * 100)
+            list.lines.length > 0
+              ? Math.round((checkedCount / list.lines.length) * 100)
               : 0;
 
           return (
@@ -180,7 +188,7 @@ export function GroceryListSelector({
                 {/* Item count and timestamp */}
                 <div className="mb-3 flex items-center justify-between text-xs text-on-surface-variant">
                   <span>
-                    {checkedCount} / {list.items.length} items
+                    {checkedCount} / {list.lines.length} items
                   </span>
                   <span>Updated {formatRelativeTime(list.updatedAt)}</span>
                 </div>

--- a/libs/web/pages/groceries/src/groceries-page/components/TripBoardIndex.tsx
+++ b/libs/web/pages/groceries/src/groceries-page/components/TripBoardIndex.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import type {
+  CatalogItem,
+  GroceryCategoryType,
+  GroceryList,
+} from '@myorganizer/core';
+import { Input, Label } from '@myorganizer/web-ui';
+import { useCallback, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { GroceryListSelector } from './GroceryListSelector';
+import {
+  CATEGORY_ORDER,
+  getCategoryEmoji,
+  getCategoryLabel,
+} from '../../shared/constants/categories';
+import { formatMoney } from '../../shared/utils';
+
+export interface TripBoardIndexProps {
+  lists: GroceryList[];
+  catalog: CatalogItem[];
+  onRenameList: (id: string) => void;
+  onDeleteList: (id: string) => void;
+  isLoading?: boolean;
+}
+
+export function TripBoardIndex({
+  lists,
+  catalog,
+  onRenameList,
+  onDeleteList,
+  isLoading = false,
+}: TripBoardIndexProps) {
+  const [searchText, setSearchText] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<
+    GroceryCategoryType | 'all'
+  >('all');
+
+  const normalizedSearch = searchText.trim().toLowerCase();
+
+  const matchingCatalogIds = useMemo(() => {
+    if (!normalizedSearch) return new Set<string>();
+
+    return new Set(
+      catalog
+        .filter((item) => item.name.toLowerCase().includes(normalizedSearch))
+        .map((item) => item.id),
+    );
+  }, [catalog, normalizedSearch]);
+
+  const filteredLists = useMemo(() => {
+    if (!normalizedSearch) return lists;
+
+    return lists.filter(
+      (list) =>
+        list.name.toLowerCase().includes(normalizedSearch) ||
+        list.lines.some((line) => matchingCatalogIds.has(line.catalogItemId)),
+    );
+  }, [lists, matchingCatalogIds, normalizedSearch]);
+
+  const filteredCatalog = useMemo(
+    () =>
+      catalog.filter(
+        (item) =>
+          (!normalizedSearch ||
+            item.name.toLowerCase().includes(normalizedSearch)) &&
+          (selectedCategory === 'all' || item.category === selectedCategory),
+      ),
+    [catalog, normalizedSearch, selectedCategory],
+  );
+
+  const categoriesInUse = useMemo(() => {
+    const categories = new Set(catalog.map((item) => item.category));
+    return CATEGORY_ORDER.filter((category) => categories.has(category));
+  }, [catalog]);
+
+  const handleSearchChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setSearchText(event.currentTarget.value);
+    },
+    [],
+  );
+
+  const createCategoryChangeHandler = useCallback(
+    (category: GroceryCategoryType | 'all') => () => {
+      setSelectedCategory(category);
+    },
+    [],
+  );
+
+  const handleRenameList = useCallback(
+    (id: string) => {
+      onRenameList(id);
+    },
+    [onRenameList],
+  );
+
+  const handleDeleteList = useCallback(
+    (id: string) => {
+      onDeleteList(id);
+    },
+    [onDeleteList],
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <Label htmlFor="trip-board-search">Search trips and staples</Label>
+        <Input
+          id="trip-board-search"
+          value={searchText}
+          onChange={handleSearchChange}
+          placeholder="Search lists or staple names..."
+          aria-describedby="trip-board-results"
+        />
+      </div>
+
+      <section aria-labelledby="staples-heading" className="space-y-3">
+        <div>
+          <h2
+            id="staples-heading"
+            className="text-lg font-semibold text-on-surface md:text-xl"
+          >
+            Staples
+          </h2>
+          <p className="text-sm text-on-surface-variant">
+            Browse your catalog for the next trip.
+          </p>
+        </div>
+
+        <div
+          className="flex gap-2 overflow-x-auto py-1"
+          role="group"
+          aria-label="Filter staples by category"
+        >
+          <button
+            type="button"
+            aria-label="Show all staples"
+            aria-pressed={selectedCategory === 'all'}
+            onClick={createCategoryChangeHandler('all')}
+            className={`whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary ${
+              selectedCategory === 'all'
+                ? 'bg-secondary text-on-secondary'
+                : 'bg-secondary-container text-on-secondary-container'
+            }`}
+          >
+            All
+          </button>
+          {categoriesInUse.map((category) => (
+            <button
+              key={category}
+              type="button"
+              aria-label={`Filter staples by ${getCategoryLabel(category)}`}
+              aria-pressed={selectedCategory === category}
+              onClick={createCategoryChangeHandler(category)}
+              className={`flex items-center gap-2 whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary ${
+                selectedCategory === category
+                  ? 'bg-secondary text-on-secondary'
+                  : 'bg-secondary-container text-on-secondary-container'
+              }`}
+            >
+              <span aria-hidden="true">{getCategoryEmoji(category)}</span>
+              {getCategoryLabel(category)}
+            </button>
+          ))}
+        </div>
+
+        {filteredCatalog.length > 0 ? (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {filteredCatalog.map((item) => (
+              <article
+                key={item.id}
+                className="rounded-lg border border-surface-variant bg-surface-container-lowest p-4"
+              >
+                <div className="flex items-start gap-2">
+                  <span aria-hidden="true">
+                    {getCategoryEmoji(item.category)}
+                  </span>
+                  <div className="min-w-0">
+                    <h3 className="truncate font-medium text-on-surface">
+                      {item.name}
+                    </h3>
+                    <p className="text-sm text-on-surface-variant">
+                      {getCategoryLabel(item.category)}
+                    </p>
+                  </div>
+                </div>
+                {typeof item.price === 'number' && (
+                  <p className="mt-3 text-sm font-semibold text-on-surface">
+                    {formatMoney(item.price)}
+                  </p>
+                )}
+              </article>
+            ))}
+          </div>
+        ) : (
+          <p
+            className="rounded-lg border border-dashed border-outline-variant p-6 text-center text-sm text-on-surface-variant"
+            role="status"
+          >
+            No staples match the current filters.
+          </p>
+        )}
+      </section>
+
+      <p
+        id="trip-board-results"
+        className="text-sm text-on-surface-variant"
+        aria-live="polite"
+      >
+        Showing {filteredLists.length} of {lists.length} trip
+        {lists.length === 1 ? '' : 's'}
+        {normalizedSearch ? ` matching “${searchText.trim()}”` : ''}
+      </p>
+
+      <GroceryListSelector
+        lists={filteredLists}
+        catalog={catalog}
+        onRenameList={handleRenameList}
+        onDeleteList={handleDeleteList}
+        isLoading={isLoading}
+      />
+    </div>
+  );
+}

--- a/libs/web/pages/groceries/src/groceries-page/components/index.ts
+++ b/libs/web/pages/groceries/src/groceries-page/components/index.ts
@@ -2,3 +2,4 @@ export { CreateListDialog } from './CreateListDialog';
 export { DeleteListConfirmDialog } from './DeleteListConfirmDialog';
 export { GroceryListSelector } from './GroceryListSelector';
 export { RenameListDialog } from './RenameListDialog';
+export { TripBoardIndex } from './TripBoardIndex';

--- a/libs/web/pages/groceries/src/shared/components/__tests__/CategorySelect.spec.tsx
+++ b/libs/web/pages/groceries/src/shared/components/__tests__/CategorySelect.spec.tsx
@@ -1,8 +1,15 @@
 /** Mocking rule: place jest.mock calls before any imports */
 jest.mock('@myorganizer/web-ui', () => {
-  const React = require('react');
+  const React = require('react') as typeof import('react');
 
-  const SelectContext = React.createContext<any>(null);
+  const SelectContext = React.createContext<{
+    value?: string;
+    onValueChange?: (value: string) => void;
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    registerItem: (value: string, label: string) => void;
+    items: Record<string, string>;
+  } | null>(null);
 
   function Select({ value, onValueChange, children }: any) {
     const [open, setOpen] = React.useState(false);
@@ -60,6 +67,7 @@ jest.mock('@myorganizer/web-ui', () => {
 
   function SelectItem({ value, children, ...props }: any) {
     const ctx = React.useContext(SelectContext);
+    if (!ctx) return null;
     const ref = React.useRef<any>(null);
     const registerItem = ctx?.registerItem;
 

--- a/libs/web/pages/groceries/src/shared/hooks/__tests__/useGroceriesVault.spec.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/__tests__/useGroceriesVault.spec.ts
@@ -530,6 +530,319 @@ describe('useGroceriesVault', () => {
     });
   });
 
+  describe('updateCatalogItem', () => {
+    it('updates only durable Catalog Item fields and persists the complete payload', async () => {
+      const catalogItem = makeCatalogItem({
+        id: 'cat-1',
+        name: 'Milk',
+        category: 'dairy',
+        price: 3,
+        notes: 'Keep chilled',
+        imageUrl: 'https://old.example/milk',
+        links: ['https://old.example'],
+      });
+      const otherCatalogItem = makeCatalogItem({
+        id: 'cat-2',
+        name: 'Bread',
+        category: 'bakery',
+      });
+      const firstLine = makeLine({
+        id: 'line-1',
+        catalogItemId: 'cat-1',
+        checked: true,
+        amount: '2 cartons',
+      });
+      const secondLine = makeLine({
+        id: 'line-2',
+        catalogItemId: 'cat-2',
+        checked: false,
+        amount: '1 loaf',
+      });
+      const listA = makeList({ id: 'listA', name: 'A', lines: [firstLine] });
+      const listB = makeList({ id: 'listB', name: 'B', lines: [secondLine] });
+      const initialPayload = {
+        catalog: [catalogItem, otherCatalogItem],
+        lists: [listA, listB],
+      };
+      const result = await setup(initialPayload);
+
+      await act(async () => {
+        await result.current.updateCatalogItem({
+          id: 'cat-1',
+          name: 'Organic Milk',
+          category: 'dairy',
+          price: 4.5,
+          notes: 'New note',
+          imageUrl: 'https://new.example/milk',
+          links: ['https://new.example'],
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.catalog[0]).toMatchObject({
+          id: catalogItem.id,
+          name: 'Organic Milk',
+          category: 'dairy',
+          price: 4.5,
+          notes: 'New note',
+          imageUrl: 'https://new.example/milk',
+          links: ['https://new.example'],
+          createdAt: catalogItem.createdAt,
+        });
+        expect(result.current.catalog[0].createdAt).toBe(catalogItem.createdAt);
+        expect(result.current.catalog[1]).toEqual(otherCatalogItem);
+        expect(result.current.lists).toEqual(initialPayload.lists);
+
+        expect(mockSaveEncryptedData).toHaveBeenCalledTimes(1);
+        expect(mockSaveEncryptedData).toHaveBeenLastCalledWith({
+          masterKeyBytes,
+          type: 'groceries',
+          value: {
+            catalog: [
+              {
+                ...catalogItem,
+                name: 'Organic Milk',
+                price: 4.5,
+                notes: 'New note',
+                imageUrl: 'https://new.example/milk',
+                links: ['https://new.example'],
+                updatedAt: expect.any(String),
+              },
+              otherCatalogItem,
+            ],
+            lists: initialPayload.lists,
+          },
+        });
+      });
+    });
+
+    it('rejects an unknown Catalog Item without persistence or state changes', async () => {
+      const initialPayload = {
+        catalog: [makeCatalogItem({ id: 'cat-1', name: 'Milk' })],
+        lists: [makeList({ id: 'listA', name: 'A' })],
+      };
+      const result = await setup(initialPayload);
+
+      let thrownError: unknown;
+      await act(async () => {
+        try {
+          await result.current.updateCatalogItem({
+            id: 'missing',
+            name: 'Unknown',
+            category: 'other',
+          });
+        } catch (error) {
+          thrownError = error;
+        }
+      });
+
+      expect(thrownError).toEqual(new Error('Catalog Item not found'));
+      expect(mockSaveEncryptedData).not.toHaveBeenCalled();
+      expect(result.current.catalog).toEqual(initialPayload.catalog);
+      expect(result.current.lists).toEqual(initialPayload.lists);
+    });
+
+    it('rethrows a persistence failure and leaves Catalog Item state unchanged', async () => {
+      const initialPayload = {
+        catalog: [makeCatalogItem({ id: 'cat-1', name: 'Milk' })],
+        lists: [makeList({ id: 'listA', name: 'A' })],
+      };
+      const result = await setup(initialPayload);
+      const saveError = new Error('save failed');
+      mockSaveEncryptedData.mockRejectedValue(saveError);
+
+      let thrownError: unknown;
+      await act(async () => {
+        try {
+          await result.current.updateCatalogItem({
+            id: 'cat-1',
+            name: 'Updated Milk',
+            category: 'dairy',
+          });
+        } catch (error) {
+          thrownError = error;
+        }
+      });
+
+      await waitFor(() => {
+        expect(thrownError).toBe(saveError);
+        expect(result.current.error).toBe(
+          'Failed to save your changes. Please try again.',
+        );
+        expect(result.current.catalog).toEqual(initialPayload.catalog);
+        expect(result.current.lists).toEqual(initialPayload.lists);
+      });
+    });
+  });
+
+  describe('updateListLine', () => {
+    it('updates only the selected line amount and persists the complete payload', async () => {
+      const catalogItem = makeCatalogItem({
+        id: 'cat-1',
+        name: 'Milk',
+        category: 'dairy',
+        price: 3,
+        notes: 'Keep chilled',
+        imageUrl: 'https://example.com/milk',
+        links: ['https://example.com'],
+      });
+      const otherCatalogItem = makeCatalogItem({
+        id: 'cat-2',
+        name: 'Bread',
+        category: 'bakery',
+      });
+      const selectedLine = makeLine({
+        id: 'line-1',
+        catalogItemId: 'cat-1',
+        checked: true,
+        amount: '1 carton',
+      });
+      const otherLine = makeLine({
+        id: 'line-2',
+        catalogItemId: 'cat-2',
+        checked: false,
+        amount: '2 loaves',
+      });
+      const listA = makeList({
+        id: 'listA',
+        name: 'A',
+        lines: [selectedLine, otherLine],
+      });
+      const listB = makeList({
+        id: 'listB',
+        name: 'B',
+        lines: [makeLine({ id: 'line-3', catalogItemId: 'cat-1' })],
+      });
+      const initialPayload = {
+        catalog: [catalogItem, otherCatalogItem],
+        lists: [listA, listB],
+      };
+      const result = await setup(initialPayload);
+
+      await act(async () => {
+        await result.current.updateListLine('listA', {
+          id: 'line-1',
+          amount: '3 cartons',
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.catalog).toEqual(initialPayload.catalog);
+        expect(result.current.lists[0].lines[0]).toMatchObject({
+          id: selectedLine.id,
+          catalogItemId: selectedLine.catalogItemId,
+          amount: '3 cartons',
+          checked: true,
+          createdAt: selectedLine.createdAt,
+        });
+        expect(result.current.lists[0].lines[1]).toEqual(otherLine);
+        expect(result.current.lists[1]).toEqual(listB);
+        expect(mockSaveEncryptedData).toHaveBeenCalledTimes(1);
+        expect(mockSaveEncryptedData).toHaveBeenLastCalledWith({
+          masterKeyBytes,
+          type: 'groceries',
+          value: {
+            catalog: initialPayload.catalog,
+            lists: [
+              {
+                ...listA,
+                lines: [
+                  {
+                    ...selectedLine,
+                    amount: '3 cartons',
+                    updatedAt: expect.any(String),
+                  },
+                  otherLine,
+                ],
+                updatedAt: expect.any(String),
+              },
+              listB,
+            ],
+          },
+        });
+      });
+    });
+
+    it('rejects an unknown list or line without persistence or state changes', async () => {
+      const initialPayload = {
+        catalog: [makeCatalogItem({ id: 'cat-1', name: 'Milk' })],
+        lists: [
+          makeList({
+            id: 'listA',
+            name: 'A',
+            lines: [makeLine({ id: 'line-1', catalogItemId: 'cat-1' })],
+          }),
+        ],
+      };
+      const result = await setup(initialPayload);
+
+      const thrownErrors: unknown[] = [];
+      await act(async () => {
+        try {
+          await result.current.updateListLine('missing-list', {
+            id: 'line-1',
+            amount: '2',
+          });
+        } catch (error) {
+          thrownErrors.push(error);
+        }
+        try {
+          await result.current.updateListLine('listA', {
+            id: 'missing-line',
+            amount: '2',
+          });
+        } catch (error) {
+          thrownErrors.push(error);
+        }
+      });
+
+      expect(thrownErrors).toEqual([
+        new Error('List Line not found'),
+        new Error('List Line not found'),
+      ]);
+      expect(mockSaveEncryptedData).not.toHaveBeenCalled();
+      expect(result.current.catalog).toEqual(initialPayload.catalog);
+      expect(result.current.lists).toEqual(initialPayload.lists);
+    });
+
+    it('rethrows a persistence failure and leaves List Line state unchanged', async () => {
+      const line = makeLine({
+        id: 'line-1',
+        catalogItemId: 'cat-1',
+        checked: true,
+        amount: '1 carton',
+      });
+      const initialPayload = {
+        catalog: [makeCatalogItem({ id: 'cat-1', name: 'Milk' })],
+        lists: [makeList({ id: 'listA', name: 'A', lines: [line] })],
+      };
+      const result = await setup(initialPayload);
+      const saveError = new Error('save failed');
+      mockSaveEncryptedData.mockRejectedValue(saveError);
+
+      let thrownError: unknown;
+      await act(async () => {
+        try {
+          await result.current.updateListLine('listA', {
+            id: 'line-1',
+            amount: '2 cartons',
+          });
+        } catch (error) {
+          thrownError = error;
+        }
+      });
+
+      await waitFor(() => {
+        expect(thrownError).toBe(saveError);
+        expect(result.current.error).toBe(
+          'Failed to save your changes. Please try again.',
+        );
+        expect(result.current.catalog).toEqual(initialPayload.catalog);
+        expect(result.current.lists).toEqual(initialPayload.lists);
+      });
+    });
+  });
+
   describe('regression: pre-existing trip lifecycle actions never destroy Catalog Items', () => {
     it('toggleLineChecked flips only the target line, catalog and other lines untouched', async () => {
       const catalogItem = makeCatalogItem({ id: 'cat-1', name: 'Milk' });

--- a/libs/web/pages/groceries/src/shared/hooks/__tests__/useGroceriesVault.spec.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/__tests__/useGroceriesVault.spec.ts
@@ -1,0 +1,415 @@
+/*
+  Tests for useGroceriesVault hook.
+  - Mocks @myorganizer/web-vault's loadDecryptedData/normalizeGroceries/saveEncryptedData
+  - Mocks @myorganizer/core's randomId with a predictable sequential generator
+  - Covers the catalog-membership mutation seams: addItemToLists,
+    addExistingCatalogItemToLists, deleteCatalogItem, plus a light regression
+    pass over pre-existing trip lifecycle actions (toggle/uncheck/remove/
+    restore/delete-line) to reinforce that they never destroy Catalog Items.
+*/
+
+/** Mocking rule: place jest.mock calls before any imports */
+jest.mock('@myorganizer/web-vault');
+
+jest.mock('@myorganizer/core', () => {
+  let counter = 0;
+  return {
+    randomId: jest.fn(() => `id-${++counter}`),
+  };
+});
+
+import type {
+  CatalogItem,
+  GroceriesVaultPayload,
+  GroceryList,
+  ListLine,
+} from '@myorganizer/core';
+import {
+  loadDecryptedData,
+  normalizeGroceries,
+  saveEncryptedData,
+} from '@myorganizer/web-vault';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useGroceriesVault } from '../useGroceriesVault';
+
+const mockLoadDecryptedData = loadDecryptedData as jest.Mock;
+const mockNormalizeGroceries = normalizeGroceries as jest.Mock;
+const mockSaveEncryptedData = saveEncryptedData as jest.Mock;
+
+describe('useGroceriesVault', () => {
+  const masterKeyBytes = new Uint8Array(32);
+
+  function makeCatalogItem(
+    overrides: Partial<CatalogItem> & Pick<CatalogItem, 'id' | 'name'>,
+  ): CatalogItem {
+    return {
+      category: 'other',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function makeLine(
+    overrides: Partial<ListLine> & Pick<ListLine, 'id' | 'catalogItemId'>,
+  ): ListLine {
+    return {
+      checked: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function makeList(
+    overrides: Partial<GroceryList> & Pick<GroceryList, 'id' | 'name'>,
+  ): GroceryList {
+    return {
+      lines: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  /** Wires the vault mocks to resolve with the given payload and renders the hook. */
+  async function setup(initialPayload: GroceriesVaultPayload) {
+    mockLoadDecryptedData.mockResolvedValue(initialPayload);
+    mockNormalizeGroceries.mockImplementation((raw: unknown) => ({
+      value: raw as GroceriesVaultPayload,
+      changed: false,
+    }));
+    mockSaveEncryptedData.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useGroceriesVault({ masterKeyBytes }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    return result;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('addItemToLists', () => {
+    it('creates a new Catalog Item and adds a new List Line to every target list', async () => {
+      const listA = makeList({ id: 'listA', name: 'A' });
+      const listB = makeList({ id: 'listB', name: 'B' });
+      const result = await setup({ catalog: [], lists: [listA, listB] });
+
+      await act(async () => {
+        await result.current.addItemToLists(['listA', 'listB'], {
+          name: 'Milk',
+          category: 'dairy',
+        });
+      });
+
+      expect(result.current.catalog).toHaveLength(1);
+      expect(result.current.catalog[0].name).toBe('Milk');
+      expect(result.current.catalog[0].category).toBe('dairy');
+
+      const catalogItemId = result.current.catalog[0].id;
+      const listAResult = result.current.lists.find((l) => l.id === 'listA');
+      const listBResult = result.current.lists.find((l) => l.id === 'listB');
+      expect(listAResult?.lines).toHaveLength(1);
+      expect(listAResult?.lines[0].catalogItemId).toBe(catalogItemId);
+      expect(listBResult?.lines).toHaveLength(1);
+      expect(listBResult?.lines[0].catalogItemId).toBe(catalogItemId);
+    });
+
+    it('reuses an existing Catalog Item case-insensitively and updates its durable fields', async () => {
+      const existing = makeCatalogItem({
+        id: 'cat-1',
+        name: 'milk',
+        category: 'other',
+      });
+      const listA = makeList({ id: 'listA', name: 'A' });
+      const result = await setup({ catalog: [existing], lists: [listA] });
+
+      await act(async () => {
+        await result.current.addItemToLists(['listA'], {
+          name: 'MILK',
+          category: 'dairy',
+          price: 2.5,
+        });
+      });
+
+      // Reused, not duplicated
+      expect(result.current.catalog).toHaveLength(1);
+      expect(result.current.catalog[0].id).toBe('cat-1');
+      expect(result.current.catalog[0].name).toBe('MILK');
+      expect(result.current.catalog[0].category).toBe('dairy');
+      expect(result.current.catalog[0].price).toBe(2.5);
+
+      const listAResult = result.current.lists.find((l) => l.id === 'listA');
+      expect(listAResult?.lines).toHaveLength(1);
+      expect(listAResult?.lines[0].catalogItemId).toBe('cat-1');
+    });
+
+    it('skips lists that already have a line for the Catalog Item, but still adds to others', async () => {
+      const existing = makeCatalogItem({ id: 'cat-1', name: 'Milk' });
+      const listA = makeList({
+        id: 'listA',
+        name: 'A',
+        lines: [makeLine({ id: 'ln-existing', catalogItemId: 'cat-1' })],
+      });
+      const listB = makeList({ id: 'listB', name: 'B' });
+      const result = await setup({
+        catalog: [existing],
+        lists: [listA, listB],
+      });
+
+      await act(async () => {
+        await result.current.addItemToLists(['listA', 'listB'], {
+          name: 'Milk',
+          category: 'dairy',
+        });
+      });
+
+      const listAResult = result.current.lists.find((l) => l.id === 'listA');
+      const listBResult = result.current.lists.find((l) => l.id === 'listB');
+      // listA already had a line for cat-1 - no duplicate added
+      expect(listAResult?.lines).toHaveLength(1);
+      expect(listAResult?.lines[0].id).toBe('ln-existing');
+      // listB did not have a line - one was added
+      expect(listBResult?.lines).toHaveLength(1);
+    });
+
+    it('creates/reuses the Catalog Item but mutates no list when listIds is empty', async () => {
+      const listA = makeList({ id: 'listA', name: 'A' });
+      const result = await setup({ catalog: [], lists: [listA] });
+
+      await act(async () => {
+        await result.current.addItemToLists([], {
+          name: 'Milk',
+          category: 'dairy',
+        });
+      });
+
+      expect(result.current.catalog).toHaveLength(1);
+      const listAResult = result.current.lists.find((l) => l.id === 'listA');
+      expect(listAResult?.lines).toHaveLength(0);
+    });
+  });
+
+  describe('addExistingCatalogItemToLists', () => {
+    it('adds a new List Line (with amount) to every target list lacking one, skipping ones that already have it', async () => {
+      const catalogItem = makeCatalogItem({ id: 'cat-1', name: 'Milk' });
+      const listA = makeList({
+        id: 'listA',
+        name: 'A',
+        lines: [makeLine({ id: 'ln-existing', catalogItemId: 'cat-1' })],
+      });
+      const listB = makeList({ id: 'listB', name: 'B' });
+      const result = await setup({
+        catalog: [catalogItem],
+        lists: [listA, listB],
+      });
+
+      let addedListIds: string[] = [];
+      await act(async () => {
+        addedListIds = await result.current.addExistingCatalogItemToLists(
+          'cat-1',
+          ['listA', 'listB'],
+          '2 gallons',
+        );
+      });
+
+      // Resolves with only the list ids that actually received a new line
+      expect(addedListIds).toEqual(['listB']);
+
+      const listAResult = result.current.lists.find((l) => l.id === 'listA');
+      const listBResult = result.current.lists.find((l) => l.id === 'listB');
+      // listA already had a line - untouched
+      expect(listAResult?.lines).toHaveLength(1);
+      expect(listAResult?.lines[0].id).toBe('ln-existing');
+      // listB gets a new line with the given amount
+      expect(listBResult?.lines).toHaveLength(1);
+      expect(listBResult?.lines[0].catalogItemId).toBe('cat-1');
+      expect(listBResult?.lines[0].amount).toBe('2 gallons');
+    });
+
+    it('rejects when the Catalog Item does not exist and does not persist any change', async () => {
+      const listA = makeList({ id: 'listA', name: 'A' });
+      const result = await setup({ catalog: [], lists: [listA] });
+
+      await expect(
+        act(async () => {
+          await result.current.addExistingCatalogItemToLists('missing', [
+            'listA',
+          ]);
+        }),
+      ).rejects.toThrow('Catalog Item not found');
+
+      expect(mockSaveEncryptedData).not.toHaveBeenCalled();
+      expect(
+        result.current.lists.find((l) => l.id === 'listA')?.lines,
+      ).toHaveLength(0);
+    });
+
+    it('does not mutate the Catalog Item durable fields', async () => {
+      const catalogItem = makeCatalogItem({
+        id: 'cat-1',
+        name: 'Milk',
+        category: 'dairy',
+        price: 3,
+      });
+      const listA = makeList({ id: 'listA', name: 'A' });
+      const result = await setup({ catalog: [catalogItem], lists: [listA] });
+
+      await act(async () => {
+        await result.current.addExistingCatalogItemToLists('cat-1', ['listA']);
+      });
+
+      expect(result.current.catalog[0]).toMatchObject({
+        id: 'cat-1',
+        name: 'Milk',
+        category: 'dairy',
+        price: 3,
+      });
+    });
+  });
+
+  describe('deleteCatalogItem', () => {
+    it('removes the Catalog Item and cascades line removal only on referencing lists', async () => {
+      const catalogItem = makeCatalogItem({ id: 'cat-1', name: 'Milk' });
+      const listA = makeList({
+        id: 'listA',
+        name: 'A',
+        lines: [makeLine({ id: 'lnA', catalogItemId: 'cat-1' })],
+      });
+      const listB = makeList({
+        id: 'listB',
+        name: 'B',
+        lines: [makeLine({ id: 'lnB', catalogItemId: 'cat-1' })],
+      });
+      const otherLine = makeLine({ id: 'lnC', catalogItemId: 'cat-other' });
+      const listC = makeList({
+        id: 'listC',
+        name: 'C',
+        lines: [otherLine],
+      });
+      const result = await setup({
+        catalog: [catalogItem],
+        lists: [listA, listB, listC],
+      });
+
+      await act(async () => {
+        await result.current.deleteCatalogItem('cat-1');
+      });
+
+      expect(result.current.catalog).toHaveLength(0);
+      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
+        [],
+      );
+      expect(result.current.lists.find((l) => l.id === 'listB')?.lines).toEqual(
+        [],
+      );
+      // listC never referenced the deleted item - untouched
+      expect(result.current.lists.find((l) => l.id === 'listC')?.lines).toEqual(
+        [otherLine],
+      );
+    });
+
+    it('removes a Catalog Item with no referencing lines cleanly', async () => {
+      const catalogItem = makeCatalogItem({ id: 'cat-1', name: 'Milk' });
+      const listA = makeList({ id: 'listA', name: 'A' });
+      const result = await setup({ catalog: [catalogItem], lists: [listA] });
+
+      await act(async () => {
+        await result.current.deleteCatalogItem('cat-1');
+      });
+
+      expect(result.current.catalog).toHaveLength(0);
+      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe('regression: pre-existing trip lifecycle actions never destroy Catalog Items', () => {
+    it('toggleLineChecked flips only the target line, catalog and other lines untouched', async () => {
+      const catalogItem = makeCatalogItem({ id: 'cat-1', name: 'Milk' });
+      const line = makeLine({ id: 'ln-1', catalogItemId: 'cat-1' });
+      const listA = makeList({ id: 'listA', name: 'A', lines: [line] });
+      const result = await setup({ catalog: [catalogItem], lists: [listA] });
+
+      await act(async () => {
+        await result.current.toggleLineChecked('listA', 'ln-1');
+      });
+
+      expect(result.current.catalog).toEqual([catalogItem]);
+      expect(
+        result.current.lists.find((l) => l.id === 'listA')?.lines[0].checked,
+      ).toBe(true);
+    });
+
+    it('uncheckAllLines unchecks every line without removing any line or Catalog Item', async () => {
+      const catalogItem = makeCatalogItem({ id: 'cat-1', name: 'Milk' });
+      const line = makeLine({
+        id: 'ln-1',
+        catalogItemId: 'cat-1',
+        checked: true,
+      });
+      const listA = makeList({ id: 'listA', name: 'A', lines: [line] });
+      const result = await setup({ catalog: [catalogItem], lists: [listA] });
+
+      await act(async () => {
+        await result.current.uncheckAllLines('listA');
+      });
+
+      expect(result.current.catalog).toEqual([catalogItem]);
+      const resultList = result.current.lists.find((l) => l.id === 'listA');
+      expect(resultList?.lines).toHaveLength(1);
+      expect(resultList?.lines[0].checked).toBe(false);
+    });
+
+    it('removeCheckedLines + restoreLines round-trips without touching the Catalog Item', async () => {
+      const catalogItem = makeCatalogItem({ id: 'cat-1', name: 'Milk' });
+      const line = makeLine({
+        id: 'ln-1',
+        catalogItemId: 'cat-1',
+        checked: true,
+      });
+      const listA = makeList({ id: 'listA', name: 'A', lines: [line] });
+      const result = await setup({ catalog: [catalogItem], lists: [listA] });
+
+      let removed: ListLine[] = [];
+      await act(async () => {
+        removed = await result.current.removeCheckedLines('listA');
+      });
+
+      expect(removed).toHaveLength(1);
+      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
+        [],
+      );
+      expect(result.current.catalog).toEqual([catalogItem]);
+
+      await act(async () => {
+        await result.current.restoreLines('listA', removed);
+      });
+
+      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
+        [line],
+      );
+      expect(result.current.catalog).toEqual([catalogItem]);
+    });
+
+    it('deleteListLine removes only that line, leaving the Catalog Item intact', async () => {
+      const catalogItem = makeCatalogItem({ id: 'cat-1', name: 'Milk' });
+      const line = makeLine({ id: 'ln-1', catalogItemId: 'cat-1' });
+      const listA = makeList({ id: 'listA', name: 'A', lines: [line] });
+      const result = await setup({ catalog: [catalogItem], lists: [listA] });
+
+      await act(async () => {
+        await result.current.deleteListLine('listA', 'ln-1');
+      });
+
+      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
+        [],
+      );
+      expect(result.current.catalog).toEqual([catalogItem]);
+    });
+  });
+});

--- a/libs/web/pages/groceries/src/shared/hooks/__tests__/useGroceriesVault.spec.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/__tests__/useGroceriesVault.spec.ts
@@ -15,6 +15,20 @@ jest.mock('@myorganizer/core', () => {
   let counter = 0;
   return {
     randomId: jest.fn(() => `id-${++counter}`),
+    GROCERY_PREDEFINED_CATEGORIES: [
+      'produce',
+      'dairy',
+      'meat',
+      'seafood',
+      'bakery',
+      'frozen',
+      'beverages',
+      'snacks',
+      'condiments',
+      'household',
+      'personal-care',
+      'other',
+    ],
   };
 });
 
@@ -92,6 +106,55 @@ describe('useGroceriesVault', () => {
     jest.resetAllMocks();
   });
 
+  it('reports a load failure and stops loading without claiming success', async () => {
+    mockLoadDecryptedData.mockRejectedValue(new Error('vault unavailable'));
+
+    const { result } = renderHook(() => useGroceriesVault({ masterKeyBytes }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe(
+      'Failed to load your grocery lists. Please try again.',
+    );
+    expect(result.current.catalog).toEqual([]);
+    expect(result.current.lists).toEqual([]);
+    expect(mockNormalizeGroceries).not.toHaveBeenCalled();
+    expect(mockSaveEncryptedData).not.toHaveBeenCalled();
+  });
+
+  it('rethrows persistence failures, reports an error, and leaves state unchanged', async () => {
+    const initialPayload = {
+      catalog: [],
+      lists: [makeList({ id: 'listA', name: 'A' })],
+    };
+    const result = await setup(initialPayload);
+    const saveError = new Error('vault is locked');
+    mockSaveEncryptedData.mockRejectedValue(saveError);
+
+    let thrownError: unknown;
+    await act(async () => {
+      try {
+        await result.current.persistPayload({
+          catalog: [],
+          lists: [makeList({ id: 'listB', name: 'B' })],
+        });
+      } catch (error) {
+        thrownError = error;
+      }
+    });
+
+    expect(thrownError).toBe(saveError);
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        'Failed to save your changes. Please try again.',
+      ),
+    );
+    await waitFor(() => {
+      expect(result.current.catalog).toEqual(initialPayload.catalog);
+      expect(result.current.lists).toEqual(initialPayload.lists);
+    });
+  });
+
   describe('addItemToLists', () => {
     it('creates a new Catalog Item and adds a new List Line to every target list', async () => {
       const listA = makeList({ id: 'listA', name: 'A' });
@@ -105,17 +168,28 @@ describe('useGroceriesVault', () => {
         });
       });
 
-      expect(result.current.catalog).toHaveLength(1);
-      expect(result.current.catalog[0].name).toBe('Milk');
-      expect(result.current.catalog[0].category).toBe('dairy');
+      await waitFor(() => {
+        expect(result.current.catalog).toHaveLength(1);
+        expect(result.current.catalog[0].name).toBe('Milk');
+        expect(result.current.catalog[0].category).toBe('dairy');
 
-      const catalogItemId = result.current.catalog[0].id;
-      const listAResult = result.current.lists.find((l) => l.id === 'listA');
-      const listBResult = result.current.lists.find((l) => l.id === 'listB');
-      expect(listAResult?.lines).toHaveLength(1);
-      expect(listAResult?.lines[0].catalogItemId).toBe(catalogItemId);
-      expect(listBResult?.lines).toHaveLength(1);
-      expect(listBResult?.lines[0].catalogItemId).toBe(catalogItemId);
+        const catalogItemId = result.current.catalog[0].id;
+        const listAResult = result.current.lists.find((l) => l.id === 'listA');
+        const listBResult = result.current.lists.find((l) => l.id === 'listB');
+        expect(listAResult?.lines).toHaveLength(1);
+        expect(listAResult?.lines[0].catalogItemId).toBe(catalogItemId);
+        expect(listBResult?.lines).toHaveLength(1);
+        expect(listBResult?.lines[0].catalogItemId).toBe(catalogItemId);
+        expect(mockSaveEncryptedData).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            type: 'groceries',
+            value: {
+              catalog: result.current.catalog,
+              lists: result.current.lists,
+            },
+          }),
+        );
+      });
     });
 
     it('reuses an existing Catalog Item case-insensitively and updates its durable fields', async () => {
@@ -135,16 +209,18 @@ describe('useGroceriesVault', () => {
         });
       });
 
-      // Reused, not duplicated
-      expect(result.current.catalog).toHaveLength(1);
-      expect(result.current.catalog[0].id).toBe('cat-1');
-      expect(result.current.catalog[0].name).toBe('MILK');
-      expect(result.current.catalog[0].category).toBe('dairy');
-      expect(result.current.catalog[0].price).toBe(2.5);
+      await waitFor(() => {
+        // Reused, not duplicated
+        expect(result.current.catalog).toHaveLength(1);
+        expect(result.current.catalog[0].id).toBe('cat-1');
+        expect(result.current.catalog[0].name).toBe('MILK');
+        expect(result.current.catalog[0].category).toBe('dairy');
+        expect(result.current.catalog[0].price).toBe(2.5);
 
-      const listAResult = result.current.lists.find((l) => l.id === 'listA');
-      expect(listAResult?.lines).toHaveLength(1);
-      expect(listAResult?.lines[0].catalogItemId).toBe('cat-1');
+        const listAResult = result.current.lists.find((l) => l.id === 'listA');
+        expect(listAResult?.lines).toHaveLength(1);
+        expect(listAResult?.lines[0].catalogItemId).toBe('cat-1');
+      });
     });
 
     it('skips lists that already have a line for the Catalog Item, but still adds to others', async () => {
@@ -167,13 +243,15 @@ describe('useGroceriesVault', () => {
         });
       });
 
-      const listAResult = result.current.lists.find((l) => l.id === 'listA');
-      const listBResult = result.current.lists.find((l) => l.id === 'listB');
-      // listA already had a line for cat-1 - no duplicate added
-      expect(listAResult?.lines).toHaveLength(1);
-      expect(listAResult?.lines[0].id).toBe('ln-existing');
-      // listB did not have a line - one was added
-      expect(listBResult?.lines).toHaveLength(1);
+      await waitFor(() => {
+        const listAResult = result.current.lists.find((l) => l.id === 'listA');
+        const listBResult = result.current.lists.find((l) => l.id === 'listB');
+        // listA already had a line for cat-1 - no duplicate added
+        expect(listAResult?.lines).toHaveLength(1);
+        expect(listAResult?.lines[0].id).toBe('ln-existing');
+        // listB did not have a line - one was added
+        expect(listBResult?.lines).toHaveLength(1);
+      });
     });
 
     it('creates/reuses the Catalog Item but mutates no list when listIds is empty', async () => {
@@ -187,9 +265,123 @@ describe('useGroceriesVault', () => {
         });
       });
 
-      expect(result.current.catalog).toHaveLength(1);
-      const listAResult = result.current.lists.find((l) => l.id === 'listA');
-      expect(listAResult?.lines).toHaveLength(0);
+      await waitFor(() => {
+        expect(result.current.catalog).toHaveLength(1);
+        const listAResult = result.current.lists.find((l) => l.id === 'listA');
+        expect(listAResult?.lines).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('addCatalogItemAndLine', () => {
+    it('creates one catalog identity and attaches one line to the requested list', async () => {
+      const result = await setup({
+        catalog: [],
+        lists: [makeList({ id: 'listA', name: 'A' })],
+      });
+
+      await act(async () => {
+        await result.current.addCatalogItemAndLine('listA', {
+          name: '  Apples  ',
+          category: 'produce',
+          price: 3.25,
+          amount: '500g',
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.catalog).toHaveLength(1);
+        expect(result.current.catalog[0]).toMatchObject({
+          name: 'Apples',
+          category: 'produce',
+          price: 3.25,
+        });
+        expect(result.current.lists[0].lines).toHaveLength(1);
+        expect(result.current.lists[0].lines[0]).toMatchObject({
+          catalogItemId: result.current.catalog[0].id,
+          amount: '500g',
+          checked: false,
+        });
+        expect(mockSaveEncryptedData).toHaveBeenCalledTimes(1);
+        expect(mockSaveEncryptedData).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            type: 'groceries',
+            value: {
+              catalog: result.current.catalog,
+              lists: result.current.lists,
+            },
+          }),
+        );
+      });
+    });
+
+    it('reuses the exact selected catalog identity without changing its durable fields', async () => {
+      const existing = makeCatalogItem({
+        id: 'cat-1',
+        name: 'Milk',
+        category: 'dairy',
+        price: 3,
+      });
+      const result = await setup({
+        catalog: [existing],
+        lists: [makeList({ id: 'listA', name: 'A' })],
+      });
+
+      await act(async () => {
+        await result.current.addCatalogItemAndLine('listA', {
+          name: 'Different label',
+          category: 'other',
+          catalogItemId: 'cat-1',
+          price: 99,
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.catalog).toEqual([existing]);
+        expect(result.current.lists[0].lines[0].catalogItemId).toBe('cat-1');
+      });
+    });
+
+    it('rejects an invalid catalog identity and does not persist', async () => {
+      const result = await setup({
+        catalog: [],
+        lists: [makeList({ id: 'listA', name: 'A' })],
+      });
+
+      await expect(
+        act(async () => {
+          await result.current.addCatalogItemAndLine('listA', {
+            name: 'Milk',
+            category: 'dairy',
+            catalogItemId: 'missing',
+          });
+        }),
+      ).rejects.toThrow('Catalog Item not found');
+
+      await waitFor(() => {
+        expect(mockSaveEncryptedData).not.toHaveBeenCalled();
+        expect(result.current.catalog).toEqual([]);
+        expect(result.current.lists[0].lines).toEqual([]);
+      });
+    });
+
+    it('rejects invalid input before persistence', async () => {
+      const result = await setup({
+        catalog: [],
+        lists: [makeList({ id: 'listA', name: 'A' })],
+      });
+
+      await expect(
+        act(async () => {
+          await result.current.addCatalogItemAndLine('listA', {
+            name: 'Milk',
+            category: 'dairy',
+            amount: '-1kg',
+          });
+        }),
+      ).rejects.toThrow('Quantity');
+
+      await waitFor(() => expect(mockSaveEncryptedData).not.toHaveBeenCalled());
     });
   });
 
@@ -216,18 +408,20 @@ describe('useGroceriesVault', () => {
         );
       });
 
-      // Resolves with only the list ids that actually received a new line
-      expect(addedListIds).toEqual(['listB']);
+      await waitFor(() => {
+        // Resolves with only the list ids that actually received a new line
+        expect(addedListIds).toEqual(['listB']);
 
-      const listAResult = result.current.lists.find((l) => l.id === 'listA');
-      const listBResult = result.current.lists.find((l) => l.id === 'listB');
-      // listA already had a line - untouched
-      expect(listAResult?.lines).toHaveLength(1);
-      expect(listAResult?.lines[0].id).toBe('ln-existing');
-      // listB gets a new line with the given amount
-      expect(listBResult?.lines).toHaveLength(1);
-      expect(listBResult?.lines[0].catalogItemId).toBe('cat-1');
-      expect(listBResult?.lines[0].amount).toBe('2 gallons');
+        const listAResult = result.current.lists.find((l) => l.id === 'listA');
+        const listBResult = result.current.lists.find((l) => l.id === 'listB');
+        // listA already had a line - untouched
+        expect(listAResult?.lines).toHaveLength(1);
+        expect(listAResult?.lines[0].id).toBe('ln-existing');
+        // listB gets a new line with the given amount
+        expect(listBResult?.lines).toHaveLength(1);
+        expect(listBResult?.lines[0].catalogItemId).toBe('cat-1');
+        expect(listBResult?.lines[0].amount).toBe('2 gallons');
+      });
     });
 
     it('rejects when the Catalog Item does not exist and does not persist any change', async () => {
@@ -242,10 +436,12 @@ describe('useGroceriesVault', () => {
         }),
       ).rejects.toThrow('Catalog Item not found');
 
-      expect(mockSaveEncryptedData).not.toHaveBeenCalled();
-      expect(
-        result.current.lists.find((l) => l.id === 'listA')?.lines,
-      ).toHaveLength(0);
+      await waitFor(() => {
+        expect(mockSaveEncryptedData).not.toHaveBeenCalled();
+        expect(
+          result.current.lists.find((l) => l.id === 'listA')?.lines,
+        ).toHaveLength(0);
+      });
     });
 
     it('does not mutate the Catalog Item durable fields', async () => {
@@ -262,12 +458,14 @@ describe('useGroceriesVault', () => {
         await result.current.addExistingCatalogItemToLists('cat-1', ['listA']);
       });
 
-      expect(result.current.catalog[0]).toMatchObject({
-        id: 'cat-1',
-        name: 'Milk',
-        category: 'dairy',
-        price: 3,
-      });
+      await waitFor(() =>
+        expect(result.current.catalog[0]).toMatchObject({
+          id: 'cat-1',
+          name: 'Milk',
+          category: 'dairy',
+          price: 3,
+        }),
+      );
     });
   });
 
@@ -299,17 +497,19 @@ describe('useGroceriesVault', () => {
         await result.current.deleteCatalogItem('cat-1');
       });
 
-      expect(result.current.catalog).toHaveLength(0);
-      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
-        [],
-      );
-      expect(result.current.lists.find((l) => l.id === 'listB')?.lines).toEqual(
-        [],
-      );
-      // listC never referenced the deleted item - untouched
-      expect(result.current.lists.find((l) => l.id === 'listC')?.lines).toEqual(
-        [otherLine],
-      );
+      await waitFor(() => {
+        expect(result.current.catalog).toHaveLength(0);
+        expect(
+          result.current.lists.find((l) => l.id === 'listA')?.lines,
+        ).toEqual([]);
+        expect(
+          result.current.lists.find((l) => l.id === 'listB')?.lines,
+        ).toEqual([]);
+        // listC never referenced the deleted item - untouched
+        expect(
+          result.current.lists.find((l) => l.id === 'listC')?.lines,
+        ).toEqual([otherLine]);
+      });
     });
 
     it('removes a Catalog Item with no referencing lines cleanly', async () => {
@@ -321,10 +521,12 @@ describe('useGroceriesVault', () => {
         await result.current.deleteCatalogItem('cat-1');
       });
 
-      expect(result.current.catalog).toHaveLength(0);
-      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
-        [],
-      );
+      await waitFor(() => {
+        expect(result.current.catalog).toHaveLength(0);
+        expect(
+          result.current.lists.find((l) => l.id === 'listA')?.lines,
+        ).toEqual([]);
+      });
     });
   });
 
@@ -339,10 +541,12 @@ describe('useGroceriesVault', () => {
         await result.current.toggleLineChecked('listA', 'ln-1');
       });
 
-      expect(result.current.catalog).toEqual([catalogItem]);
-      expect(
-        result.current.lists.find((l) => l.id === 'listA')?.lines[0].checked,
-      ).toBe(true);
+      await waitFor(() => {
+        expect(result.current.catalog).toEqual([catalogItem]);
+        expect(
+          result.current.lists.find((l) => l.id === 'listA')?.lines[0].checked,
+        ).toBe(true);
+      });
     });
 
     it('uncheckAllLines unchecks every line without removing any line or Catalog Item', async () => {
@@ -359,10 +563,12 @@ describe('useGroceriesVault', () => {
         await result.current.uncheckAllLines('listA');
       });
 
-      expect(result.current.catalog).toEqual([catalogItem]);
-      const resultList = result.current.lists.find((l) => l.id === 'listA');
-      expect(resultList?.lines).toHaveLength(1);
-      expect(resultList?.lines[0].checked).toBe(false);
+      await waitFor(() => {
+        expect(result.current.catalog).toEqual([catalogItem]);
+        const resultList = result.current.lists.find((l) => l.id === 'listA');
+        expect(resultList?.lines).toHaveLength(1);
+        expect(resultList?.lines[0].checked).toBe(false);
+      });
     });
 
     it('removeCheckedLines + restoreLines round-trips without touching the Catalog Item', async () => {
@@ -380,20 +586,24 @@ describe('useGroceriesVault', () => {
         removed = await result.current.removeCheckedLines('listA');
       });
 
-      expect(removed).toHaveLength(1);
-      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
-        [],
-      );
-      expect(result.current.catalog).toEqual([catalogItem]);
+      await waitFor(() => {
+        expect(removed).toHaveLength(1);
+        expect(
+          result.current.lists.find((l) => l.id === 'listA')?.lines,
+        ).toEqual([]);
+        expect(result.current.catalog).toEqual([catalogItem]);
+      });
 
       await act(async () => {
         await result.current.restoreLines('listA', removed);
       });
 
-      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
-        [line],
-      );
-      expect(result.current.catalog).toEqual([catalogItem]);
+      await waitFor(() => {
+        expect(
+          result.current.lists.find((l) => l.id === 'listA')?.lines,
+        ).toEqual([line]);
+        expect(result.current.catalog).toEqual([catalogItem]);
+      });
     });
 
     it('deleteListLine removes only that line, leaving the Catalog Item intact', async () => {
@@ -406,10 +616,12 @@ describe('useGroceriesVault', () => {
         await result.current.deleteListLine('listA', 'ln-1');
       });
 
-      expect(result.current.lists.find((l) => l.id === 'listA')?.lines).toEqual(
-        [],
-      );
-      expect(result.current.catalog).toEqual([catalogItem]);
+      await waitFor(() => {
+        expect(
+          result.current.lists.find((l) => l.id === 'listA')?.lines,
+        ).toEqual([]);
+        expect(result.current.catalog).toEqual([catalogItem]);
+      });
     });
   });
 });

--- a/libs/web/pages/groceries/src/shared/hooks/index.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/index.ts
@@ -1,2 +1,6 @@
 export { useGroceriesVault } from './useGroceriesVault';
-export type { AddCatalogItemAndLineInput } from './useGroceriesVault';
+export type {
+  AddCatalogItemAndLineInput,
+  UpdateCatalogItemInput,
+  UpdateListLineInput,
+} from './useGroceriesVault';

--- a/libs/web/pages/groceries/src/shared/hooks/index.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useGroceriesVault } from './useGroceriesVault';
+export type { AddCatalogItemAndLineInput } from './useGroceriesVault';

--- a/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
@@ -14,6 +14,7 @@ import {
   saveEncryptedData,
 } from '@myorganizer/web-vault';
 import { useCallback, useEffect, useState } from 'react';
+import { validateAddCatalogItemAndLineInput } from '../utils';
 
 interface UseGroceriesVaultOptions {
   masterKeyBytes: Uint8Array;
@@ -23,6 +24,7 @@ interface UseGroceriesVaultOptions {
 export interface AddCatalogItemAndLineInput {
   name: string;
   category: GroceryCategoryType;
+  catalogItemId?: string;
   price?: number;
   notes?: string;
   imageUrl?: string;
@@ -398,41 +400,52 @@ export function useGroceriesVault({
   const addCatalogItemAndLine = useCallback(
     async (listId: string, input: AddCatalogItemAndLineInput) => {
       try {
+        const validatedInput = validateAddCatalogItemAndLineInput(input);
         const now = new Date().toISOString();
-        const trimmedName = input.name.trim();
-        const existing = payload.catalog.find(
-          (item) =>
-            item.name.trim().toLowerCase() === trimmedName.toLowerCase(),
-        );
+        const trimmedName = validatedInput.name;
+        const existing = validatedInput.catalogItemId
+          ? payload.catalog.find(
+              (item) => item.id === validatedInput.catalogItemId,
+            )
+          : payload.catalog.find(
+              (item) =>
+                item.name.trim().toLowerCase() === trimmedName.toLowerCase(),
+            );
+
+        if (validatedInput.catalogItemId && !existing) {
+          throw new Error('Catalog Item not found');
+        }
 
         let catalogItemId: string;
         let nextCatalog: CatalogItem[];
 
         if (existing) {
           catalogItemId = existing.id;
-          nextCatalog = payload.catalog.map((item) =>
-            item.id === existing.id
-              ? {
-                  ...item,
-                  name: trimmedName,
-                  category: input.category,
-                  price: input.price,
-                  notes: input.notes,
-                  imageUrl: input.imageUrl,
-                  links: input.links,
-                  updatedAt: now,
-                }
-              : item,
-          );
+          nextCatalog = validatedInput.catalogItemId
+            ? payload.catalog
+            : payload.catalog.map((item) =>
+                item.id === existing.id
+                  ? {
+                      ...item,
+                      name: trimmedName,
+                      category: validatedInput.category,
+                      price: validatedInput.price,
+                      notes: validatedInput.notes,
+                      imageUrl: validatedInput.imageUrl,
+                      links: validatedInput.links,
+                      updatedAt: now,
+                    }
+                  : item,
+              );
         } else {
           const newCatalogItem: CatalogItem = {
             id: randomId(),
             name: trimmedName,
-            category: input.category,
-            price: input.price,
-            notes: input.notes,
-            imageUrl: input.imageUrl,
-            links: input.links,
+            category: validatedInput.category,
+            price: validatedInput.price,
+            notes: validatedInput.notes,
+            imageUrl: validatedInput.imageUrl,
+            links: validatedInput.links,
             createdAt: now,
             updatedAt: now,
           };
@@ -444,7 +457,7 @@ export function useGroceriesVault({
           id: randomId(),
           catalogItemId,
           checked: false,
-          amount: input.amount,
+          amount: validatedInput.amount,
           createdAt: now,
           updatedAt: now,
         };
@@ -480,41 +493,52 @@ export function useGroceriesVault({
   const addItemToLists = useCallback(
     async (listIds: string[], input: AddCatalogItemAndLineInput) => {
       try {
+        const validatedInput = validateAddCatalogItemAndLineInput(input);
         const now = new Date().toISOString();
-        const trimmedName = input.name.trim();
-        const existing = payload.catalog.find(
-          (item) =>
-            item.name.trim().toLowerCase() === trimmedName.toLowerCase(),
-        );
+        const trimmedName = validatedInput.name;
+        const existing = validatedInput.catalogItemId
+          ? payload.catalog.find(
+              (item) => item.id === validatedInput.catalogItemId,
+            )
+          : payload.catalog.find(
+              (item) =>
+                item.name.trim().toLowerCase() === trimmedName.toLowerCase(),
+            );
+
+        if (validatedInput.catalogItemId && !existing) {
+          throw new Error('Catalog Item not found');
+        }
 
         let catalogItemId: string;
         let nextCatalog: CatalogItem[];
 
         if (existing) {
           catalogItemId = existing.id;
-          nextCatalog = payload.catalog.map((item) =>
-            item.id === existing.id
-              ? {
-                  ...item,
-                  name: trimmedName,
-                  category: input.category,
-                  price: input.price,
-                  notes: input.notes,
-                  imageUrl: input.imageUrl,
-                  links: input.links,
-                  updatedAt: now,
-                }
-              : item,
-          );
+          nextCatalog = validatedInput.catalogItemId
+            ? payload.catalog
+            : payload.catalog.map((item) =>
+                item.id === existing.id
+                  ? {
+                      ...item,
+                      name: trimmedName,
+                      category: validatedInput.category,
+                      price: validatedInput.price,
+                      notes: validatedInput.notes,
+                      imageUrl: validatedInput.imageUrl,
+                      links: validatedInput.links,
+                      updatedAt: now,
+                    }
+                  : item,
+              );
         } else {
           const newCatalogItem: CatalogItem = {
             id: randomId(),
             name: trimmedName,
-            category: input.category,
-            price: input.price,
-            notes: input.notes,
-            imageUrl: input.imageUrl,
-            links: input.links,
+            category: validatedInput.category,
+            price: validatedInput.price,
+            notes: validatedInput.notes,
+            imageUrl: validatedInput.imageUrl,
+            links: validatedInput.links,
             createdAt: now,
             updatedAt: now,
           };
@@ -535,7 +559,7 @@ export function useGroceriesVault({
               id: randomId(),
               catalogItemId,
               checked: false,
-              amount: input.amount,
+              amount: validatedInput.amount,
               createdAt: now,
               updatedAt: now,
             };

--- a/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { GroceryList } from '@myorganizer/core';
+import type { GroceryList, GroceriesVaultPayload } from '@myorganizer/core';
 import { randomId } from '@myorganizer/core';
 import {
   loadDecryptedData,
@@ -20,7 +20,7 @@ interface UseGroceriesVaultResult {
   selectedListId: string | null;
   setSelectedListId: (id: string | null) => void;
   setError: (error: string | null) => void;
-  persistLists: (lists: GroceryList[]) => Promise<void>;
+  persistPayload: (payload: GroceriesVaultPayload) => Promise<void>;
   createList: (name: string) => Promise<void>;
   renameList: (listId: string, newName: string) => Promise<void>;
   deleteList: (listId: string) => Promise<void>;
@@ -30,7 +30,7 @@ interface UseGroceriesVaultResult {
  * Custom hook for managing grocery lists with vault persistence.
  *
  * Handles:
- * - Loading grocery lists from encrypted vault storage
+ * - Loading grocery lists from encrypted vault storage (catalog + lists payload)
  * - Saving changes back to vault
  * - Normalizing data on load
  * - Error handling and reporting
@@ -41,32 +41,35 @@ interface UseGroceriesVaultResult {
  * @example
  * ```tsx
  * const vault = useGroceriesVault({ masterKeyBytes });
- * // Use vault.lists, vault.persistLists, etc.
+ * // Use vault.lists, vault.createList, vault.renameList, vault.deleteList
  * ```
  */
 export function useGroceriesVault({
   masterKeyBytes,
 }: UseGroceriesVaultOptions): UseGroceriesVaultResult {
-  const [lists, setLists] = useState<GroceryList[]>([]);
+  const [payload, setPayload] = useState<GroceriesVaultPayload>({
+    catalog: [],
+    lists: [],
+  });
   const [loading, setLoading] = useState(true);
   const [selectedListId, setSelectedListId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Load lists from vault on mount
+  // Load payload from vault on mount
   useEffect(() => {
     setError(null);
     loadDecryptedData<unknown>({
       masterKeyBytes,
       type: 'groceries',
-      defaultValue: [],
+      defaultValue: null,
     })
       .then(async (raw) => {
         const normalized = normalizeGroceries(raw);
-        setLists(normalized.value);
-        if (normalized.value.length > 0) {
-          setSelectedListId(normalized.value[0].id);
+        setPayload(normalized.value);
+        if (normalized.value.lists.length > 0) {
+          setSelectedListId(normalized.value.lists[0].id);
         }
-        // Re-save if data was normalized (data migration)
+        // Re-save if data was normalized (data migration or repair)
         if (normalized.changed) {
           await saveEncryptedData({
             masterKeyBytes,
@@ -83,17 +86,17 @@ export function useGroceriesVault({
       });
   }, [masterKeyBytes]);
 
-  // Persist lists to vault
-  const persistLists = useCallback(
-    async (nextLists: GroceryList[]) => {
+  // Persist full payload to vault
+  const persistPayload = useCallback(
+    async (nextPayload: GroceriesVaultPayload) => {
       setError(null);
       try {
         await saveEncryptedData({
           masterKeyBytes,
           type: 'groceries',
-          value: nextLists,
+          value: nextPayload,
         });
-        setLists(nextLists);
+        setPayload(nextPayload);
       } catch (err) {
         console.error('Failed to save grocery lists to vault:', err);
         setError('Failed to save your changes. Please try again.');
@@ -110,43 +113,53 @@ export function useGroceriesVault({
         const newList: GroceryList = {
           id: randomId(),
           name,
-          items: [],
+          lines: [],
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         };
-        const nextLists = [...lists, newList];
-        await persistLists(nextLists);
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: [...payload.lists, newList],
+        };
+        await persistPayload(nextPayload);
         setSelectedListId(newList.id);
       } catch (err) {
         console.error('Failed to create list:', err);
       }
     },
-    [lists, persistLists],
+    [payload, persistPayload],
   );
 
   // Rename an existing grocery list
   const renameList = useCallback(
     async (listId: string, newName: string) => {
       try {
-        const nextLists = lists.map((list) =>
-          list.id === listId
-            ? { ...list, name: newName, updatedAt: new Date().toISOString() }
-            : list,
-        );
-        await persistLists(nextLists);
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: payload.lists.map((list) =>
+            list.id === listId
+              ? { ...list, name: newName, updatedAt: new Date().toISOString() }
+              : list,
+          ),
+        };
+        await persistPayload(nextPayload);
       } catch (err) {
         console.error('Failed to rename list:', err);
       }
     },
-    [lists, persistLists],
+    [payload, persistPayload],
   );
 
   // Delete a grocery list
   const deleteList = useCallback(
     async (listId: string) => {
       try {
-        const nextLists = lists.filter((list) => list.id !== listId);
-        await persistLists(nextLists);
+        const nextLists = payload.lists.filter((list) => list.id !== listId);
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: nextLists,
+        };
+        await persistPayload(nextPayload);
         if (selectedListId === listId) {
           setSelectedListId(nextLists.length > 0 ? nextLists[0].id : null);
         }
@@ -154,17 +167,17 @@ export function useGroceriesVault({
         console.error('Failed to delete list:', err);
       }
     },
-    [lists, selectedListId, persistLists],
+    [payload, selectedListId, persistPayload],
   );
 
   return {
-    lists,
+    lists: payload.lists,
     loading,
     error,
     selectedListId,
     setSelectedListId,
     setError,
-    persistLists,
+    persistPayload,
     createList,
     renameList,
     deleteList,

--- a/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
@@ -1,6 +1,12 @@
 'use client';
 
-import type { GroceryList, GroceriesVaultPayload } from '@myorganizer/core';
+import type {
+  CatalogItem,
+  GroceryCategoryType,
+  GroceryList,
+  GroceriesVaultPayload,
+  ListLine,
+} from '@myorganizer/core';
 import { randomId } from '@myorganizer/core';
 import {
   loadDecryptedData,
@@ -13,8 +19,20 @@ interface UseGroceriesVaultOptions {
   masterKeyBytes: Uint8Array;
 }
 
+/** Fields a caller may supply when adding an item to a Grocery List. */
+export interface AddCatalogItemAndLineInput {
+  name: string;
+  category: GroceryCategoryType;
+  price?: number;
+  notes?: string;
+  imageUrl?: string;
+  links?: string[];
+  amount?: string;
+}
+
 interface UseGroceriesVaultResult {
   lists: GroceryList[];
+  catalog: CatalogItem[];
   loading: boolean;
   error: string | null;
   selectedListId: string | null;
@@ -24,6 +42,28 @@ interface UseGroceriesVaultResult {
   createList: (name: string) => Promise<void>;
   renameList: (listId: string, newName: string) => Promise<void>;
   deleteList: (listId: string) => Promise<void>;
+  /** Toggle a single List Line's checked (bought-on-this-trip) state. */
+  toggleLineChecked: (listId: string, lineId: string) => Promise<void>;
+  /** Turn every Checked Item back to unchecked. Never removes lines. */
+  uncheckAllLines: (listId: string) => Promise<void>;
+  /**
+   * Removes Checked Items from the list only (Catalog Items are untouched).
+   * Returns the removed lines so the caller can offer an undo affordance.
+   */
+  removeCheckedLines: (listId: string) => Promise<ListLine[]>;
+  /** Re-inserts previously removed lines (undo for removeCheckedLines). */
+  restoreLines: (listId: string, lines: ListLine[]) => Promise<void>;
+  /** Deletes one List Line only; the referenced Catalog Item remains. */
+  deleteListLine: (listId: string, lineId: string) => Promise<void>;
+  /**
+   * Adds an item to a Grocery List: reuses an existing Catalog Item when the
+   * name matches case-insensitively (updating its durable fields), otherwise
+   * creates a new Catalog Item, then attaches a new List Line to the list.
+   */
+  addCatalogItemAndLine: (
+    listId: string,
+    input: AddCatalogItemAndLineInput,
+  ) => Promise<void>;
 }
 
 /**
@@ -170,8 +210,238 @@ export function useGroceriesVault({
     [payload, selectedListId, persistPayload],
   );
 
+  /** Toggle a single List Line's checked (bought-on-this-trip) state. */
+  const toggleLineChecked = useCallback(
+    async (listId: string, lineId: string) => {
+      try {
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: payload.lists.map((list) =>
+            list.id === listId
+              ? {
+                  ...list,
+                  lines: list.lines.map((line) =>
+                    line.id === lineId
+                      ? {
+                          ...line,
+                          checked: !line.checked,
+                          updatedAt: new Date().toISOString(),
+                        }
+                      : line,
+                  ),
+                  updatedAt: new Date().toISOString(),
+                }
+              : list,
+          ),
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to toggle list line:', err);
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /** Turn every Checked Item back to unchecked. Never removes lines. */
+  const uncheckAllLines = useCallback(
+    async (listId: string) => {
+      try {
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: payload.lists.map((list) =>
+            list.id === listId
+              ? {
+                  ...list,
+                  lines: list.lines.map((line) =>
+                    line.checked
+                      ? {
+                          ...line,
+                          checked: false,
+                          updatedAt: new Date().toISOString(),
+                        }
+                      : line,
+                  ),
+                  updatedAt: new Date().toISOString(),
+                }
+              : list,
+          ),
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to uncheck all list lines:', err);
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /**
+   * Removes Checked Items from the list only (Catalog Items are untouched).
+   * Returns the removed lines so the caller can offer an undo affordance.
+   */
+  const removeCheckedLines = useCallback(
+    async (listId: string): Promise<ListLine[]> => {
+      const list = payload.lists.find((l) => l.id === listId);
+      if (!list) return [];
+
+      const removed = list.lines.filter((line) => line.checked);
+      if (removed.length === 0) return [];
+
+      try {
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: payload.lists.map((l) =>
+            l.id === listId
+              ? {
+                  ...l,
+                  lines: l.lines.filter((line) => !line.checked),
+                  updatedAt: new Date().toISOString(),
+                }
+              : l,
+          ),
+        };
+        await persistPayload(nextPayload);
+        return removed;
+      } catch (err) {
+        console.error('Failed to remove checked list lines:', err);
+        return [];
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /** Re-inserts previously removed lines (undo for removeCheckedLines). */
+  const restoreLines = useCallback(
+    async (listId: string, lines: ListLine[]) => {
+      if (lines.length === 0) return;
+      try {
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: payload.lists.map((list) => {
+            if (list.id !== listId) return list;
+            const existingIds = new Set(list.lines.map((line) => line.id));
+            const toRestore = lines.filter((line) => !existingIds.has(line.id));
+            return {
+              ...list,
+              lines: [...list.lines, ...toRestore],
+              updatedAt: new Date().toISOString(),
+            };
+          }),
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to restore list lines:', err);
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /** Deletes one List Line only; the referenced Catalog Item remains. */
+  const deleteListLine = useCallback(
+    async (listId: string, lineId: string) => {
+      try {
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: payload.lists.map((list) =>
+            list.id === listId
+              ? {
+                  ...list,
+                  lines: list.lines.filter((line) => line.id !== lineId),
+                  updatedAt: new Date().toISOString(),
+                }
+              : list,
+          ),
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to delete list line:', err);
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /**
+   * Adds an item to a Grocery List: reuses an existing Catalog Item when the
+   * name matches case-insensitively (updating its durable fields), otherwise
+   * creates a new Catalog Item, then attaches a new List Line to the list.
+   */
+  const addCatalogItemAndLine = useCallback(
+    async (listId: string, input: AddCatalogItemAndLineInput) => {
+      try {
+        const now = new Date().toISOString();
+        const trimmedName = input.name.trim();
+        const existing = payload.catalog.find(
+          (item) =>
+            item.name.trim().toLowerCase() === trimmedName.toLowerCase(),
+        );
+
+        let catalogItemId: string;
+        let nextCatalog: CatalogItem[];
+
+        if (existing) {
+          catalogItemId = existing.id;
+          nextCatalog = payload.catalog.map((item) =>
+            item.id === existing.id
+              ? {
+                  ...item,
+                  name: trimmedName,
+                  category: input.category,
+                  price: input.price,
+                  notes: input.notes,
+                  imageUrl: input.imageUrl,
+                  links: input.links,
+                  updatedAt: now,
+                }
+              : item,
+          );
+        } else {
+          const newCatalogItem: CatalogItem = {
+            id: randomId(),
+            name: trimmedName,
+            category: input.category,
+            price: input.price,
+            notes: input.notes,
+            imageUrl: input.imageUrl,
+            links: input.links,
+            createdAt: now,
+            updatedAt: now,
+          };
+          catalogItemId = newCatalogItem.id;
+          nextCatalog = [...payload.catalog, newCatalogItem];
+        }
+
+        const newLine: ListLine = {
+          id: randomId(),
+          catalogItemId,
+          checked: false,
+          amount: input.amount,
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        const nextPayload: GroceriesVaultPayload = {
+          catalog: nextCatalog,
+          lists: payload.lists.map((list) =>
+            list.id === listId
+              ? {
+                  ...list,
+                  lines: [...list.lines, newLine],
+                  updatedAt: now,
+                }
+              : list,
+          ),
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to add item to list:', err);
+        throw err;
+      }
+    },
+    [payload, persistPayload],
+  );
+
   return {
     lists: payload.lists,
+    catalog: payload.catalog,
     loading,
     error,
     selectedListId,
@@ -181,5 +451,11 @@ export function useGroceriesVault({
     createList,
     renameList,
     deleteList,
+    toggleLineChecked,
+    uncheckAllLines,
+    removeCheckedLines,
+    restoreLines,
+    deleteListLine,
+    addCatalogItemAndLine,
   };
 }

--- a/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
@@ -64,6 +64,37 @@ interface UseGroceriesVaultResult {
     listId: string,
     input: AddCatalogItemAndLineInput,
   ) => Promise<void>;
+  /**
+   * Adds an item to one or many Grocery Lists in a single action: reuses an
+   * existing Catalog Item when the name matches case-insensitively (updating
+   * its durable fields), otherwise creates a new Catalog Item. Skips any
+   * target list that already carries a List Line for that Catalog Item, so
+   * the same identity is never duplicated on one list.
+   */
+  addItemToLists: (
+    listIds: string[],
+    input: AddCatalogItemAndLineInput,
+  ) => Promise<void>;
+  /**
+   * Adds an already-existing Catalog Item as a new List Line to one or many
+   * Grocery Lists, without changing any of the Catalog Item's durable
+   * fields. Skips any target list that already carries a List Line for that
+   * Catalog Item. Resolves with the ids of the lists that actually received
+   * a new List Line (a subset of `listIds` — lists that already had a line
+   * for this Catalog Item are skipped and excluded from the result), so
+   * callers can give accurate feedback when some targets were skipped.
+   */
+  addExistingCatalogItemToLists: (
+    catalogItemId: string,
+    listIds: string[],
+    amount?: string,
+  ) => Promise<string[]>;
+  /**
+   * Permanently destroys a Catalog Item and every List Line referencing it
+   * across every Grocery List. Requires strong confirmation in the UI before
+   * being called — this cannot be undone.
+   */
+  deleteCatalogItem: (catalogItemId: string) => Promise<void>;
 }
 
 /**
@@ -439,6 +470,183 @@ export function useGroceriesVault({
     [payload, persistPayload],
   );
 
+  /**
+   * Adds an item to one or many Grocery Lists in a single action: reuses an
+   * existing Catalog Item when the name matches case-insensitively (updating
+   * its durable fields), otherwise creates a new Catalog Item. Skips any
+   * target list that already carries a List Line for that Catalog Item, so
+   * the same identity is never duplicated on one list.
+   */
+  const addItemToLists = useCallback(
+    async (listIds: string[], input: AddCatalogItemAndLineInput) => {
+      try {
+        const now = new Date().toISOString();
+        const trimmedName = input.name.trim();
+        const existing = payload.catalog.find(
+          (item) =>
+            item.name.trim().toLowerCase() === trimmedName.toLowerCase(),
+        );
+
+        let catalogItemId: string;
+        let nextCatalog: CatalogItem[];
+
+        if (existing) {
+          catalogItemId = existing.id;
+          nextCatalog = payload.catalog.map((item) =>
+            item.id === existing.id
+              ? {
+                  ...item,
+                  name: trimmedName,
+                  category: input.category,
+                  price: input.price,
+                  notes: input.notes,
+                  imageUrl: input.imageUrl,
+                  links: input.links,
+                  updatedAt: now,
+                }
+              : item,
+          );
+        } else {
+          const newCatalogItem: CatalogItem = {
+            id: randomId(),
+            name: trimmedName,
+            category: input.category,
+            price: input.price,
+            notes: input.notes,
+            imageUrl: input.imageUrl,
+            links: input.links,
+            createdAt: now,
+            updatedAt: now,
+          };
+          catalogItemId = newCatalogItem.id;
+          nextCatalog = [...payload.catalog, newCatalogItem];
+        }
+
+        const targetIds = new Set(listIds);
+        const nextPayload: GroceriesVaultPayload = {
+          catalog: nextCatalog,
+          lists: payload.lists.map((list) => {
+            if (!targetIds.has(list.id)) return list;
+            const alreadyHasLine = list.lines.some(
+              (line) => line.catalogItemId === catalogItemId,
+            );
+            if (alreadyHasLine) return list;
+            const newLine: ListLine = {
+              id: randomId(),
+              catalogItemId,
+              checked: false,
+              amount: input.amount,
+              createdAt: now,
+              updatedAt: now,
+            };
+            return {
+              ...list,
+              lines: [...list.lines, newLine],
+              updatedAt: now,
+            };
+          }),
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to add item to lists:', err);
+        throw err;
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /**
+   * Adds an already-existing Catalog Item as a new List Line to one or many
+   * Grocery Lists, without changing any of the Catalog Item's durable
+   * fields. Skips any target list that already carries a List Line for that
+   * Catalog Item. Resolves with the ids of the lists that actually received
+   * a new List Line, so callers can report accurate feedback when some
+   * targets were skipped as duplicates.
+   */
+  const addExistingCatalogItemToLists = useCallback(
+    async (
+      catalogItemId: string,
+      listIds: string[],
+      amount?: string,
+    ): Promise<string[]> => {
+      try {
+        const catalogItem = payload.catalog.find(
+          (item) => item.id === catalogItemId,
+        );
+        if (!catalogItem) {
+          throw new Error('Catalog Item not found');
+        }
+
+        const now = new Date().toISOString();
+        const targetIds = new Set(listIds);
+        const addedListIds: string[] = [];
+        const nextPayload: GroceriesVaultPayload = {
+          ...payload,
+          lists: payload.lists.map((list) => {
+            if (!targetIds.has(list.id)) return list;
+            const alreadyHasLine = list.lines.some(
+              (line) => line.catalogItemId === catalogItemId,
+            );
+            if (alreadyHasLine) return list;
+            const newLine: ListLine = {
+              id: randomId(),
+              catalogItemId,
+              checked: false,
+              amount,
+              createdAt: now,
+              updatedAt: now,
+            };
+            addedListIds.push(list.id);
+            return {
+              ...list,
+              lines: [...list.lines, newLine],
+              updatedAt: now,
+            };
+          }),
+        };
+        await persistPayload(nextPayload);
+        return addedListIds;
+      } catch (err) {
+        console.error('Failed to add existing catalog item to lists:', err);
+        throw err;
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /**
+   * Permanently destroys a Catalog Item and every List Line referencing it
+   * across every Grocery List. This is the Delete From Catalog action — it
+   * cascades off every list and cannot be undone.
+   */
+  const deleteCatalogItem = useCallback(
+    async (catalogItemId: string) => {
+      try {
+        const nextPayload: GroceriesVaultPayload = {
+          catalog: payload.catalog.filter((item) => item.id !== catalogItemId),
+          lists: payload.lists.map((list) => {
+            const hasLine = list.lines.some(
+              (line) => line.catalogItemId === catalogItemId,
+            );
+            if (!hasLine) return list;
+            return {
+              ...list,
+              lines: list.lines.filter(
+                (line) => line.catalogItemId !== catalogItemId,
+              ),
+              updatedAt: new Date().toISOString(),
+            };
+          }),
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to delete catalog item:', err);
+        throw err;
+      }
+    },
+    [payload, persistPayload],
+  );
+
   return {
     lists: payload.lists,
     catalog: payload.catalog,
@@ -457,5 +665,8 @@ export function useGroceriesVault({
     restoreLines,
     deleteListLine,
     addCatalogItemAndLine,
+    addItemToLists,
+    addExistingCatalogItemToLists,
+    deleteCatalogItem,
   };
 }

--- a/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
+++ b/libs/web/pages/groceries/src/shared/hooks/useGroceriesVault.ts
@@ -32,6 +32,21 @@ export interface AddCatalogItemAndLineInput {
   amount?: string;
 }
 
+export interface UpdateCatalogItemInput {
+  id: string;
+  name: string;
+  category: GroceryCategoryType;
+  price?: number;
+  notes?: string;
+  imageUrl?: string;
+  links?: string[];
+}
+
+export interface UpdateListLineInput {
+  id: string;
+  amount?: string;
+}
+
 interface UseGroceriesVaultResult {
   lists: GroceryList[];
   catalog: CatalogItem[];
@@ -57,6 +72,8 @@ interface UseGroceriesVaultResult {
   restoreLines: (listId: string, lines: ListLine[]) => Promise<void>;
   /** Deletes one List Line only; the referenced Catalog Item remains. */
   deleteListLine: (listId: string, lineId: string) => Promise<void>;
+  updateCatalogItem: (input: UpdateCatalogItemInput) => Promise<void>;
+  updateListLine: (listId: string, input: UpdateListLineInput) => Promise<void>;
   /**
    * Adds an item to a Grocery List: reuses an existing Catalog Item when the
    * name matches case-insensitively (updating its durable fields), otherwise
@@ -270,6 +287,7 @@ export function useGroceriesVault({
         await persistPayload(nextPayload);
       } catch (err) {
         console.error('Failed to toggle list line:', err);
+        throw err;
       }
     },
     [payload, persistPayload],
@@ -302,6 +320,7 @@ export function useGroceriesVault({
         await persistPayload(nextPayload);
       } catch (err) {
         console.error('Failed to uncheck all list lines:', err);
+        throw err;
       }
     },
     [payload, persistPayload],
@@ -336,7 +355,7 @@ export function useGroceriesVault({
         return removed;
       } catch (err) {
         console.error('Failed to remove checked list lines:', err);
-        return [];
+        throw err;
       }
     },
     [payload, persistPayload],
@@ -387,6 +406,67 @@ export function useGroceriesVault({
         await persistPayload(nextPayload);
       } catch (err) {
         console.error('Failed to delete list line:', err);
+        throw err;
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /** Updates only durable Catalog Item fields; List Lines are untouched. */
+  const updateCatalogItem = useCallback(
+    async (input: UpdateCatalogItemInput) => {
+      try {
+        const existing = payload.catalog.find((item) => item.id === input.id);
+        if (!existing) throw new Error('Catalog Item not found');
+
+        const now = new Date().toISOString();
+        const nextPayload: GroceriesVaultPayload = {
+          catalog: payload.catalog.map((item) =>
+            item.id === input.id ? { ...item, ...input, updatedAt: now } : item,
+          ),
+          lists: payload.lists,
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to update catalog item:', err);
+        throw err;
+      }
+    },
+    [payload, persistPayload],
+  );
+
+  /** Updates only one List Line's trip-local amount; checked is untouched. */
+  const updateListLine = useCallback(
+    async (listId: string, input: UpdateListLineInput) => {
+      try {
+        const list = payload.lists.find(
+          (currentList) => currentList.id === listId,
+        );
+        if (!list || !list.lines.some((line) => line.id === input.id)) {
+          throw new Error('List Line not found');
+        }
+
+        const now = new Date().toISOString();
+        const nextPayload: GroceriesVaultPayload = {
+          catalog: payload.catalog,
+          lists: payload.lists.map((currentList) =>
+            currentList.id === listId
+              ? {
+                  ...currentList,
+                  lines: currentList.lines.map((line) =>
+                    line.id === input.id
+                      ? { ...line, amount: input.amount, updatedAt: now }
+                      : line,
+                  ),
+                  updatedAt: now,
+                }
+              : currentList,
+          ),
+        };
+        await persistPayload(nextPayload);
+      } catch (err) {
+        console.error('Failed to update list line:', err);
+        throw err;
       }
     },
     [payload, persistPayload],
@@ -688,6 +768,8 @@ export function useGroceriesVault({
     removeCheckedLines,
     restoreLines,
     deleteListLine,
+    updateCatalogItem,
+    updateListLine,
     addCatalogItemAndLine,
     addItemToLists,
     addExistingCatalogItemToLists,

--- a/libs/web/pages/groceries/src/shared/utils/__tests__/groceryTotals.spec.ts
+++ b/libs/web/pages/groceries/src/shared/utils/__tests__/groceryTotals.spec.ts
@@ -1,0 +1,51 @@
+import type { CatalogItem, ListLine } from '@myorganizer/core';
+import { summarizeListSpend } from '../groceryTotals';
+
+describe('summarizeListSpend', () => {
+  const item = (id: string, price?: number): CatalogItem => ({
+    id,
+    name: id,
+    category: 'other',
+    ...(price === undefined ? {} : { price }),
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  });
+  const line = (
+    id: string,
+    catalogItemId: string,
+    checked = false,
+  ): ListLine => ({
+    id,
+    catalogItemId,
+    checked,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  });
+
+  it('sums each priced line once and counts only checked priced lines in checkedKnown', () => {
+    expect(
+      summarizeListSpend(
+        [line('l1', 'a', true), line('l2', 'a'), line('l3', 'b', true)],
+        [item('a', 2.5), item('b', 4)],
+      ),
+    ).toEqual({
+      known: 9,
+      pricedCount: 3,
+      unpricedCount: 0,
+      checkedKnown: 6.5,
+    });
+  });
+
+  it('does not treat missing, non-numeric, or stale catalog prices as zero', () => {
+    expect(
+      summarizeListSpend(
+        [
+          line('l1', 'missing'),
+          line('l2', 'no-price'),
+          line('l3', 'nan', true),
+        ],
+        [item('no-price'), item('nan', Number.NaN)],
+      ),
+    ).toEqual({ known: 0, pricedCount: 0, unpricedCount: 3, checkedKnown: 0 });
+  });
+});

--- a/libs/web/pages/groceries/src/shared/utils/__tests__/groceryValidation.spec.ts
+++ b/libs/web/pages/groceries/src/shared/utils/__tests__/groceryValidation.spec.ts
@@ -1,0 +1,44 @@
+import type { AddCatalogItemAndLineInput } from '../../hooks/useGroceriesVault';
+import { validateAddCatalogItemAndLineInput } from '../groceryValidation';
+
+describe('validateAddCatalogItemAndLineInput', () => {
+  const valid: AddCatalogItemAndLineInput = {
+    name: ' Milk ',
+    category: 'dairy',
+  };
+
+  it.each([
+    ['blank name', { name: '   ' }],
+    ['overlong name', { name: 'x'.repeat(201) }],
+    ['invalid category', { category: 'invalid' }],
+    ['negative price', { price: -1 }],
+    ['NaN price', { price: Number.NaN }],
+    ['out-of-range price', { price: 100_000 }],
+    ['invalid image URL', { imageUrl: 'not-a-url' }],
+    [
+      'too many links',
+      { links: Array.from({ length: 11 }, () => 'https://example.com') },
+    ],
+    ['negative quantity', { amount: '-1kg' }],
+    ['malformed quantity', { amount: '1kg!' }],
+  ])('rejects %s', (_label, override) => {
+    expect(() =>
+      validateAddCatalogItemAndLineInput({
+        ...valid,
+        ...override,
+      } as AddCatalogItemAndLineInput),
+    ).toThrow();
+  });
+
+  it('accepts blank and supported unit quantities and normalizes name/amount', () => {
+    expect(
+      validateAddCatalogItemAndLineInput({ ...valid, amount: '  500g  ' }),
+    ).toMatchObject({ name: 'Milk', amount: '500g' });
+    expect(
+      validateAddCatalogItemAndLineInput({ ...valid, amount: '   ' }),
+    ).toMatchObject({ name: 'Milk', amount: undefined });
+    expect(
+      validateAddCatalogItemAndLineInput({ ...valid, amount: '1 dozen' }),
+    ).toMatchObject({ name: 'Milk', amount: '1 dozen' });
+  });
+});

--- a/libs/web/pages/groceries/src/shared/utils/groceryTotals.ts
+++ b/libs/web/pages/groceries/src/shared/utils/groceryTotals.ts
@@ -48,7 +48,7 @@ export function summarizeListSpend(
     const catalogItem = resolveCatalogItem(line, catalog);
     const price = catalogItem?.price;
 
-    if (typeof price === 'number' && !Number.isNaN(price)) {
+    if (typeof price === 'number' && Number.isFinite(price)) {
       known += price;
       pricedCount += 1;
       if (line.checked) checkedKnown += price;

--- a/libs/web/pages/groceries/src/shared/utils/groceryTotals.ts
+++ b/libs/web/pages/groceries/src/shared/utils/groceryTotals.ts
@@ -1,0 +1,66 @@
+/**
+ * Trip Board spend summary helpers.
+ * Prices live on the CatalogItem (durable identity); ListLine is trip-local
+ * state (checked, amount). A line only contributes to "known spend" when its
+ * referenced CatalogItem has a numeric price — missing prices are never
+ * silently treated as $0.
+ */
+
+import type { CatalogItem, ListLine } from '@myorganizer/core';
+
+export interface ListSpendSummary {
+  /** Sum of prices for lines whose Catalog Item has a known price. */
+  known: number;
+  /** Count of lines whose Catalog Item has no price set. */
+  unpricedCount: number;
+  /** Count of lines whose Catalog Item has a known price. */
+  pricedCount: number;
+  /** Known spend restricted to Checked Items only. */
+  checkedKnown: number;
+}
+
+/**
+ * Resolves the CatalogItem referenced by a ListLine, or undefined if the
+ * reference is missing (should not happen after normalization, but defends
+ * against stale UI state mid-mutation).
+ */
+export function resolveCatalogItem(
+  line: ListLine,
+  catalog: CatalogItem[],
+): CatalogItem | undefined {
+  return catalog.find((item) => item.id === line.catalogItemId);
+}
+
+/**
+ * Summarizes known spend + unpriced count for a set of List Lines against
+ * the vault's Catalog Item price data.
+ */
+export function summarizeListSpend(
+  lines: ListLine[],
+  catalog: CatalogItem[],
+): ListSpendSummary {
+  let known = 0;
+  let unpricedCount = 0;
+  let pricedCount = 0;
+  let checkedKnown = 0;
+
+  for (const line of lines) {
+    const catalogItem = resolveCatalogItem(line, catalog);
+    const price = catalogItem?.price;
+
+    if (typeof price === 'number' && !Number.isNaN(price)) {
+      known += price;
+      pricedCount += 1;
+      if (line.checked) checkedKnown += price;
+    } else {
+      unpricedCount += 1;
+    }
+  }
+
+  return { known, unpricedCount, pricedCount, checkedKnown };
+}
+
+/** Formats a number as USD-style currency for display, e.g. `$12.50`. */
+export function formatMoney(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}

--- a/libs/web/pages/groceries/src/shared/utils/groceryValidation.ts
+++ b/libs/web/pages/groceries/src/shared/utils/groceryValidation.ts
@@ -1,0 +1,50 @@
+import type { GroceryCategoryType } from '@myorganizer/core';
+import { GROCERY_PREDEFINED_CATEGORIES } from '@myorganizer/core';
+import { z } from 'zod';
+import type { AddCatalogItemAndLineInput } from '../hooks/useGroceriesVault';
+
+const quantityPattern = /^\d+(?:[.,]\d+)?(?:\s*[a-zA-Z]+(?:\s+[a-zA-Z]+)*)?$/;
+
+export const addCatalogItemAndLineInputSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  category: z.enum(GROCERY_PREDEFINED_CATEGORIES),
+  price: z.number().finite().min(0).lt(100_000).optional(),
+  notes: z.string().max(1000).optional(),
+  imageUrl: z.string().url().optional(),
+  links: z.array(z.string().url()).max(10).optional(),
+  amount: z
+    .string()
+    .max(50)
+    .refine(
+      (value) =>
+        value.trim() === '' ||
+        (quantityPattern.test(value.trim()) &&
+          Number.isFinite(
+            Number(
+              value
+                .trim()
+                .match(/^\d+(?:[.,]\d+)?/)?.[0]
+                .replace(',', '.'),
+            ),
+          )),
+      'Quantity must be a valid non-negative number or a value such as 500g or 1 dozen',
+    )
+    .optional(),
+  catalogItemId: z.string().min(1).optional(),
+});
+
+export function validateAddCatalogItemAndLineInput(
+  input: AddCatalogItemAndLineInput,
+): AddCatalogItemAndLineInput {
+  const result = addCatalogItemAndLineInputSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error(result.error.issues[0]?.message ?? 'Invalid grocery item');
+  }
+
+  return {
+    ...input,
+    name: input.name.trim(),
+    category: input.category as GroceryCategoryType,
+    amount: input.amount?.trim() || undefined,
+  };
+}

--- a/libs/web/pages/groceries/src/shared/utils/index.ts
+++ b/libs/web/pages/groceries/src/shared/utils/index.ts
@@ -9,3 +9,7 @@ export {
   summarizeListSpend,
 } from './groceryTotals';
 export type { ListSpendSummary } from './groceryTotals';
+export {
+  addCatalogItemAndLineInputSchema,
+  validateAddCatalogItemAndLineInput,
+} from './groceryValidation';

--- a/libs/web/pages/groceries/src/shared/utils/index.ts
+++ b/libs/web/pages/groceries/src/shared/utils/index.ts
@@ -3,3 +3,9 @@ export {
   getVaultErrorMessage,
   validateGroceryListName,
 } from './vault';
+export {
+  formatMoney,
+  resolveCatalogItem,
+  summarizeListSpend,
+} from './groceryTotals';
+export type { ListSpendSummary } from './groceryTotals';

--- a/libs/web/pages/groceries/src/shared/utils/vault.ts
+++ b/libs/web/pages/groceries/src/shared/utils/vault.ts
@@ -3,7 +3,7 @@
  * Provides consistent error handling and common patterns.
  */
 
-import type { GroceryList } from '@myorganizer/core';
+import type { GroceryList, GroceriesVaultPayload } from '@myorganizer/core';
 import { randomId } from '@myorganizer/core';
 
 /**
@@ -51,8 +51,19 @@ export function createEmptyGroceryList(name: string): GroceryList {
   return {
     id: randomId(),
     name,
-    items: [],
+    lines: [],
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Creates a fresh empty groceries vault payload.
+ * @returns A new GroceriesVaultPayload with empty catalog and lists
+ */
+export function createFreshGroceriesPayload(): GroceriesVaultPayload {
+  return {
+    catalog: [],
+    lists: [],
   };
 }


### PR DESCRIPTION
## Why
Implements the grocery trip board and catalog workflow described by PRD #224.

## Changes
- Separate catalog items from grocery list lines.
- Add catalog suggestions, validation, membership, and trip lifecycle actions.
- Add trip board detail and index screens.
- Retarget stale grocery fixtures to the current ListLine shape.

## Validation
- Changes are based on seven commits on `feat/web-groceries-trip-board-catalog`.
- Related to #224.

## QA
- QA plan: #237