### PR TITLE
fix(hooks): unify agent hooks across Copilot, Cursor, and Claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node",
-            "args": [
-              "-e",
-              "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const j=JSON.parse(d);const cmd=(j.tool_input&&j.tool_input.command)||'';if(/yarn (add|remove|up|upgrade)|npm (install|uninstall|update)/i.test(cmd)){process.stdout.write(JSON.stringify({systemMessage:'package.json may have changed - run /dep-sync to update TECH_STACK.md.'})+String.fromCharCode(10));}}catch(e){}});"
-            ],
+            "command": "node tools/scripts/copilot-hooks/dep-sync-reminder.mjs",
             "timeout": 5
           }
         ]

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": "node tools/scripts/copilot-hooks/secret-scan.mjs",
+        "matcher": "Shell|Write|Delete",
+        "timeout": 5
+      },
+      {
+        "command": "node tools/scripts/copilot-hooks/pre-tool-use.mjs",
+        "matcher": "Shell|Write|Delete",
+        "timeout": 5
+      }
+    ],
+    "postToolUse": [
+      {
+        "command": "node tools/scripts/copilot-hooks/post-tool-use.mjs",
+        "matcher": "Shell|Write|Delete",
+        "timeout": 5
+      },
+      {
+        "command": "node tools/scripts/copilot-hooks/dep-sync-reminder.mjs",
+        "matcher": "Shell",
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/.github/hooks/dep-sync-reminder.json
+++ b/.github/hooks/dep-sync-reminder.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "node tools/scripts/copilot-hooks/dep-sync-reminder.mjs",
+        "powershell": "node tools/scripts/copilot-hooks/dep-sync-reminder.mjs",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -48,6 +48,10 @@ Committed ninth wave:
 - `implement` (adapted from `mattpocock/skills`, with MyOrganizer delegation, validation, and commit/PR conventions)
 - `code-review` (adapted from `mattpocock/skills`, with MyOrganizer standards sources and GitHub issue fetching)
 
+Committed tenth wave:
+
+- `create-hooks` (multi-harness Copilot / Cursor / Claude agent hooks)
+
 These skills capture project-specific workflows that are easy for agents to miss even after reading the general repo instructions.
 
 Note: these are VS Code workspace skills stored in `.github/skills`. They are intended for agent discovery inside the editor. They may not appear in `npx skills list`, which focuses on skills installed through the `skills` CLI.

--- a/.github/skills/create-hooks/SKILL.md
+++ b/.github/skills/create-hooks/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: create-hooks
+description: >-
+  Create and maintain multi-harness agent hooks for GitHub Copilot, Cursor
+  IDE/CLI, and Claude Code. Use when adding, fixing, or reviewing hooks,
+  preToolUse/postToolUse scripts, .github/hooks, .cursor/hooks.json, or
+  .claude/settings.json hook blocks.
+---
+
+# Create Hooks
+
+Add agent lifecycle hooks that work across harnesses. Prefer **one shared Node
+script** under `tools/scripts/copilot-hooks/` and thin per-harness config that
+points at it.
+
+## When to Use
+
+- User asks to add, fix, or review agent hooks
+- Copilot/Cursor/Claude reports hook errors or silent no-ops
+- New guardrail needed (secrets, protected paths, reminders)
+
+## Canonical Layout
+
+| Harness | Config | Notes |
+| --- | --- | --- |
+| GitHub Copilot CLI / cloud | `.github/hooks/<name>.json` | `version: 1`, camelCase events, `bash` + `powershell` |
+| Cursor IDE / CLI / cloud | `.cursor/hooks.json` | Single file, camelCase events, `command` string only |
+| Claude Code | `.claude/settings.json` → `hooks` | PascalCase events, nested `matcher` + `hooks[]` |
+| Shared scripts | `tools/scripts/copilot-hooks/*.mjs` | Always use `./lib.mjs` helpers |
+
+Cursor does **not** read `.github/hooks/*.json`. Copilot cloud does **not** read
+`.cursor/hooks.json`. Wire both when the behavior should apply everywhere.
+
+Claude hooks are also loaded by Cursor when third-party configs are enabled
+(Settings → Rules, Skills, Subagents). Avoid duplicate logic: prefer shared
+scripts and keep Claude config as a thin launcher.
+
+## Workflow
+
+Copy this checklist:
+
+```
+Hook Progress:
+- [ ] 1. Decide event + behavior (block vs remind)
+- [ ] 2. Implement/reuse script in tools/scripts/copilot-hooks/
+- [ ] 3. Wire Copilot `.github/hooks/*.json` if needed
+- [ ] 4. Wire Cursor `.cursor/hooks.json` if needed
+- [ ] 5. Wire Claude `.claude/settings.json` if needed
+- [ ] 6. Smoke-test with piped JSON
+- [ ] 7. Confirm no bare `node` + `args` arrays
+```
+
+### 1. Choose the event
+
+| Goal | Prefer |
+| --- | --- |
+| Block a tool call | `preToolUse` (all). Cursor also has `beforeShellExecution` / `beforeReadFile` |
+| Remind after a change | `postToolUse` |
+| Package install → dep-sync | `postToolUse` + shell matcher → `dep-sync-reminder.mjs` |
+
+### 2. Write or extend a shared script
+
+- Import from `./lib.mjs`: `readPayloadOrExit`, `getToolName`, `getToolInput`,
+  `isMutatingTool`, `allowTool`, `denyTool`, `emitAdditionalContext`
+- Never `process.exit(1)` on parse errors — use `readPayloadOrExit` (fail-open)
+- Allow/skip with `allowTool()` on preToolUse scripts (required before enabling
+  Cursor `failClosed`)
+- Block with `denyTool(reason)` (emits dual-format JSON + exit `2`)
+- Remind with `emitAdditionalContext(message)` (emits Copilot + Cursor + Claude fields)
+
+### 3. Wire harness configs
+
+**Copilot** (`.github/hooks/<name>.json`):
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "node tools/scripts/copilot-hooks/<script>.mjs",
+        "powershell": "node tools/scripts/copilot-hooks/<script>.mjs",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}
+```
+
+**Cursor** (merge into `.cursor/hooks.json`):
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": "node tools/scripts/copilot-hooks/<script>.mjs",
+        "matcher": "Shell|Write|Delete",
+        "timeout": 5
+      }
+    ]
+  }
+}
+```
+
+Do **not** set `failClosed: true` unless every allow/skip path emits explicit
+allow JSON via `allowTool()`. Empty stdout + `failClosed` blocks the tool in
+Cursor (including this agent).
+
+**Claude** (`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node tools/scripts/copilot-hooks/<script>.mjs",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 4. Hard rules (avoid known failures)
+
+1. **Never** use Claude-style `"command": "node", "args": [...]` — Copilot/Cursor
+   treat `command` as a single shell string; bare `node` crashes on JSON stdin.
+2. Always include both `bash` and `powershell` for Copilot.
+3. Cursor project scripts run with cwd = repo root — use `node tools/scripts/...`.
+4. Keep `timeout` / `timeoutSec` ≤ 5s unless necessary.
+5. Do not duplicate the same reminder in Claude + Cursor unless the script is
+   idempotent — Cursor merges Claude hooks when third-party configs are on.
+
+### 5. Smoke-test
+
+```powershell
+'{"toolName":"bash","toolArgs":"{\"command\":\"ls\"}"}' | node tools/scripts/copilot-hooks/<script>.mjs; echo exit=$LASTEXITCODE
+'{"toolName":"edit","toolArgs":"{\"path\":\"libs/app-api-client/src/index.ts\"}"}' | node tools/scripts/copilot-hooks/pre-tool-use.mjs; echo exit=$LASTEXITCODE
+```
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Allow / success |
+| `2` | Deny / block |
+| other | Failure |
+
+## Existing Shared Scripts
+
+| Script | Role |
+| --- | --- |
+| `pre-tool-use.mjs` | Block edits to generated/protected paths |
+| `secret-scan.mjs` | Block secret-looking tool input |
+| `post-tool-use.mjs` | Remind after OpenAPI/Prisma contract edits |
+| `dep-sync-reminder.mjs` | Remind `/dep-sync` after package manager mutations |
+| `lib.mjs` | Shared stdin parsing + dual-format output |
+
+## More Detail
+
+- Harness field matrices and output schemas: [reference.md](reference.md)

--- a/.github/skills/create-hooks/reference.md
+++ b/.github/skills/create-hooks/reference.md
@@ -1,0 +1,112 @@
+# Agent Hooks Reference
+
+Quick matrix for MyOrganizer multi-harness hooks. Prefer the shared scripts in
+`tools/scripts/copilot-hooks/` and the workflow in [SKILL.md](SKILL.md).
+
+## Config Sources
+
+| Host | Loads |
+| --- | --- |
+| GitHub Copilot CLI | `.github/hooks/*.json`, `~/.copilot/hooks/`, `.claude/settings.json` |
+| GitHub Copilot cloud | `.github/hooks/*.json` only (Linux; `bash` / `command`) |
+| Cursor IDE / CLI | `.cursor/hooks.json`, `~/.cursor/hooks.json`, Claude settings (if third-party enabled) |
+| Cursor cloud | `.cursor/hooks.json` (command hooks; subset of events) |
+| Claude Code | `.claude/settings.json`, `.claude/settings.local.json` |
+| VS Code Copilot Chat | `.github/hooks/*.json` + `.claude/settings.json` (format bridging) |
+
+## Event Name Mapping
+
+| Copilot / Cursor | Claude / VS Code PascalCase |
+| --- | --- |
+| `preToolUse` | `PreToolUse` |
+| `postToolUse` | `PostToolUse` |
+| `sessionStart` | `SessionStart` |
+| `sessionEnd` | `SessionEnd` |
+| `preCompact` | `PreCompact` |
+| `stop` / `agentStop` | `Stop` |
+| `subagentStop` | `SubagentStop` |
+
+Cursor-only extras: `beforeShellExecution`, `afterShellExecution`,
+`beforeReadFile`, `afterFileEdit`, `beforeSubmitPrompt`, `afterAgentResponse`.
+
+## Per-Hook Command Fields
+
+| Field | Copilot | Cursor | Claude |
+| --- | --- | --- | --- |
+| `type: "command"` | yes | optional (default) | yes |
+| `command` (single string) | yes (fallback) | **required** | yes |
+| `bash` / `powershell` | yes | no | no |
+| `args` array | **no** | **no** | Claude-only; **do not use** here |
+| `cwd` | yes | no (project root) | no |
+| `timeoutSec` / `timeout` | `timeoutSec` | `timeout` | `timeout` |
+| `matcher` | optional regex on tool name | string / regex by event | Claude matcher syntax |
+| `failClosed` | no | yes (only with explicit `allowTool()` JSON) | no |
+
+## Tool Names (lowercased in scripts)
+
+| Host | Shell | Edit / write | Create | Delete |
+| --- | --- | --- | --- | --- |
+| Copilot CLI | `bash`, `powershell` | `edit` | `create` | `delete` |
+| Cursor | `Shell` | `Write` | `Write` | `Delete` |
+| Claude | `Bash` | `Edit` / `Write` | `Write` | — |
+| VS Code Chat | `runTerminalCommand` | `editFiles` / `replace_string_in_file` | `createFile` / `create_file` | `deleteFile` |
+
+## Output Fields Emitted by `lib.mjs`
+
+### Allow (`allowTool`)
+
+```json
+{
+  "permissionDecision": "allow",
+  "permission": "allow",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+```
+
+Exit `0`.
+
+### Deny (`denyTool`)
+
+```json
+{
+  "permissionDecision": "deny",
+  "permissionDecisionReason": "<reason>",
+  "permission": "deny",
+  "user_message": "<reason>",
+  "agent_message": "<reason>",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "<reason>"
+  }
+}
+```
+
+Exit `2`.
+
+### Context (`emitAdditionalContext`)
+
+```json
+{
+  "additionalContext": "<message>",
+  "additional_context": "<message>",
+  "systemMessage": "<message>",
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "<message>"
+  }
+}
+```
+
+Exit `0`.
+
+## Docs
+
+- Copilot hooks: https://docs.github.com/en/copilot/concepts/agents/hooks
+- Copilot reference: https://docs.github.com/en/copilot/reference/hooks-reference
+- Cursor hooks: https://cursor.com/docs/hooks
+- Cursor third-party (Claude): https://cursor.com/docs/reference/third-party-hooks
+- VS Code agent hooks: https://code.visualstudio.com/docs/copilot/customization/agent-hooks

--- a/tools/scripts/copilot-hooks/dep-sync-reminder.mjs
+++ b/tools/scripts/copilot-hooks/dep-sync-reminder.mjs
@@ -1,0 +1,58 @@
+import {
+  emitAdditionalContext,
+  getToolInput,
+  getToolName,
+  readPayloadOrExit,
+} from './lib.mjs';
+
+const PACKAGE_MUTATION =
+  /\b(?:yarn|npm|pnpm)\s+(?:add|remove|up|upgrade|install|uninstall|update)\b/i;
+
+const SHELL_TOOL_NAMES = new Set([
+  'bash',
+  'command',
+  'execute',
+  'powershell',
+  'run',
+  'runterminalcommand',
+  'shell',
+]);
+
+function extractCommand(toolInput) {
+  if (typeof toolInput === 'string') {
+    return toolInput;
+  }
+
+  if (!toolInput || typeof toolInput !== 'object') {
+    return '';
+  }
+
+  for (const key of ['command', 'cmd', 'script', 'shell']) {
+    const value = toolInput[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return '';
+}
+
+async function main() {
+  const payload = await readPayloadOrExit();
+  const toolName = getToolName(payload);
+
+  if (toolName && !SHELL_TOOL_NAMES.has(toolName)) {
+    process.exit(0);
+  }
+
+  const command = extractCommand(getToolInput(payload));
+  if (!PACKAGE_MUTATION.test(command)) {
+    process.exit(0);
+  }
+
+  emitAdditionalContext(
+    'package.json may have changed — run /dep-sync to update TECH_STACK.md.',
+  );
+}
+
+main();

--- a/tools/scripts/copilot-hooks/lib.mjs
+++ b/tools/scripts/copilot-hooks/lib.mjs
@@ -1,0 +1,212 @@
+import process from 'node:process';
+
+/**
+ * Shared helpers for multi-harness agent hooks (Copilot CLI/cloud, VS Code Copilot,
+ * Cursor IDE/CLI, Claude Code).
+ *
+ * Scripts emit dual-format JSON so one implementation works across hosts.
+ */
+
+export const MUTATING_TOOL_NAMES = new Set([
+  // Copilot CLI / cloud
+  'apply_patch',
+  'applypatch',
+  'bash',
+  'command',
+  'create',
+  'delete',
+  'edit',
+  'execute',
+  'move',
+  'multiedit',
+  'multi_edit',
+  'patch',
+  'powershell',
+  'rename',
+  'replace',
+  'run',
+  'shell',
+  'write',
+  // Cursor tool types (preToolUse matcher values, lowercased)
+  'delete',
+  'shell',
+  'write',
+  // VS Code Copilot Chat tool names
+  'create_file',
+  'createfile',
+  'deletefile',
+  'editfiles',
+  'replace_string_in_file',
+  'runterminalcommand',
+  // Claude Code tool names (payloads may use these)
+  'bash',
+  'edit',
+  'write',
+]);
+
+export function normalizeText(value) {
+  return value.replace(/\\/g, '/').toLowerCase();
+}
+
+export function getToolName(payload) {
+  const value =
+    payload?.toolName ??
+    payload?.tool_name ??
+    payload?.tool ??
+    payload?.name ??
+    '';
+
+  return typeof value === 'string' ? value.toLowerCase() : '';
+}
+
+export function getToolInput(payload) {
+  const raw =
+    payload?.toolArgs ??
+    payload?.tool_args ??
+    payload?.toolInput ??
+    payload?.tool_input ??
+    payload?.input ??
+    payload?.args ??
+    payload?.arguments ??
+    null;
+
+  if (typeof raw !== 'string') {
+    return raw;
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return raw;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return raw;
+  }
+}
+
+export function collectStrings(node, output = []) {
+  if (node === null || node === undefined) {
+    return output;
+  }
+
+  if (typeof node === 'string') {
+    output.push(node);
+    return output;
+  }
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectStrings(item, output);
+    }
+
+    return output;
+  }
+
+  if (typeof node === 'object') {
+    for (const value of Object.values(node)) {
+      collectStrings(value, output);
+    }
+  }
+
+  return output;
+}
+
+export function readStdin() {
+  return new Promise((resolve) => {
+    let rawInput = '';
+
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      rawInput += chunk;
+    });
+    process.stdin.on('end', () => {
+      resolve(rawInput);
+    });
+  });
+}
+
+/**
+ * Parse hook stdin. On empty/invalid input, allow and exit (fail-open).
+ * Never exit non-zero on parse errors — that fail-closes Copilot preToolUse
+ * and can trip Cursor failClosed when stdout is empty.
+ */
+export async function readPayloadOrExit() {
+  const rawInput = await readStdin();
+
+  if (!rawInput.trim()) {
+    allowTool();
+  }
+
+  try {
+    return JSON.parse(rawInput);
+  } catch (error) {
+    console.error('[agent-hooks] Unable to parse hook payload.');
+    console.error(error instanceof Error ? error.message : String(error));
+    allowTool();
+  }
+}
+
+export function isMutatingTool(toolName) {
+  return Boolean(toolName) && MUTATING_TOOL_NAMES.has(toolName);
+}
+
+/**
+ * Explicit allow for preToolUse. Required if Cursor `failClosed: true` is set —
+ * empty stdout is treated as hook failure and blocks the tool.
+ */
+export function allowTool() {
+  process.stdout.write(
+    JSON.stringify({
+      permissionDecision: 'allow',
+      permission: 'allow',
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'allow',
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+/**
+ * Deny a tool call in a format accepted by Copilot, VS Code, Cursor, and Claude.
+ * Exit 2 is the portable "block" signal across Cursor and Claude; Copilot
+ * preToolUse also treats exit 2 as deny.
+ */
+export function denyTool(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+      permission: 'deny',
+      user_message: reason,
+      agent_message: reason,
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(2);
+}
+
+/**
+ * Inject follow-up context after a tool completes.
+ */
+export function emitAdditionalContext(message) {
+  process.stdout.write(
+    JSON.stringify({
+      additionalContext: message,
+      additional_context: message,
+      systemMessage: message,
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: message,
+      },
+    }),
+  );
+  process.exit(0);
+}

--- a/tools/scripts/copilot-hooks/post-tool-use.mjs
+++ b/tools/scripts/copilot-hooks/post-tool-use.mjs
@@ -1,23 +1,12 @@
-import process from 'node:process';
-
-const MUTATING_TOOL_NAMES = new Set([
-  'apply_patch',
-  'applypatch',
-  'bash',
-  'command',
-  'delete',
-  'execute',
-  'edit',
-  'move',
-  'patch',
-  'run',
-  'replace',
-  'rename',
-  'multiedit',
-  'multi_edit',
-  'shell',
-  'write',
-]);
+import {
+  collectStrings,
+  emitAdditionalContext,
+  getToolInput,
+  getToolName,
+  isMutatingTool,
+  normalizeText,
+  readPayloadOrExit,
+} from './lib.mjs';
 
 const CONTRACT_TARGETS = [
   {
@@ -31,61 +20,6 @@ const CONTRACT_TARGETS = [
       'You changed Prisma schema files.\n- Run `yarn nx run backend:generate-types`\n- Run `yarn nx run backend:migrate`\n- Run the relevant backend tests',
   },
 ];
-
-function normalizeText(value) {
-  return value.replace(/\\/g, '/').toLowerCase();
-}
-
-function getToolName(payload) {
-  const value =
-    payload?.toolName ??
-    payload?.tool_name ??
-    payload?.tool ??
-    payload?.name ??
-    '';
-
-  return typeof value === 'string' ? value.toLowerCase() : '';
-}
-
-function getToolInput(payload) {
-  return (
-    payload?.toolArgs ??
-    payload?.tool_args ??
-    payload?.toolInput ??
-    payload?.tool_input ??
-    payload?.input ??
-    payload?.args ??
-    payload?.arguments ??
-    null
-  );
-}
-
-function collectStrings(node, output = []) {
-  if (node === null || node === undefined) {
-    return output;
-  }
-
-  if (typeof node === 'string') {
-    output.push(node);
-    return output;
-  }
-
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      collectStrings(item, output);
-    }
-
-    return output;
-  }
-
-  if (typeof node === 'object') {
-    for (const value of Object.values(node)) {
-      collectStrings(value, output);
-    }
-  }
-
-  return output;
-}
 
 function getAdditionalContext(strings) {
   const matches = new Set();
@@ -107,47 +41,23 @@ function getAdditionalContext(strings) {
   return Array.from(matches).join('\n\n');
 }
 
-function main() {
-  let rawInput = '';
+async function main() {
+  const payload = await readPayloadOrExit();
+  const toolName = getToolName(payload);
 
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', (chunk) => {
-    rawInput += chunk;
-  });
+  if (!isMutatingTool(toolName)) {
+    process.exit(0);
+  }
 
-  process.stdin.on('end', () => {
-    if (!rawInput.trim()) {
-      process.exit(0);
-      return;
-    }
+  const additionalContext = getAdditionalContext(
+    collectStrings(getToolInput(payload)),
+  );
 
-    let payload;
-    try {
-      payload = JSON.parse(rawInput);
-    } catch (error) {
-      console.error('[copilot-hooks] Unable to parse postToolUse payload.');
-      console.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
-      return;
-    }
+  if (!additionalContext) {
+    process.exit(0);
+  }
 
-    const toolName = getToolName(payload);
-    if (!MUTATING_TOOL_NAMES.has(toolName)) {
-      process.exit(0);
-      return;
-    }
-
-    const additionalContext = getAdditionalContext(
-      collectStrings(getToolInput(payload)),
-    );
-
-    if (!additionalContext) {
-      process.exit(0);
-      return;
-    }
-
-    process.stdout.write(JSON.stringify({ additionalContext }));
-  });
+  emitAdditionalContext(additionalContext);
 }
 
 main();

--- a/tools/scripts/copilot-hooks/pre-tool-use.mjs
+++ b/tools/scripts/copilot-hooks/pre-tool-use.mjs
@@ -1,23 +1,12 @@
-import process from 'node:process';
-
-const MUTATING_TOOL_NAMES = new Set([
-  'apply_patch',
-  'applypatch',
-  'bash',
-  'command',
-  'delete',
-  'execute',
-  'edit',
-  'move',
-  'patch',
-  'run',
-  'replace',
-  'rename',
-  'multiedit',
-  'multi_edit',
-  'shell',
-  'write',
-]);
+import {
+  allowTool,
+  denyTool,
+  getToolInput,
+  getToolName,
+  isMutatingTool,
+  normalizeText,
+  readPayloadOrExit,
+} from './lib.mjs';
 
 const COMMAND_KEYS = new Set(['cmd', 'command', 'script', 'shell']);
 const PATH_KEYS = new Set([
@@ -87,10 +76,6 @@ const PROTECTED_PATTERNS = [
   },
 ];
 
-function normalizeText(value) {
-  return value.replace(/\\/g, '/').toLowerCase();
-}
-
 function looksLikePath(text) {
   const normalized = normalizeText(text);
 
@@ -98,30 +83,6 @@ function looksLikePath(text) {
     normalized.includes('/') ||
     normalized.startsWith('.') ||
     /\.[a-z0-9]{1,5}(?:[?*].*)?$/i.test(normalized)
-  );
-}
-
-function getToolName(payload) {
-  const value =
-    payload?.toolName ??
-    payload?.tool_name ??
-    payload?.tool ??
-    payload?.name ??
-    '';
-
-  return typeof value === 'string' ? value.toLowerCase() : '';
-}
-
-function getToolInput(payload) {
-  return (
-    payload?.toolArgs ??
-    payload?.tool_args ??
-    payload?.toolInput ??
-    payload?.tool_input ??
-    payload?.input ??
-    payload?.args ??
-    payload?.arguments ??
-    null
   );
 }
 
@@ -239,7 +200,13 @@ function inspectToolInput(toolName, toolInput) {
   }
 
   if (typeof toolInput === 'string') {
-    if (toolName === 'bash' || toolName === 'command' || toolName === 'shell') {
+    if (
+      toolName === 'bash' ||
+      toolName === 'command' ||
+      toolName === 'shell' ||
+      toolName === 'powershell' ||
+      toolName === 'runterminalcommand'
+    ) {
       if (!isLikelyWriteCommand(toolInput)) {
         return null;
       }
@@ -257,49 +224,20 @@ function inspectToolInput(toolName, toolInput) {
   return inspectNode(toolInput);
 }
 
-function main() {
-  let rawInput = '';
+async function main() {
+  const payload = await readPayloadOrExit();
+  const toolName = getToolName(payload);
 
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', (chunk) => {
-    rawInput += chunk;
-  });
+  if (!isMutatingTool(toolName)) {
+    allowTool();
+  }
 
-  process.stdin.on('end', () => {
-    if (!rawInput.trim()) {
-      process.exit(0);
-      return;
-    }
+  const reason = inspectToolInput(toolName, getToolInput(payload));
+  if (!reason) {
+    allowTool();
+  }
 
-    let payload;
-    try {
-      payload = JSON.parse(rawInput);
-    } catch (error) {
-      console.error('[copilot-hooks] Unable to parse preToolUse payload.');
-      console.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
-      return;
-    }
-
-    const toolName = getToolName(payload);
-    if (!MUTATING_TOOL_NAMES.has(toolName)) {
-      process.exit(0);
-      return;
-    }
-
-    const reason = inspectToolInput(toolName, getToolInput(payload));
-    if (!reason) {
-      process.exit(0);
-      return;
-    }
-
-    process.stdout.write(
-      JSON.stringify({
-        permissionDecision: 'deny',
-        permissionDecisionReason: reason,
-      }),
-    );
-  });
+  denyTool(reason);
 }
 
 main();

--- a/tools/scripts/copilot-hooks/secret-scan.mjs
+++ b/tools/scripts/copilot-hooks/secret-scan.mjs
@@ -1,23 +1,12 @@
-import process from 'node:process';
-
-const MUTATING_TOOL_NAMES = new Set([
-  'apply_patch',
-  'applypatch',
-  'bash',
-  'command',
-  'delete',
-  'execute',
-  'edit',
-  'move',
-  'patch',
-  'run',
-  'replace',
-  'rename',
-  'multiedit',
-  'multi_edit',
-  'shell',
-  'write',
-]);
+import {
+  allowTool,
+  collectStrings,
+  denyTool,
+  getToolInput,
+  getToolName,
+  isMutatingTool,
+  readPayloadOrExit,
+} from './lib.mjs';
 
 const SECRET_PATTERNS = [
   {
@@ -50,57 +39,6 @@ const SECRET_PATTERNS = [
   },
 ];
 
-function getToolName(payload) {
-  const value =
-    payload?.toolName ??
-    payload?.tool_name ??
-    payload?.tool ??
-    payload?.name ??
-    '';
-
-  return typeof value === 'string' ? value.toLowerCase() : '';
-}
-
-function getToolInput(payload) {
-  return (
-    payload?.toolArgs ??
-    payload?.tool_args ??
-    payload?.toolInput ??
-    payload?.tool_input ??
-    payload?.input ??
-    payload?.args ??
-    payload?.arguments ??
-    null
-  );
-}
-
-function collectStrings(node, output = []) {
-  if (node === null || node === undefined) {
-    return output;
-  }
-
-  if (typeof node === 'string') {
-    output.push(node);
-    return output;
-  }
-
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      collectStrings(item, output);
-    }
-
-    return output;
-  }
-
-  if (typeof node === 'object') {
-    for (const value of Object.values(node)) {
-      collectStrings(value, output);
-    }
-  }
-
-  return output;
-}
-
 function getSecretReason(strings) {
   for (const text of strings) {
     for (const secretPattern of SECRET_PATTERNS) {
@@ -113,49 +51,20 @@ function getSecretReason(strings) {
   return null;
 }
 
-function main() {
-  let rawInput = '';
+async function main() {
+  const payload = await readPayloadOrExit();
+  const toolName = getToolName(payload);
 
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', (chunk) => {
-    rawInput += chunk;
-  });
+  if (!isMutatingTool(toolName)) {
+    allowTool();
+  }
 
-  process.stdin.on('end', () => {
-    if (!rawInput.trim()) {
-      process.exit(0);
-      return;
-    }
+  const secretReason = getSecretReason(collectStrings(getToolInput(payload)));
+  if (!secretReason) {
+    allowTool();
+  }
 
-    let payload;
-    try {
-      payload = JSON.parse(rawInput);
-    } catch (error) {
-      console.error('[copilot-hooks] Unable to parse preToolUse payload.');
-      console.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
-      return;
-    }
-
-    const toolName = getToolName(payload);
-    if (!MUTATING_TOOL_NAMES.has(toolName)) {
-      process.exit(0);
-      return;
-    }
-
-    const secretReason = getSecretReason(collectStrings(getToolInput(payload)));
-    if (!secretReason) {
-      process.exit(0);
-      return;
-    }
-
-    process.stdout.write(
-      JSON.stringify({
-        permissionDecision: 'deny',
-        permissionDecisionReason: secretReason,
-      }),
-    );
-  });
+  denyTool(secretReason);
 }
 
 main();


### PR DESCRIPTION
## Why
Unify agent hooks across Copilot, Cursor, and Claude.

## Changes
- Centralize hook I/O in lib.mjs so allow/deny/remind works in every harness
- Refactor pre/post/secret-scan scripts and add dep-sync-reminder after package changes
- Wire .cursor/hooks.json and .github/hooks; fix Claude launcher that crashed on JSON stdin
- Document multi-harness hook workflow in create-hooks skill

## Validation
- Generated from 1 commit(s) on `fix/multi-harness-hooks`.
- Compared against base branch `main`.
