### PR TITLE
ci(release): publish GitHub Releases from version tags

### DIFF
--- a/.github/skills/release-and-deploy-workflow/SKILL.md
+++ b/.github/skills/release-and-deploy-workflow/SKILL.md
@@ -155,6 +155,8 @@ The script will:
 3. Create annotated tag `vX.Y.Z`
 4. Push the tag to `origin`
 
+Pushing the tag triggers `Publish GitHub Release`, which checks out the tagged commit and creates or updates the GitHub Release using `RELEASE_NOTES.md` as its body.
+
 ---
 
 ### Phase 7 — Merge the release PR back to main

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -1,0 +1,101 @@
+name: Publish GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to publish (e.g. v0.3.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-github-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Resolve release tag
+        id: release
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          PUSHED_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-$PUSHED_TAG}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: '$tag' is not a semantic release tag."
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tagged release
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+          fetch-depth: 1
+
+      - name: Create or update GitHub Release
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('node:fs');
+            const tag = process.env.RELEASE_TAG;
+            const notesPath = 'RELEASE_NOTES.md';
+
+            if (!fs.existsSync(notesPath)) {
+              core.setFailed(`Missing ${notesPath} at ${tag}.`);
+              return;
+            }
+
+            const body = fs.readFileSync(notesPath, 'utf8').trim();
+            if (!body) {
+              core.setFailed(`${notesPath} is empty at ${tag}.`);
+              return;
+            }
+
+            const release = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: `Release ${tag}`,
+              body,
+              draft: false,
+              prerelease: false,
+            };
+
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({
+                owner: release.owner,
+                repo: release.repo,
+                tag: release.tag_name,
+              });
+
+              await github.rest.repos.updateRelease({
+                owner: release.owner,
+                repo: release.repo,
+                release_id: existing.data.id,
+                name: release.name,
+                body: release.body,
+                draft: release.draft,
+                prerelease: release.prerelease,
+              });
+              core.info(`Updated GitHub Release ${tag}.`);
+            } catch (error) {
+              if (error.status !== 404) throw error;
+
+              await github.rest.repos.createRelease(release);
+              core.info(`Created GitHub Release ${tag}.`);
+            }

--- a/docs/deployment/CI_CD_AND_RELEASE_PROCESS.md
+++ b/docs/deployment/CI_CD_AND_RELEASE_PROCESS.md
@@ -207,7 +207,11 @@ Use a versioned release branch so production deploys are unambiguous:
   - `git tag -a v1.2.3 -m "Release v1.2.3"`
   - `git push origin v1.2.3`
 
-5. Create a GitHub Release using the tag `v1.2.3` for traceability (release notes + links).
+5. Push the tag and let the `Publish GitHub Release` workflow create the GitHub Release.
+
+- The workflow checks out the tagged commit and uses its `RELEASE_NOTES.md` as the release body.
+- Re-running the workflow updates the existing release, so publishing is idempotent.
+- To publish an existing tag manually, run the workflow with the `tag` input.
 
 ### Release checklist (copy/paste)
 
@@ -255,12 +259,6 @@ If enabled, a workflow can automatically:
 - Enable GitHub auto-merge so it merges after required checks pass
 
 This requires repository settings to allow auto-merge and that branch protection rules do not require manual approvals.
-
-5. Create the GitHub Release:
-
-- GitHub → Releases → Draft a new release
-- Tag: `vX.Y.Z`
-- Target: `release/vX.Y.Z`
 
 Notes:
 


### PR DESCRIPTION
## Why
Publish GitHub Releases from version tags.

## Changes
- Create or update releases from tagged commits using RELEASE_NOTES.md
- Document automatic and manual release publishing behavior

## Validation
- Generated from 1 commit(s) on `fix/publish-github-release`.
- Compared against base branch `main`.
