### PR TITLE
docs(context): add Followed Channel and watching glossary terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,16 @@ _Avoid_: Pool item, master item, product, favorite (unless UI label), template
 A Grocery List’s reference to a Catalog Item for a trip, carrying trip-local state such as checked and quantity/amount. The same Catalog Item may appear on multiple Grocery Lists at once.
 _Avoid_: Embedded item, list-owned item, row (as domain name)
 
+## YouTube (focused watching)
+
+**Shorts Daily Budget**:
+The User’s configurable daily cap on time spent in the Shorts lane (default one hour), measured as wall-clock while a Short is active and the document is visible.
+_Avoid_: Shorts quota, daily Shorts timer (as the product name), playtime limit
+
+**Shorts Hard Stop**:
+The locked state when the Shorts Daily Budget is exhausted for the User’s local calendar day: in-app Shorts playback and navigation are unavailable until local midnight or the User raises the limit enough to unlock.
+_Avoid_: Soft lock, cooldown, Shorts ban, timeout
+
 ## Frontend Architecture
 
 **UI Primitive**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,7 +87,7 @@ Metadata MyOrganizer stores for one upload from an Enabled Channel (ids, title, 
 _Avoid_: Video (as the domain name alone), synced video, YouTube video row
 
 **Watched**:
-The marked state that a Cached Upload has been completed for browsing purposes (manual or near-end completion — not play-start).
+The binary completion/seen state of a Cached Upload for a User. Reversible by the User; not a viewing-analytics history.
 _Avoid_: Viewed, seen, played, completed
 
 **New**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,26 @@ _Avoid_: Embedded item, list-owned item, row (as domain name)
 
 ## YouTube (focused watching)
 
+**Followed Channel**:
+A YouTube channel the User follows, imported from their connected YouTube account.
+_Avoid_: Subscription, YouTube subscription, channel subscription
+
+**Enabled Channel**:
+A Followed Channel the User has turned on for metadata sync and focused watching surfaces.
+_Avoid_: Active channel, selected channel, subscribed channel
+
+**Cached Upload**:
+Metadata MyOrganizer stores for one upload from an Enabled Channel (ids, title, thumb, published time, duration). Never the media file.
+_Avoid_: Video (as the domain name alone), synced video, YouTube video row
+
+**Watched**:
+The marked state that a Cached Upload has been completed for browsing purposes (manual or near-end completion — not play-start).
+_Avoid_: Viewed, seen, played, completed
+
+**New**:
+A Cached Upload that is not Watched.
+_Avoid_: Unwatched, unread, unseen
+
 **Shorts Daily Budget**:
 The User’s configurable daily cap on time spent in the Shorts lane (default one hour), measured as wall-clock while a Short is active and the document is visible.
 _Avoid_: Shorts quota, daily Shorts timer (as the product name), playtime limit


### PR DESCRIPTION
## Summary
- Adds **Followed Channel**, **Enabled Channel**, **Cached Upload**, **Watched**, and **New** to `CONTEXT.md` under YouTube (focused watching).
- Builds on the Shorts glossary already merged in #259.

## Test plan
- [x] Glossary matches the resolution on #257
- [x] No unrelated `CONTEXT.md` drift

Refs #257