### PR TITLE
docs(agents): adopt tiered quality gates and issue unblock

### DIFF
--- a/.claude/agents/component-reviewer.md
+++ b/.claude/agents/component-reviewer.md
@@ -129,6 +129,29 @@ For each file found:
 
 ## Output — Review Report
 
+Keep reports short by default (`PASS|FAIL|PASS_WITH_WARNINGS` + ≤5 bullets). Expand the full table only when the verdict is `FAIL` or the main agent requests detail (`gate:full` after a rejection).
+
+```markdown
+## ComponentReviewer Report
+
+### Verdict
+
+PASS | PASS_WITH_WARNINGS | FAIL
+
+### Summary (≤5 bullets)
+
+- <guideline or quality finding, or "none">
+
+### Required Revisions
+
+- [ ] <specific change ComponentBuilder must make, citing guideline section — omit if PASS>
+```
+
+When `FAIL` (or on request), also include the Guidelines Compliance table, Code Quality Findings, and Direct Importers sections from the long template below.
+
+<details>
+<summary>Full report template (FAIL / requested detail)</summary>
+
 ```markdown
 ## ComponentReviewer Report
 
@@ -192,9 +215,16 @@ PASS | PASS_WITH_WARNINGS | FAIL
 - [ ] <specific change ComponentBuilder must make, citing guideline section>
 ```
 
+</details>
+
+## Retry policy (main agent)
+
+The main agent may re-invoke ComponentBuilder → ComponentReviewer at most **3** times after a `FAIL`. On the 4th failure, escalate with a diagnosis — do not continue the loop.
+
 ## Constraints
 
 - Do NOT edit, create, or delete any file.
 - Do NOT fabricate findings — unknown = noted as such, not guessed.
 - Do NOT review Storybook stories or test files.
 - Every FAIL must cite a specific guideline section or concrete code quality issue.
+- Prefer the short report format unless FAIL or detail was requested.

--- a/.claude/checklist.md
+++ b/.claude/checklist.md
@@ -2,148 +2,165 @@
 
 **CRITICAL:** Use this checklist BEFORE making ANY file edits.
 
-## Step 1: Pre-Action Decision Tree
+Policy: [`docs/adr/0012-tiered-quality-gates.md`](../docs/adr/0012-tiered-quality-gates.md)
 
-Before editing ANY file, answer these questions:
+---
+
+## Step 0: Choose a gate tier
+
+State the tier in your first reply (interactive) or follow the slice `gate:*` label (AFK). When unsure → **promote**. User may override.
+
+| Tier              | Use when                                                                          | Execution                                                                           |
+| ----------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `gate:mechanical` | All mechanical criteria below are true                                            | Main agent may edit directly; focused lint + focused tests/`tsc`                    |
+| `gate:standard`   | Single-surface behavior change                                                    | One specialist hop for the artifact type (+ reviewer/runner as that skill requires) |
+| `gate:full`       | New module, vault/crypto, API contract, multi-file product behavior, ambiguous UX | Full mandatory pipelines                                                            |
+
+### Mechanical criteria (all must be true)
+
+1. No new product behavior or public API contract.
+2. Diff is localized (prefer ≤2 files; larger only if pure rename/delete).
+3. Assertions/stories unchanged **or** only fixture/type retarget to an already-landed domain model.
+4. Success is decidable by deterministic checks alone (`tsc` / `eslint` / focused jest).
+
+If any fails → `gate:standard` or `gate:full`.
+
+**Ticket optional:** Ad-hoc interactive work does not require a GitHub issue. Planned features still use `/to-prd` → `/to-issues`.
+
+---
+
+## Step 1: Pre-Action Decision Tree
 
 ### Q1: What file type am I modifying?
 
-- **`*.spec.ts` (Playwright E2E tests)** → Go to "E2E Tests" section
-- **`*.test.ts` (Jest unit/integration tests)** → Go to "Jest Tests" section
-- **`*.stories.tsx` (Storybook stories)** → Go to "Storybook Stories" section
-- **Component in `libs/web-ui/` (UI Primitives)** → Go to "React Components" section
-- **Component in `libs/web/pages/` (Feature Components)** → Go to "React Components" section
-- **Other files** → Proceed to Step 2
+- **`*.spec.ts` (Playwright E2E)** → E2E section (tier applies)
+- **`*.test.ts` / `*.spec.tsx` (Jest)** → Jest section (tier applies)
+- **`*.stories.tsx`** → Storybook section (tier applies)
+- **Component in `libs/web-ui/` or `libs/web/pages/`** → React Components section (tier applies)
+- **Other files** → Step 2 / matrix
 
-### Q2: Am I UPDATING existing code or CREATING new code?
+### Q2: Updating or creating?
 
-- **Updating test behavior or fixing test logic** → DELEGATE (even small fixes)
-- **Creating new test files** → DELEGATE
-- **Updating component implementation** → DELEGATE
-- **Other infrastructure/config** → Check "Red Flags" section
+- Mechanical retarget/rename/delete → may stay `gate:mechanical`
+- New behavior, new assertions, new props contracts → at least `gate:standard`
+- New UI primitive / multi-pipeline slice → `gate:full`
 
 ---
 
-## Step 2: Red Flags — Stop and Delegate If You See Any
+## Step 2: Red Flags — escalate the gate
 
-Before calling `replace_string_in_file` or `create_file`, check for these patterns:
+These patterns usually mean **not** mechanical (promote unless Step 0 criteria still hold):
 
-- ☐ The file extension is `.spec.ts` or `.test.ts`
-- ☐ The file path contains `/helpers/` within an E2E test directory
-- ☐ The code contains `setupBackend()`, `setupVault*()`, test fixtures, or mock helpers
-- ☐ The word "fixture", "setup", "mock", "beforeEach", "afterEach", "test.describe" appears
-- ☐ Playwright page object or browser automation code (`page.goto()`, `page.click()`, etc.)
-- ☐ Jest mock configuration or test structure (`jest.mock()`, `.mock()`)
-- ☐ Storybook story definition (`export const MyStory`)
-- ☐ React component JSX in `libs/web-ui/` or `libs/web/pages/`
-- ☐ UI behavior changes (styling, interactivity, props)
-- ☐ Test assertions being added or changed
+- New or changed product assertions / flows
+- New Jest mocks that encode behavior
+- Playwright page-object flow changes (not selector-only strings)
+- UI behavior changes (styling, interactivity, props contracts)
+- Vault/crypto, API contract, or OpenAPI surface changes
 
-**If ANY of these apply: STOP → READ SKILL FILE → DELEGATE to sub-agent**
+Config/docs/type-only edits with no behavior change may stay mechanical or direct-edit.
 
 ---
 
-## Step 3: Task Classification Matrix
+## Step 3: Task Classification Matrix (by gate)
 
-| File Pattern               | Operation         | Skill/Agent                                                                                                    | Delegated?                                  |
-| -------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `*.spec.ts` (E2E)          | Create/Update/Fix | `.github/skills/playwright-e2e-workflow/SKILL.md` → E2EPlanner + TestScaffold → TestReviewer (structural only) | ✅ **Always**                               |
-| `*.test.ts` (Jest)         | Create/Update/Fix | `.github/skills/unit-test-delegation-workflow/SKILL.md` → TestScaffold → TestReviewer → TestRunner             | ✅ **Always**                               |
-| `*.stories.tsx`            | Create/Update     | `.github/skills/storybook-delegation-workflow/SKILL.md` → StorybookCurator                                     | ✅ **Always**                               |
-| Component (libs/web-ui)    | Create/Edit       | `.claude/commands/component-builder.md` → ComponentBuilder → ComponentReviewer                                 | ✅ **Always**                               |
-| Component (libs/web/pages) | Create/Edit       | `.claude/commands/component-builder.md` → ComponentBuilder → ComponentReviewer                                 | ✅ **Always**                               |
-| Config/Infrastructure      | Edit              | Direct edit OK                                                                                                 | ⚠️ Only if no test/component files involved |
-| Docs/README                | Create/Update     | Direct edit OK                                                                                                 | ⚠️ Can delegate to Docs agent if complex    |
-| Type definitions           | Create/Update     | Direct edit OK                                                                                                 | ⚠️ Unless tests need updating too           |
+| File Pattern                                  | `gate:mechanical`                                        | `gate:standard`                                                                    | `gate:full`                                                                          |
+| --------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Playwright `*.spec.ts`                        | Direct edit (selector/string only) + note; no E2EPlanner | TestScaffold + TestReviewer (structural); skip E2EPlanner if flow matrix unchanged | E2EPlanner → TestScaffold → TestReviewer (structural); never execute E2E in AFK      |
+| Jest `*.test.ts` / page `*.spec.tsx`          | Direct edit (fixture/type retarget) + focused jest       | TestScaffold → TestReviewer → TestRunner                                           | Same full pipeline (max 3 retries)                                                   |
+| `*.stories.tsx`                               | Direct edit only for rename/import path                  | StorybookCurator                                                                   | StorybookCurator                                                                     |
+| Components `libs/web-ui/` / `libs/web/pages/` | Direct edit only for rename/import/dead delete           | ComponentBuilder → ComponentReviewer                                               | ComponentBuilder → ComponentReviewer (max 3 FAIL loops) + Storybook/tests after PASS |
+| Config / docs / types                         | Direct edit OK                                           | Direct edit OK                                                                     | Direct edit OK                                                                       |
 
----
+Skills:
 
-## Step 4: Mandatory Delegation Rules
-
-### **NO EXCEPTIONS** — These tasks ALWAYS require delegation:
-
-1. **E2E Test Changes** (`.spec.ts` files)
-   - Skill: `.github/skills/playwright-e2e-workflow/SKILL.md`
-   - Agent flow: E2EPlanner → TestScaffold
-   - What this means: Even a one-line bug fix in an E2E test must go through delegation
-
-2. **Jest Test Changes** (`.test.ts` files)
-   - Skill: `.github/skills/unit-test-delegation-workflow/SKILL.md`
-   - Agent flow: TestScaffold → TestReviewer → TestRunner (max 3 retries before escalating to main agent)
-   - What this means: Any test creation, update, or fix uses the full three-stage pipeline
-
-3. **Storybook Stories** (`*.stories.tsx` files)
-   - Skill: `.github/skills/storybook-delegation-workflow/SKILL.md`
-   - Agent flow: StorybookCurator
-   - What this means: New or updated story files go through StorybookCurator
-
-4. **React Components** (libs/web-ui/_, libs/web/pages/_)
-   - Workflow: ComponentBuilder → ComponentReviewer (no exceptions)
-   - What this means: Component creation/edits follow the compound pattern via agents
+- E2E: `.github/skills/playwright-e2e-workflow/SKILL.md`
+- Jest: `.github/skills/unit-test-delegation-workflow/SKILL.md`
+- Storybook: `.github/skills/storybook-delegation-workflow/SKILL.md`
+- Components: `CLAUDE.md` → UI Component Workflows / `.claude/commands/component-builder.md`
 
 ---
 
-## Step 5: Common Failure Pattern (What We're Preventing)
+## Step 4: Mandatory rules (tiered — not absolute)
 
-### ❌ **Anti-Pattern to Avoid:**
+1. **Behavioral / structural work** on tests, stories, or components **must** use the matching specialist path for that gate — do not “quietly” hand-edit to skip Reviewer on `standard`/`full`.
+2. **Mechanical work** may be edited by the main agent; still run focused deterministic checks and state `gate:mechanical` explicitly.
+3. **ComponentReviewer** and **TestReviewer** retries: max **3** cycles, then escalate to the main agent / human.
+4. Specialist reports: `PASS|FAIL|ESCALATE` + ≤5 bullets unless `gate:full` after a rejection needs detail.
+5. E2E chain when required: **E2EPlanner → TestScaffold → TestReviewer (structural only)**. Never execute Playwright autonomously in Sandcastle.
+
+---
+
+## Step 5: Anti-patterns
+
+### ❌ Wrong (behavioral work)
 
 ```
-"I see a bug in the E2E tests. Let me:
-1. Read the similar test file to find the pattern
-2. Understand what needs fixing
-3. Apply the fix directly with replace_string_in_file"
+"I see a behavior bug in an E2E test. I'll copy a sibling and patch it directly."
 ```
 
-### ✅ **Correct Pattern:**
+### ✅ Right (behavioral — `gate:standard` / `gate:full`)
 
 ```
-"I see a bug in the E2E tests. This is an E2E test UPDATE, so I need to:
-1. Read .github/skills/playwright-e2e-workflow/SKILL.md
-2. Use E2EPlanner to outline the fix (flow matrix + issues)
-3. Delegate to TestScaffold with a precise E2E brief
-4. TestScaffold executes the changes
-5. I verify the result"
+1. Classify gate tier
+2. Read .github/skills/playwright-e2e-workflow/SKILL.md
+3. E2EPlanner if flow changed (skip only for selector-only + unchanged matrix)
+4. TestScaffold → TestReviewer (structural)
+```
+
+### ❌ Wrong (mechanical work)
+
+```
+"This is a one-line fixture retarget — run TestScaffold → TestReviewer → TestRunner anyway."
+```
+
+### ✅ Right (mechanical)
+
+```
+1. State gate:mechanical
+2. Edit directly
+3. Run focused jest / tsc
+4. Short summary (≤5 bullets)
 ```
 
 ---
 
 ## Step 6: Tool-Level Gatekeeping
 
-**BEFORE calling these tools on test/component files:**
+**BEFORE** editing test/component/story files:
 
-- `replace_string_in_file` on `*.spec.ts`, `*.test.ts`, `*.stories.tsx`, or component files → DELEGATE FIRST
-- `create_file` for test or story files → DELEGATE FIRST
-- `read_file` (if 3+ consecutive reads needed for exploration) → Use CodeExplorer instead
-
----
-
-## Quick Reference: What to Do Next
-
-| Scenario                         | Action                                                                                                       |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| "Fix a bug in an E2E test"       | → Read `.github/skills/playwright-e2e-workflow/SKILL.md`, use E2EPlanner + TestScaffold                      |
-| "Update a Jest test"             | → Read `.github/skills/unit-test-delegation-workflow/SKILL.md`, use TestScaffold → TestReviewer → TestRunner |
-| "Create a new Storybook story"   | → Read `.github/skills/storybook-delegation-workflow/SKILL.md`, use StorybookCurator                         |
-| "Edit a React component"         | → Build Structured Spec, use ComponentBuilder → ComponentReviewer                                            |
-| "Explore codebase for a pattern" | → Use CodeExplorer (not 3+ manual reads)                                                                     |
-| "Fix a config file"              | → Direct edit OK (but check for tests that might break)                                                      |
-| "Update documentation"           | → Direct edit OK (or use Docs agent for complex docs)                                                        |
+- If `gate:standard` or `gate:full` → delegate first (do not `StrReplace` / create those files in the main agent).
+- If `gate:mechanical` → edit allowed; still run focused checks.
+- 3+ consecutive reads for exploration → CodeExplorer.
 
 ---
 
-## How to Use This Checklist
+## Quick Reference
 
-1. **Before starting work:** Run through Step 1 & 2 mentally
-2. **If any red flag triggers:** Skip to Step 3, find your file type, follow the delegation flow
-3. **If no red flags:** Proceed with direct edit (but still verify with Step 4)
-4. **If you're ever unsure:** Re-read Step 4 — if it's a test/component/story file, delegate
+| Scenario                                      | Gate                                  | Action                       |
+| --------------------------------------------- | ------------------------------------- | ---------------------------- |
+| Fixture/type retarget, rename, dead delete    | mechanical                            | Direct edit + focused checks |
+| One assertion suite / one component props fix | standard                              | Matching specialist chain    |
+| New UI module / vault / API contract          | full                                  | Full pipelines               |
+| Selector-only E2E string, matrix unchanged    | mechanical or standard (skip planner) | See Playwright skill         |
+| Explore for a pattern                         | —                                     | CodeExplorer                 |
+| Config / docs                                 | —                                     | Direct edit OK               |
+
+---
+
+## How to Use
+
+1. Step 0 — pick/state gate (or read `gate:*` label).
+2. Step 1–3 — route by file type + gate.
+3. If unsure — promote the gate.
+4. Keep reports short.
 
 ---
 
 ## Reference Links
 
-- E2E Workflow: `.github/skills/playwright-e2e-workflow/SKILL.md`
-- Jest Workflow: `.github/skills/unit-test-delegation-workflow/SKILL.md`
-- Storybook Workflow: `.github/skills/storybook-delegation-workflow/SKILL.md`
-- Component Workflow: `CLAUDE.md` → "UI Component Workflows"
-- This checklist: `.claude/checklist.md`
+- ADR: `docs/adr/0012-tiered-quality-gates.md`
+- E2E: `.github/skills/playwright-e2e-workflow/SKILL.md`
+- Jest: `.github/skills/unit-test-delegation-workflow/SKILL.md`
+- Storybook: `.github/skills/storybook-delegation-workflow/SKILL.md`
+- Components: `CLAUDE.md` → UI Component Workflows
+- Implement (ad-hoc): `.github/skills/implement/SKILL.md`

--- a/.claude/commands/component-builder.md
+++ b/.claude/commands/component-builder.md
@@ -1,0 +1,14 @@
+# Component Builder Command
+
+Use this when creating or editing React components in `libs/web-ui/` or `libs/web/pages/`.
+
+1. Classify gate tier via `.claude/checklist.md` Step 0 (`docs/adr/0012-tiered-quality-gates.md`).
+2. For `gate:mechanical` (rename / import path / dead delete only): main agent may edit + focused lint; skip Builder/Reviewer.
+3. For `gate:standard` or `gate:full`:
+   - Build a **Structured Spec** (see `CLAUDE.md` → UI Component Workflows).
+   - Delegate to `ComponentBuilder` (`.claude/agents/component-builder.md`).
+   - Always run `ComponentReviewer` after Builder (`.claude/agents/component-reviewer.md`).
+   - On `FAIL`: max **3** Builder↔Reviewer cycles, then escalate.
+4. After `PASS` / `PASS_WITH_WARNINGS` on `gate:full` (and when needed on `standard`): Storybook via `/storybook`, tests via `/unit-test`.
+
+Do not invent conventions — enforce `docs/ui/GUIDELINES.md` and `TECH_STACK.md`.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,11 +1,13 @@
 # Implement Command
 
-Use this workflow when the user wants to implement agreed work from a spec, PRD, slice issue, or ticket set in the current session.
+Use this workflow when the user wants to implement agreed work from a spec, PRD, slice issue, ticket set, **or ad-hoc request** in the current session.
 
 1. Read and follow `.github/skills/implement/SKILL.md` exactly.
-2. Confirm the spec source and read `AGENTS.md` for touched areas.
-3. Use `/tdd` at pre-agreed test seams; otherwise work in small vertical slices.
-4. Route Jest tests, Playwright specs, Storybook, and React components through their mandatory delegation workflows (see `.claude/checklist.md`).
-5. Run `yarn nx lint` / `yarn nx test` on affected projects while iterating; run the full relevant suite at the end.
-6. Review the diff with `/code-review` before finishing.
-7. Commit or open a PR only when the user explicitly asks (`/commit`, `/create-pr`).
+2. **Classify and state the gate tier** (`gate:mechanical | standard | full` — ADR 0012 / `.claude/checklist.md` Step 0). Ticket optional for ad-hoc work.
+3. Confirm the spec source and read `AGENTS.md` for touched areas.
+4. If targeting a GitHub issue: check `## Blocked by` / `## Blocks`; after completion run the unblock protocol in the skill.
+5. Use `/tdd` at pre-agreed test seams when appropriate; otherwise work in small vertical slices.
+6. Route Jest / Playwright / Storybook / components by **gate + file type** (not absolute always-delegate).
+7. Run focused `yarn nx lint` / tests while iterating; full relevant suite at the end.
+8. `/code-review` for `gate:full` (and large `standard`); skip for mechanical unless asked.
+9. Commit or open a PR only when the user explicitly asks (`/commit`, `/create-pr`).

--- a/.claude/commands/to-issues.md
+++ b/.claude/commands/to-issues.md
@@ -5,4 +5,4 @@ Use this workflow when a PRD Issue exists and needs to be broken into Slice Issu
 1. Ask the user for the PRD Issue number if not already provided.
 2. Read and follow `.github/skills/to-issues/SKILL.md` exactly.
 3. Run `yarn ai:create-labels` first if any required labels are missing from the repo.
-4. After all slices are published, remind the user to run `yarn dispatch-agents --prd <issue-number>` to hand off to autonomous agents.
+4. After all slices are published (with bidirectional `## Blocked by` / `## Blocks` and `status:blocked` on dependents), remind the user to run `yarn dispatch-agents --prd <issue-number>` to hand off to autonomous agents.

--- a/.cursor/agents/component-reviewer.md
+++ b/.cursor/agents/component-reviewer.md
@@ -124,6 +124,29 @@ For each file found:
 
 ## Output — Review Report
 
+Keep reports short by default (`PASS|FAIL|PASS_WITH_WARNINGS` + ≤5 bullets). Expand the full table only when the verdict is `FAIL` or the main agent requests detail (`gate:full` after a rejection).
+
+```markdown
+## ComponentReviewer Report
+
+### Verdict
+
+PASS | PASS_WITH_WARNINGS | FAIL
+
+### Summary (≤5 bullets)
+
+- <guideline or quality finding, or "none">
+
+### Required Revisions
+
+- [ ] <specific change ComponentBuilder must make, citing guideline section — omit if PASS>
+```
+
+When `FAIL` (or on request), also include the Guidelines Compliance table, Code Quality Findings, and Direct Importers sections from the long template below.
+
+<details>
+<summary>Full report template (FAIL / requested detail)</summary>
+
 ```markdown
 ## ComponentReviewer Report
 
@@ -187,9 +210,16 @@ PASS | PASS_WITH_WARNINGS | FAIL
 - [ ] <specific change ComponentBuilder must make, citing guideline section>
 ```
 
+</details>
+
+## Retry policy (main agent)
+
+The main agent may re-invoke ComponentBuilder → ComponentReviewer at most **3** times after a `FAIL`. On the 4th failure, escalate with a diagnosis — do not continue the loop.
+
 ## Constraints
 
 - Do NOT edit, create, or delete any file.
 - Do NOT fabricate findings — unknown = noted as such, not guessed.
 - Do NOT review Storybook stories or test files.
 - Every FAIL must cite a specific guideline section or concrete code quality issue.
+- Prefer the short report format unless FAIL or detail was requested.

--- a/.cursor/rules/ask-matt-workflow.mdc
+++ b/.cursor/rules/ask-matt-workflow.mdc
@@ -16,14 +16,17 @@ Read and follow `.github/skills/ask-matt/SKILL.md` exactly.
 
 Routing highlights:
 
-- Planned feature -> `to-prd` then `to-issues`
+- Recommend a **gate tier** first (`gate:mechanical | standard | full` — ADR 0012)
+- Planned feature -> `to-prd` then `to-issues` (assign `gate:*`)
+- Ad-hoc fix now (no ticket) -> classify gate -> `implement`
 - Agreed spec ready to build -> `implement`
 - Design ambiguity -> `grill-with-docs`
 - Runnable validation required -> `prototype` (+ `handoff` if crossing sessions)
-- Jest/Playwright work -> matching test delegation workflow
+- Jest/Playwright work -> matching test workflow (mechanical may skip specialist hops)
 - Release preparation -> `release-and-deploy-workflow`
-- Review branch or WIP changes -> `code-review`
+- Review branch or WIP changes -> `code-review` (optional for mechanical)
 
 ## Skill Files
 
 - `.github/skills/ask-matt/SKILL.md`
+- `docs/adr/0012-tiered-quality-gates.md`

--- a/.cursor/rules/implement-workflow.mdc
+++ b/.cursor/rules/implement-workflow.mdc
@@ -16,13 +16,16 @@ Read and follow `.github/skills/implement/SKILL.md` exactly.
 
 Key points:
 
-- Confirm the spec source and read relevant `AGENTS.md` files first.
+- Classify **gate tier** first (`gate:mechanical | standard | full` — ADR 0012). Ad-hoc work needs no ticket.
+- If targeting a GitHub issue, honor `## Blocked by` / `## Blocks` and unblock dependents on completion (see implement skill).
+- Confirm the spec source and read relevant `AGENTS.md` files.
 - Use `/tdd` at pre-agreed seams; otherwise ship in small vertical slices.
-- Route tests, Storybook, E2E, and React components through mandatory delegation workflows.
+- Route tests, Storybook, E2E, and React components by gate + file type (`.claude/checklist.md`).
 - Run lint and focused tests while iterating; run the full relevant suite at the end.
-- Review the diff with `/code-review` before finishing.
+- `/code-review` for `gate:full` (and large `standard`); optional for mechanical.
 - Commit and open PRs only when the user explicitly asks.
 
 ## Skill Files
 
 - `.github/skills/implement/SKILL.md`
+- `docs/adr/0012-tiered-quality-gates.md`

--- a/.cursor/rules/unit-test-delegation-workflow.mdc
+++ b/.cursor/rules/unit-test-delegation-workflow.mdc
@@ -15,12 +15,14 @@ Use the Playwright E2E workflow for specs in `apps/myorganizer-e2e`.
 
 ## Core Rules
 
-- Do not write Jest tests inline in the main context. Delegate to a focused sub-context or `TestScaffold` invocation.
+- Classify `gate:*` first (ADR 0012). `gate:mechanical` fixture/type retargets may be edited by the main agent + focused jest — skip the specialist pipeline.
+- On `gate:standard` / `gate:full`, do not write Jest tests inline in the main context. Delegate to `TestScaffold`.
 - Always send a complete delegation brief; never just "add comprehensive tests".
 - Build the brief from the actual implementation, not only type signatures or desired behavior.
 - Include unsupported behavior to avoid testing, such as retry, concurrency, timeout, or thrown-error expectations that the code does not provide.
 - Happy-path-only coverage is not acceptable when reachable error paths, side effects, boundary values, or security-sensitive misuse paths exist.
 - The main agent acts as quality reviewer and must challenge weak coverage, incorrect mock patterns, duplicate generated content, and vacuous tests.
+- Run the suite once after TestReviewer approval (TestRunner) — avoid redundant full-suite runs in every hop.
 
 ## Workflow
 

--- a/.gemini/agents/component-reviewer.md
+++ b/.gemini/agents/component-reviewer.md
@@ -132,6 +132,29 @@ For each file found:
 
 ## Output — Review Report
 
+Keep reports short by default (`PASS|FAIL|PASS_WITH_WARNINGS` + ≤5 bullets). Expand the full table only when the verdict is `FAIL` or the main agent requests detail (`gate:full` after a rejection).
+
+```markdown
+## ComponentReviewer Report
+
+### Verdict
+
+PASS | PASS_WITH_WARNINGS | FAIL
+
+### Summary (≤5 bullets)
+
+- <guideline or quality finding, or "none">
+
+### Required Revisions
+
+- [ ] <specific change ComponentBuilder must make, citing guideline section — omit if PASS>
+```
+
+When `FAIL` (or on request), also include the Guidelines Compliance table, Code Quality Findings, and Direct Importers sections from the long template below.
+
+<details>
+<summary>Full report template (FAIL / requested detail)</summary>
+
 ```markdown
 ## ComponentReviewer Report
 
@@ -195,9 +218,16 @@ PASS | PASS_WITH_WARNINGS | FAIL
 - [ ] <specific change ComponentBuilder must make, citing guideline section>
 ```
 
+</details>
+
+## Retry policy (main agent)
+
+The main agent may re-invoke ComponentBuilder → ComponentReviewer at most **3** times after a `FAIL`. On the 4th failure, escalate with a diagnosis — do not continue the loop.
+
 ## Constraints
 
 - Do NOT edit, create, or delete any file.
 - Do NOT fabricate findings — unknown = noted as such, not guessed.
 - Do NOT review Storybook stories or test files.
 - Every FAIL must cite a specific guideline section or concrete code quality issue.
+- Prefer the short report format unless FAIL or detail was requested.

--- a/.gemini/commands/implement.md
+++ b/.gemini/commands/implement.md
@@ -1,11 +1,13 @@
 # Implement Command
 
-Use this workflow when the user wants to implement agreed work from a spec, PRD, slice issue, or ticket set in the current session.
+Use this workflow when the user wants to implement agreed work from a spec, PRD, slice issue, ticket set, **or ad-hoc request** in the current session.
 
 1. Read and follow `.github/skills/implement/SKILL.md` exactly.
-2. Confirm the spec source and read `AGENTS.md` for touched areas.
-3. Use `/tdd` at pre-agreed test seams; otherwise work in small vertical slices.
-4. Route Jest tests, Playwright specs, Storybook, and React components through their mandatory delegation workflows.
-5. Run `yarn nx lint` / `yarn nx test` on affected projects while iterating; run the full relevant suite at the end.
-6. Review the diff with `/code-review` before finishing.
-7. Commit or open a PR only when the user explicitly asks.
+2. **Classify and state the gate tier** (`gate:mechanical | standard | full` — ADR 0012 / `.claude/checklist.md` Step 0). Ticket optional for ad-hoc work.
+3. Confirm the spec source and read `AGENTS.md` for touched areas.
+4. If targeting a GitHub issue: check `## Blocked by` / `## Blocks`; after completion run the unblock protocol in the skill.
+5. Use `/tdd` at pre-agreed test seams when appropriate; otherwise work in small vertical slices.
+6. Route Jest / Playwright / Storybook / components by **gate + file type**.
+7. Run focused `yarn nx lint` / tests while iterating; full relevant suite at the end.
+8. `/code-review` for `gate:full` (and large `standard`); skip for mechanical unless asked.
+9. Commit or open a PR only when the user explicitly asks.

--- a/.github/agents/component-reviewer.agent.md
+++ b/.github/agents/component-reviewer.agent.md
@@ -127,6 +127,29 @@ For each file found:
 
 ## Output — Review Report
 
+Keep reports short by default (`PASS|FAIL|PASS_WITH_WARNINGS` + ≤5 bullets). Expand the full table only when the verdict is `FAIL` or the main agent requests detail (`gate:full` after a rejection).
+
+```markdown
+## ComponentReviewer Report
+
+### Verdict
+
+PASS | PASS_WITH_WARNINGS | FAIL
+
+### Summary (≤5 bullets)
+
+- <guideline or quality finding, or "none">
+
+### Required Revisions
+
+- [ ] <specific change ComponentBuilder must make, citing guideline section — omit if PASS>
+```
+
+When `FAIL` (or on request), also include the Guidelines Compliance table, Code Quality Findings, and Direct Importers sections from the long template below.
+
+<details>
+<summary>Full report template (FAIL / requested detail)</summary>
+
 ```markdown
 ## ComponentReviewer Report
 
@@ -190,9 +213,16 @@ PASS | PASS_WITH_WARNINGS | FAIL
 - [ ] <specific change ComponentBuilder must make, citing guideline section>
 ```
 
+</details>
+
+## Retry policy (main agent)
+
+The main agent may re-invoke ComponentBuilder → ComponentReviewer at most **3** times after a `FAIL`. On the 4th failure, escalate with a diagnosis — do not continue the loop.
+
 ## Constraints
 
 - Do NOT edit, create, or delete any file.
 - Do NOT fabricate findings — unknown = noted as such, not guessed.
 - Do NOT review Storybook stories or test files.
 - Every FAIL must cite a specific guideline section or concrete code quality issue.
+- Prefer the short report format unless FAIL or detail was requested.

--- a/.github/skills/ask-matt/SKILL.md
+++ b/.github/skills/ask-matt/SKILL.md
@@ -10,6 +10,8 @@ Adapted from `mattpocock/skills`, adjusted to MyOrganizer's actual skill set and
 
 Use this as a **router** when you are unsure which workflow to run.
 
+Always recommend a **gate tier** first (`gate:mechanical | standard | full` — ADR 0012 / `.claude/checklist.md` Step 0).
+
 ## Main MyOrganizer flow: idea -> implementation
 
 1. **`/grill-with-docs`**  
@@ -20,22 +22,23 @@ Use this as a **router** when you are unsure which workflow to run.
 
 3. **Planned feature path (multi-slice work)**
    - `/to-prd` -> publish PRD issue
-   - `/to-issues` -> split into slice issues
+   - `/to-issues` -> split into slice issues (assign `gate:*` + `complexity:*`)
    - then run `yarn dispatch-agents --prd <issue-number>` for AFK slices
 
-4. **Ad-hoc or single-shot implementation**
-   - If request is issue creation: `/github-issue-creation-workflow`
-   - If request is direct implementation in current session: **`/implement`**, then pull in domain workflow skills as needed (for example `/frontend-page-library-workflow`, `/backend-api-contract-change`, `/vault-feature-workflow`, `/youtube-integration-workflow`)
+4. **Ad-hoc or single-shot implementation (ticket optional)**
+   - Classify gate tier (no ticket required for mechanical/standard fixes).
+   - If the user wants a tracked bug/enhancement issue: `/github-issue-creation-workflow`
+   - If they want it built now: **`/implement`**, then domain skills as needed
 
 ## Quality and delivery routing
 
-- Jest unit/integration tests -> `/unit-test-delegation-workflow`
-- Playwright E2E work -> `/playwright-e2e-workflow`
-- Storybook story changes -> `/storybook-delegation-workflow`
-- Prisma/schema/migrations -> `/prisma-migration-workflow`
-- Release/deploy preparation -> `/release-and-deploy-workflow`
-- Architecture deepening pass -> `/improve-codebase-architecture`
-- Review branch or WIP changes -> `/code-review`
+- Jest unit/integration tests → `/unit-test-delegation-workflow` (or mechanical direct edit per checklist)
+- Playwright E2E work → `/playwright-e2e-workflow` (skip E2EPlanner for selector-only + unchanged matrix)
+- Storybook story changes → `/storybook-delegation-workflow`
+- Prisma/schema/migrations → `/prisma-migration-workflow`
+- Release/deploy preparation → `/release-and-deploy-workflow`
+- Architecture deepening pass → `/improve-codebase-architecture`
+- Review branch or WIP changes → `/code-review` (optional for `gate:mechanical`)
 
 ## Session transitions
 
@@ -46,7 +49,8 @@ Use this as a **router** when you are unsure which workflow to run.
 
 If the work is:
 
-- **New planned feature** -> `/to-prd`
-- **Incoming raw request/bug report** -> `/github-issue-creation-workflow`
-- **Test-heavy or test-file changes** -> delegate through the matching test workflow skill
-- **Architecture/terminology uncertainty** -> `/grill-with-docs` (and `/domain-modeling` when actively updating glossary/ADRs)
+- **New planned feature** → `/to-prd`
+- **Incoming raw request to track** → `/github-issue-creation-workflow`
+- **Ad-hoc fix now, no ticket** → classify gate → `/implement`
+- **Test-heavy behavioral change** → matching test workflow at `standard`/`full`
+- **Architecture/terminology uncertainty** → `/grill-with-docs` (and `/domain-modeling` when updating glossary/ADRs)

--- a/.github/skills/implement/SKILL.md
+++ b/.github/skills/implement/SKILL.md
@@ -8,19 +8,41 @@ disable-model-invocation: true
 
 Adapted from [mattpocock/skills — implement](https://github.com/mattpocock/skills/tree/main/skills/engineering/implement) for MyOrganizer workflows.
 
-Implement the work described by the user in the spec, PRD, slice issue, or ticket set.
+Implement the work described by the user in the spec, PRD, slice issue, ticket set, **or ad-hoc request** (no ticket required).
 
 ## Before you start
 
-1. Confirm the spec source (issue body, PRD, slice ticket, or user-provided path).
-2. Read nearby `AGENTS.md` files for touched apps/libraries.
-3. Check `.claude/checklist.md` before editing — route file types through mandatory delegation (Jest tests, E2E specs, Storybook, React components).
+1. **Classify gate tier** (ADR 0012) and state it in your first reply:
+   - Slice/issue with `gate:*` → use that label.
+   - No ticket → apply `.claude/checklist.md` Step 0 mechanical criteria; when unsure → promote.
+   - User may override the gate.
+2. Confirm the spec source (issue body, PRD, slice ticket, user message, or path).
+3. If the work targets a **GitHub issue**, load it with `gh issue view <N> --json number,title,state,labels,body` and note:
+   - `## Blocked by` / `## Blocks`
+   - whether it has `status:blocked` (do not start until blockers are done, unless the user explicitly overrides)
+4. Read nearby `AGENTS.md` files for touched apps/libraries.
+5. Check `.claude/checklist.md` before editing — route by **gate + file type**.
+
+## Ad-hoc / no-ticket playbook
+
+Use this when the user asks to fix or change something without a GitHub issue:
+
+1. State `gate:mechanical | standard | full`.
+2. Do **not** open IssueCreator unless the user wants a tracked ticket.
+3. Execute the matching path from the checklist.
+4. Run focused lint/tests; for `gate:full` (and large `standard` diffs), finish with `/code-review`.
+5. Commit/PR only if the user asks.
+6. Skip the issue unblock section below (no ticket).
+
+Mechanical examples: fixture/type retarget, rename, dead-code delete, selector-only E2E string.  
+Standard examples: one component props fix, one assertion suite update.  
+Full examples: new page module, vault surface, API contract change.
 
 ## Implementation
 
-Use **`/tdd`** (`.github/skills/tdd/SKILL.md`) where possible, at pre-agreed test seams.
+Use **`/tdd`** (`.github/skills/tdd/SKILL.md`) where possible, at pre-agreed test seams — still respect gate tier for who authors the tests.
 
-When TDD is not appropriate, still work in small vertical slices and keep changes scoped to the spec.
+When TDD is not appropriate, work in small vertical slices scoped to the spec.
 
 Pick domain workflow skills when they apply:
 
@@ -35,19 +57,64 @@ Respect MyOrganizer structure: thin Next.js route wrappers in `apps/myorganizer`
 
 ## Validation loop
 
-Run checks regularly while implementing:
-
-- Typecheck/lint affected projects: `yarn nx lint <project>` (and project tests as you go).
-- Run single test files or focused Nx test targets while iterating.
-- Run the full relevant test suite once at the end: `yarn nx test <project>` (or the broader set the change touches).
-
-After backend contract changes, run `yarn openapi:sync` and confirm with `yarn openapi:check`.
+- Typecheck/lint affected projects: `yarn nx lint <project>` (and focused project tests as you go).
+- Prefer single-file / focused Nx test targets while iterating; full suite once at the end.
+- Do not re-run the same suite in Scaffold notes, Reviewer, and Runner — one authoritative execution after approval.
+- After backend contract changes, run `yarn openapi:sync` and confirm with `yarn openapi:check`.
 
 ## Review before finishing
 
-Use **`/code-review`** (`.github/skills/code-review/SKILL.md`) to review the diff against the originating spec or tickets and repo standards.
+- `gate:mechanical`: short self-check (diff + focused tests); skip `/code-review` unless user asks.
+- `gate:standard`: `/code-review` when the diff touches >2 behavioral files or the user asks.
+- `gate:full`: use **`/code-review`** against the originating spec/tickets (or `main` merge-base if none).
 
-If the user did not supply a fixed point, compare against `main` (or the branch merge-base they specify).
+## Complete a GitHub issue + unblock dependents (required when an issue was the target)
+
+When `/implement` was invoked against a specific issue (slice or ad-hoc ticket), finish with this protocol. Same contract as `to-issues` / Sandcastle (ADR 0002).
+
+### 1. Mark the current issue complete
+
+```sh
+gh issue edit <N> --repo mnaimfaizy/myorganizer \
+  --remove-label status:in-progress \
+  --add-label status:done
+
+gh issue comment <N> --repo mnaimfaizy/myorganizer \
+  --body "Implementation complete in this session. Unblocking dependents next."
+```
+
+Close the issue only when appropriate (AFK-style slices, or when the user asks):
+
+```sh
+gh issue close <N> --repo mnaimfaizy/myorganizer --reason completed
+```
+
+### 2. Discover dependents
+
+Prefer the completed issue’s `## Blocks` section (`#M` refs).  
+Fallback: search open issues that cite `#<N>` under `## Blocked by` (same PRD when `PRD: #…` is present).
+
+### 3. Unblock each ready dependent
+
+For every dependent that still has `status:blocked`:
+
+1. Parse its `## Blocked by` list.
+2. For each blocker, check `gh issue view <blocker> --json state,labels` — treat as satisfied if `state=CLOSED` **or** labels include `status:done`.
+3. If **all** blockers are satisfied:
+
+```sh
+gh issue edit <dependent> --repo mnaimfaizy/myorganizer --remove-label status:blocked
+gh issue comment <dependent> --repo mnaimfaizy/myorganizer \
+  --body "Unblocked: #<completed> is done. Remaining blockers: none — ready for agent/human."
+```
+
+4. If any blocker remains open/incomplete, leave `status:blocked` and optionally comment which blockers remain.
+
+### 4. Report
+
+In the final reply, list: completed issue, dependents unblocked, dependents still blocked (and why).
+
+Do **not** flip `type:hitl` → `type:afk` automatically — that remains a human decision.
 
 ## Commit and PR
 

--- a/.github/skills/playwright-e2e-workflow/SKILL.md
+++ b/.github/skills/playwright-e2e-workflow/SKILL.md
@@ -5,11 +5,23 @@ description: 'Use when adding or changing Playwright end-to-end tests, validatin
 
 # Playwright E2E Workflow
 
+Policy: [`docs/adr/0012-tiered-quality-gates.md`](../../docs/adr/0012-tiered-quality-gates.md) — classify `gate:*` before choosing hops.
+
 ## Use This Skill When
 
 - Adding or changing Playwright tests in `apps/myorganizer-e2e`
 - Validating critical route flows after frontend or auth changes
 - Debugging browser behavior that is hard to cover with unit tests alone
+
+## Gate tier routing
+
+| Gate              | Path                                                                                                                                                                 |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gate:mechanical` | Selector/string-only fix; flow matrix unchanged → main agent may edit directly; no E2EPlanner; still do not execute E2E in AFK                                       |
+| `gate:standard`   | Behavior/assertion change with unchanged high-level flow → TestScaffold + TestReviewer (structural); **skip E2EPlanner** when the existing flow matrix still applies |
+| `gate:full`       | New flow or matrix change → **E2EPlanner → TestScaffold → TestReviewer (structural)**                                                                                |
+
+Canonical chain when planning is required: **E2EPlanner → TestScaffold → TestReviewer (structural only)**. Never execute Playwright autonomously in Sandcastle.
 
 ## Autonomous Agent Execution Policy
 
@@ -21,7 +33,7 @@ description: 'Use when adding or changing Playwright end-to-end tests, validatin
 - Post a PR comment: _"E2E tests written but not executed — requires human verification before merge. Run: `yarn nx e2e myorganizer-e2e`"_
 - Apply label `needs-e2e-review` to the PR.
 
-**In human-in-the-loop sessions (interactive, human present), follow the full procedure below.**
+**In human-in-the-loop sessions (interactive, human present), follow the full procedure below (and execute browsers only when the human is present).**
 
 ## Critical Prerequisites (Before Planning)
 

--- a/.github/skills/storybook-delegation-workflow/SKILL.md
+++ b/.github/skills/storybook-delegation-workflow/SKILL.md
@@ -6,16 +6,25 @@ argument-hint: 'Requirement summary + component path(s) + story file path(s) + e
 
 # Storybook Delegation Workflow
 
+Policy: [`docs/adr/0012-tiered-quality-gates.md`](../../docs/adr/0012-tiered-quality-gates.md)
+
 ## Use This Skill When
 
 - A task asks to create Storybook stories for a new UI component.
 - A task asks to update existing stories after component behavior changes.
 - A Storybook file needs UX-focused improvement (states, controls, docs clarity, edge scenarios).
 
+## Gate tier routing
+
+| Gate                          | Path                                                     |
+| ----------------------------- | -------------------------------------------------------- |
+| `gate:mechanical`             | Rename / import-path only → main agent may edit directly |
+| `gate:standard` / `gate:full` | New or behavioral story updates → StorybookCurator       |
+
 ## Core Rules
 
-- Always delegate Storybook implementation to the `StorybookCurator` sub-agent.
-- Do not create or edit `*.stories.tsx` directly in the main agent context when this workflow applies.
+- On `standard`/`full`, always delegate Storybook implementation to the `StorybookCurator` sub-agent.
+- Do not create or edit `*.stories.tsx` directly in the main agent context when this workflow applies (except mechanical).
 - The sub-agent must analyze requirement quality first (completeness, ambiguity, conflicts) before touching files.
 - If requirements are incomplete, the sub-agent must stop and return targeted clarification questions.
 - The sub-agent may disagree with the requested implementation when it would reduce quality (accessibility gaps, misleading stories, missing critical states, anti-patterns).

--- a/.github/skills/to-issues/SKILL.md
+++ b/.github/skills/to-issues/SKILL.md
@@ -24,11 +24,45 @@ Break a PRD Issue into independently-grabbable Slice Issues using tracer-bullet 
 - Quiz the user before publishing any issues. Publish only after explicit approval.
 - Flag `type:hitl` slices prominently in the quiz: "⚠️ This slice is HITL — `dispatch-agents` will skip it until you unblock it manually."
 - Publish issues in dependency order (blockers first) so you can reference real issue numbers in `## Blocked by` fields.
+- Maintain **bidirectional** dependency links: every slice has `## Blocked by` and `## Blocks` (see Blocking / unblocking below).
+- Apply `status:blocked` when creating any slice whose `## Blocked by` is non-empty. `dispatch-agents` skips `status:blocked` until dependents are unblocked.
 - After publishing all slices, update the PRD Issue `## Slices` section with links to each created issue.
 - Do NOT close or modify the PRD Issue body beyond the `## Slices` section.
 - Do not include specific file paths or code snippets in issue bodies — they go stale. Exception: decision-rich prototype snippets (schema shape, state machine, type) — trim to the essential parts only.
-- For each slice, detect which mandatory delegation pipelines apply (ComponentBuilder, TestScaffold, StorybookCurator). If a slice requires two or more non-trivial pipelines, flag it as a **split candidate** in the quiz — splitting keeps each agent iteration focused on one pipeline and prevents guardrail bypasses.
+- For each slice, assign a `gate:*` tier (ADR 0012) and detect which delegation pipelines apply under that gate (ComponentBuilder, TestScaffold, StorybookCurator). If a `gate:full` slice requires two or more non-trivial pipelines, flag it as a **split candidate** in the quiz — splitting keeps each agent iteration focused on one pipeline and prevents guardrail bypasses.
 - When an acceptance criterion involves creating test files, suffix it with `(via TestScaffold — do not write directly)`. This removes the agent's rationalization surface for writing tests inline.
+
+## Blocking / unblocking (required)
+
+Dependency edges are part of the label + body contract (ADR 0002):
+
+| Field / label    | Role                                                                           |
+| ---------------- | ------------------------------------------------------------------------------ |
+| `## Blocked by`  | Upstream issues that must complete before this slice may start                 |
+| `## Blocks`      | Downstream issues this slice unlocks when it completes                         |
+| `status:blocked` | Machine-readable “not ready”; orchestrator and `/implement` skip until removed |
+
+### When publishing slices
+
+1. Publish **blockers first**.
+2. For a slice with upstream deps:
+   - Set `## Blocked by` to real `#N` issue numbers.
+   - Add label `status:blocked` on create (`gh issue create ... --label status:blocked` or `gh issue edit --add-label status:blocked`).
+3. After dependents exist, **edit each blocker** so its `## Blocks` lists those dependents (and set `## Blocks` to `None` when nothing depends on it).
+4. Never leave a one-way edge: if A blocks B, A’s `## Blocks` must include B and B’s `## Blocked by` must include A.
+
+### When a slice / issue completes (AFK or interactive)
+
+Sandcastle does this automatically after a successful integrate. `/implement` must do the same when finishing a GitHub issue (see that skill).
+
+1. Mark the completed issue `status:done` (and close with reason `completed` for AFK slices).
+2. Read its `## Blocks` list (fallback: search open issues whose `## Blocked by` cites this number).
+3. For each dependent still labelled `status:blocked`:
+   - Re-read that dependent’s `## Blocked by`.
+   - If **every** blocker is `CLOSED` or has `status:done`, remove `status:blocked` and comment that it was unblocked.
+   - If any blocker remains open/incomplete, leave `status:blocked` on.
+
+HITL note: `type:hitl` is separate from `status:blocked`. HITL needs a human to flip to `type:afk` (or otherwise unblock). Dependency blocking uses `status:blocked` + `## Blocked by` only.
 
 ## Workflow
 
@@ -52,30 +86,34 @@ Break a PRD Issue into independently-grabbable Slice Issues using tracer-bullet 
    - Break the PRD into tracer-bullet slices. Each slice cuts through ALL integration layers end-to-end.
    - For each slice, assign:
      - **Type**: `type:afk` (agent can implement alone) or `type:hitl` (needs human decision)
-     - **Complexity**: `complexity:low` / `complexity:medium` / `complexity:high`
+     - **Complexity**: `complexity:low` / `complexity:medium` / `complexity:high` (model size)
+     - **Gate**: `gate:mechanical` / `gate:standard` / `gate:full` (pipeline depth — ADR 0012)
      - **Blocked by**: which other slices (if any) must complete first
-     - **Delegation pipelines** — detect which mandatory pipelines apply to this slice:
-       - New or edited component in `libs/web-ui/` or `libs/web/pages/` → `ComponentBuilder → ComponentReviewer`
-       - New test file (`*.spec.tsx` / `*.test.ts`) → `TestScaffold → TestReviewer → TestRunner`
-       - New or updated Storybook story (`*.stories.tsx`) → `StorybookCurator`
+     - **Delegation pipelines** — detect which pipelines apply **under the chosen gate**:
+       - `gate:mechanical` → prefer `direct edit` (fixture/type retarget, rename, delete, selector-only)
+       - New or edited component behavior in `libs/web-ui/` or `libs/web/pages/` → `ComponentBuilder → ComponentReviewer` (`standard`/`full`)
+       - New/behavioral test file → `TestScaffold → TestReviewer → TestRunner` (`standard`/`full`)
+       - New or updated Storybook story → `StorybookCurator` (`standard`/`full`)
        - File moves, import path updates, config, docs → `direct edit`
-         If two or more entries are non-`direct edit`, mark the slice **split candidate ⚠️**.
+         If two or more entries are non-`direct edit` on `gate:full`, mark the slice **split candidate ⚠️**.
 
 5. **Quiz the user**
 
    Present the proposed breakdown as a numbered table:
 
-   | #   | Title | Type    | Complexity | Blocked by | Pipelines                                |
-   | --- | ----- | ------- | ---------- | ---------- | ---------------------------------------- |
-   | 1   | ...   | AFK     | medium     | none       | ComponentBuilder, TestScaffold ⚠️ split? |
-   | 2   | ...   | HITL ⚠️ | high       | #1         | direct edit                              |
+   | #   | Title | Type    | Complexity | Gate       | Blocked by | Pipelines                                |
+   | --- | ----- | ------- | ---------- | ---------- | ---------- | ---------------------------------------- |
+   | 1   | ...   | AFK     | medium     | standard   | —          | ComponentBuilder                         |
+   | 2   | ...   | AFK     | low        | mechanical | —          | direct edit                              |
+   | 3   | ...   | HITL ⚠️ | high       | full       | #1         | ComponentBuilder, TestScaffold ⚠️ split? |
 
    Ask:
    - Does the granularity feel right? (too coarse / too fine)
    - Are dependency relationships correct?
    - Should any slices be merged or split?
    - Are HITL classifications correct?
-   - Are there slices marked **split candidate ⚠️** (two or more delegation pipelines)? Splitting them prevents agents from bypassing TestScaffold or ComponentBuilder under task pressure — one pipeline per slice is the target.
+   - Are `gate:*` assignments correct? (mechanical vs standard vs full)
+   - Are there slices marked **split candidate ⚠️** (two or more delegation pipelines on `gate:full`)? Splitting them prevents agents from bypassing specialists under task pressure — one pipeline per slice is the target.
 
    Iterate until the user approves the full breakdown.
 
@@ -90,8 +128,15 @@ Break a PRD Issue into independently-grabbable Slice Issues using tracer-bullet 
      --label "ready-for-agent" \
      --label "type:afk" \
      --label "complexity:medium" \
+     --label "gate:standard" \
      --body "<issue body>"
    ```
+
+   Defaults: missing `gate:*` → orchestrator treats as `gate:standard`. Use `gate:mechanical` for cleanup/retarget/verify-only slices; `gate:full` for new modules / vault / API contracts.
+
+   If `## Blocked by` is not `None`, also pass `--label "status:blocked"`.
+
+   After dependents are created, edit each blocker issue body so `## Blocks` lists them.
 
    Issue body format:
 
@@ -110,22 +155,24 @@ Break a PRD Issue into independently-grabbable Slice Issues using tracer-bullet 
 
    ## Agent Workflow
 
-   (Omit this section entirely when all work is direct file edits — e.g. import updates, config, docs.)
+   (Omit this section entirely when gate is mechanical / all work is direct file edits.)
 
-   Required delegation pipelines for this slice — do NOT bypass these:
+   Required delegation pipelines for this slice under its gate:* — do NOT bypass on standard/full:
    - [ ] `ComponentBuilder → ComponentReviewer` for: <ComponentName>
    - [ ] `TestScaffold → TestReviewer → TestRunner` for: <SpecFileName.spec.tsx>
    - [ ] `StorybookCurator` for: <StoryFileName.stories.tsx>
-
-   ⚠️ Do NOT write these file types directly, even to verify your own work:
-   - `*.spec.tsx` / `*.test.ts` → always use TestScaffold
-   - Components in `libs/web-ui/` or `libs/web/pages/` → always use ComponentBuilder
 
    ## Blocked by
 
    - #<blocking-issue-number>
 
-   (or "None — can start immediately")
+   (or `- None — can start immediately`)
+
+   ## Blocks
+
+   - #<dependent-issue-number>
+
+   (or `- None — nothing waits on this slice`)
    ```
 
 7. **Update the PRD Issue**
@@ -143,10 +190,14 @@ Break a PRD Issue into independently-grabbable Slice Issues using tracer-bullet 
    ```
    ## Slices
 
-   | # | Title | Type | Complexity | Status |
-   |---|---|---|---|---|
-   | #N | [Slice title](issue-url) | AFK | medium | open |
+   | # | Title | Type | Complexity | Gate | Status |
+   |---|---|---|---|---|---|
+   | #N | [Slice title](issue-url) | AFK | medium | standard | open / blocked |
    ```
+
+7b. **Wire `## Blocks` on blockers (required pass)**
+
+After all slice numbers exist, ensure every blocker’s `## Blocks` section lists its dependents. Apply `status:blocked` to any dependent that still has unfinished blockers and is missing the label.
 
 8. **Return a summary**
 
@@ -159,9 +210,12 @@ Break a PRD Issue into independently-grabbable Slice Issues using tracer-bullet 
 
 ## Validation
 
-- Confirm all required labels (`ready-for-agent`, `type:afk`/`type:hitl`, `complexity:*`) exist in the repo. If missing, instruct the user to run `yarn ai:create-labels`.
+- Confirm all required labels (`ready-for-agent`, `type:afk`/`type:hitl`, `complexity:*`, `gate:*`, `status:blocked`) exist in the repo. If missing, instruct the user to run `yarn ai:create-labels`.
 - Confirm every slice issue body starts with `PRD: #<N>`.
 - Confirm every slice title starts with `[Slice] `.
+- Confirm every slice has both `## Blocked by` and `## Blocks` sections.
+- Confirm slices with non-empty `## Blocked by` carry `status:blocked`.
+- Confirm blocker ↔ dependent edges are bidirectional.
 - Confirm the PRD Issue `## Slices` section was updated after all slices are published.
 
 ## References
@@ -170,5 +224,6 @@ Break a PRD Issue into independently-grabbable Slice Issues using tracer-bullet 
 - `.github/agents/explore.agent.md` — codebase exploration
 - `CONTEXT.md` — domain language glossary
 - `docs/adr/0002-agent-orchestration-label-vocabulary.md` — label ADR
+- `docs/adr/0012-tiered-quality-gates.md` — gate tiers
 - `.github/skills/to-prd/SKILL.md` — prerequisite skill
-- `.sandcastle/main.ts` — orchestrator that picks up AFK slices
+- `.sandcastle/main.mts` — orchestrator that picks up AFK slices

--- a/.github/skills/to-issues/config.md
+++ b/.github/skills/to-issues/config.md
@@ -16,9 +16,13 @@ GitHub Issues
 | `complexity:low`     | Route to Haiku — simple, well-scoped task               |
 | `complexity:medium`  | Route to Sonnet — moderate complexity                   |
 | `complexity:high`    | Route to Opus — complex, deep reasoning required        |
+| `gate:mechanical`    | Mechanical path — no specialist chains (ADR 0012)       |
+| `gate:standard`      | Single-hop specialist path (ADR 0012)                   |
+| `gate:full`          | Full mandatory pipelines (ADR 0012)                     |
 | `type:afk`           | Agent can implement and merge without human interaction |
 | `type:hitl`          | Human decision required before agent can proceed        |
 | `status:in-progress` | Agent has picked up the issue                           |
+| `status:blocked`     | Waiting on `## Blocked by` deps — skipped until cleared |
 | `status:done`        | Agent finished; integrated into local feature branch    |
 | `prd`                | Parent PRD Issue for a planned feature                  |
 
@@ -42,9 +46,10 @@ GitHub Issues
 ### Slice Issue
 
 - **Title format**: `[Slice] <Feature Name>: <short description>`
-- **Labels**: `ready-for-agent` + `type:afk` or `type:hitl` + one `complexity:*` label
-- **Body**: Must include `PRD: #<parent-issue-number>` on the first line. Then acceptance criteria, affected libs, test seams.
-- **Created by**: `to-issues` skill via IssueCreator agent.
+- **Labels**: `ready-for-agent` + `type:afk` or `type:hitl` + one `complexity:*` + one `gate:*` (default `gate:standard` if omitted) + `status:blocked` when `## Blocked by` is non-empty
+- **Body**: Must include `PRD: #<parent-issue-number>` on the first line, plus `## Blocked by` and `## Blocks` sections. Then acceptance criteria, affected libs, test seams.
+- **Created by**: `to-issues` skill via `gh issue create` directly (not via IssueCreator agent).
+- **Unblock**: when a slice completes, remove `status:blocked` from dependents whose blockers are all `status:done` / closed (Sandcastle + `/implement`).
 
 ## Integration Strategy (local-only)
 
@@ -63,11 +68,15 @@ yarn dispatch-agents --prd <prd-issue-number>
 - Only picks up issues labelled `ready-for-agent` + `type:afk`.
 - Skips `type:hitl` issues — these require human unblocking first.
 - Reads `complexity:*` label to select model for each slice.
+- Reads `gate:*` label to select pipeline depth (default `gate:standard`); see ADR 0012.
+- Skips issues labelled `status:blocked` until dependents are unblocked after blockers complete.
+- On successful integrate: labels `status:done`, closes the slice, and removes `status:blocked` from dependents whose `## Blocked by` deps are all done.
 - Posts a comment on each slice issue when the agent completes.
 - Sends a desktop notification when the full batch is done.
 
 ## References
 
 - ADR: `docs/adr/0002-agent-orchestration-label-vocabulary.md`
+- Gate tiers: `docs/adr/0012-tiered-quality-gates.md`
 - Domain glossary: `CONTEXT.md`
-- Orchestrator: `.sandcastle/main.ts`
+- Orchestrator: `.sandcastle/main.mts`

--- a/.github/skills/to-prd/config.md
+++ b/.github/skills/to-prd/config.md
@@ -44,7 +44,8 @@ GitHub Issues
 - **Title format**: `[Slice] <Feature Name>: <short description>`
 - **Labels**: `ready-for-agent` + `type:afk` or `type:hitl` + one `complexity:*` label
 - **Body**: Must include `PRD: #<parent-issue-number>` on the first line. Then acceptance criteria, affected libs, test seams.
-- **Created by**: `to-issues` skill via IssueCreator agent.
+- **Created by**: `to-issues` skill via `gh issue create` directly (not via IssueCreator agent).
+- **Labels**: also include one `gate:*` (ADR 0012); default `gate:standard` when missing.
 
 ## Integration Strategy (local-only)
 

--- a/.github/skills/unit-test-delegation-workflow/SKILL.md
+++ b/.github/skills/unit-test-delegation-workflow/SKILL.md
@@ -6,6 +6,8 @@ argument-hint: 'Requirement summary + source path(s) + test type + expected beha
 
 # Jest Test Delegation Workflow
 
+Policy: [`docs/adr/0012-tiered-quality-gates.md`](../../docs/adr/0012-tiered-quality-gates.md) — classify `gate:*` before delegating.
+
 ## Use This Skill When
 
 - A feature, bug fix, or refactor requires new or changed Jest tests.
@@ -14,12 +16,19 @@ argument-hint: 'Requirement summary + source path(s) + test type + expected beha
 
 Use `.github/skills/playwright-e2e-workflow/SKILL.md` for Playwright specs in `apps/myorganizer-e2e`.
 
+## Gate tier routing
+
+| Gate                          | Path                                                                                                                       |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `gate:mechanical`             | Fixture/type retarget or rename only → main agent may edit + focused jest; **do not** run TestScaffold → Reviewer → Runner |
+| `gate:standard` / `gate:full` | Behavioral assertion changes → full pipeline below                                                                         |
+
 ## Core Rules
 
-- Always delegate Jest test implementation to the `TestScaffold` custom agent.
+- On `standard`/`full`, always delegate Jest test implementation to the `TestScaffold` custom agent.
 - Send a complete requirement brief; never ask for generic "comprehensive tests".
 - The brief must include a behavior matrix based on the actual implementation, not desired behavior from a template.
-- After `TestScaffold` reports, delegate the output to `TestReviewer` — it is the static quality gate (checklist verification, `tsc --noEmit`, `eslint`). After `TestReviewer` approves, delegate to `TestRunner` for execution. The main agent handles escalation only.
+- After `TestScaffold` reports, delegate the output to `TestReviewer` — it is the static quality gate (checklist verification, `tsc --noEmit`, `eslint`). After `TestReviewer` approves, delegate to `TestRunner` for **one** authoritative execution. Do not re-run the full suite in every hop.
 - Happy-path-only tests are not acceptable when reachable side effects, error paths, boundaries, or security-sensitive misuse paths exist.
 
 ## Workflow

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -238,6 +238,120 @@ function blockedBy(issue: Issue): number[] {
   return [...section.matchAll(/#(\d+)/g)].map((match) => Number(match[1]));
 }
 
+function blocks(issue: Issue): number[] {
+  const section = issue.body.match(
+    /##\s+Blocks\s*([\s\S]*?)(?=\n##\s|$)/i,
+  )?.[1];
+  if (!section || /^\s*-\s*None\b/im.test(section)) return [];
+
+  return [...section.matchAll(/#(\d+)/g)].map((match) => Number(match[1]));
+}
+
+function isIssueSatisfied(issue: Issue | undefined): boolean {
+  if (!issue) return false;
+  return isCompleted(issue);
+}
+
+/**
+ * After a slice completes, clear `status:blocked` on dependents whose
+ * ## Blocked by deps are all done/closed. Prefer ## Blocks on the completed
+ * issue; also scan same-PRD open slices as a fallback.
+ */
+function unblockDependents(completed: Issue): void {
+  const prdMatch = completed.body?.match(/PRD:\s*#(\d+)/i);
+  const prdRef = prdMatch ? `PRD: #${prdMatch[1]}` : null;
+
+  const candidateNumbers = new Set<number>(blocks(completed));
+  for (const issue of allIssues) {
+    if (issue.number === completed.number) continue;
+    if (prdRef && !issue.body?.includes(prdRef)) continue;
+    if (blockedBy(issue).includes(completed.number)) {
+      candidateNumbers.add(issue.number);
+    }
+  }
+
+  if (candidateNumbers.size === 0) return;
+
+  // Refresh issue metadata for accurate labels/state.
+  const byNumber = new Map<number, Issue>();
+  for (const issue of allIssues) {
+    byNumber.set(issue.number, issue);
+  }
+  byNumber.set(completed.number, {
+    ...completed,
+    state: 'CLOSED',
+    labels: [
+      ...completed.labels.filter((l) => l.name !== 'status:in-progress'),
+      { name: 'status:done' },
+    ],
+  });
+
+  for (const dependentNumber of candidateNumbers) {
+    let dependent = byNumber.get(dependentNumber);
+    if (!dependent) {
+      try {
+        dependent = ghJson<Issue>([
+          'issue',
+          'view',
+          String(dependentNumber),
+          '--repo',
+          REPO,
+          '--json',
+          'number,title,state,labels,body',
+        ]);
+        byNumber.set(dependentNumber, dependent);
+      } catch {
+        console.warn(
+          `  [#${completed.number}] unblock: could not load dependent #${dependentNumber}`,
+        );
+        continue;
+      }
+    }
+
+    if (!dependent.labels.some((l) => l.name === 'status:blocked')) {
+      continue;
+    }
+
+    const deps = blockedBy(dependent);
+    const unfinished = deps.filter((blockerNumber) => {
+      if (blockerNumber === completed.number) return false;
+      const blocker = byNumber.get(blockerNumber);
+      return !isIssueSatisfied(blocker);
+    });
+
+    if (unfinished.length > 0) {
+      console.log(
+        `  [#${completed.number}] #${dependentNumber} still blocked by ${unfinished
+          .map((n) => `#${n}`)
+          .join(', ')}`,
+      );
+      continue;
+    }
+
+    ghSilent([
+      'issue',
+      'edit',
+      String(dependentNumber),
+      '--repo',
+      REPO,
+      '--remove-label',
+      'status:blocked',
+    ]);
+    ghSilent([
+      'issue',
+      'comment',
+      String(dependentNumber),
+      '--repo',
+      REPO,
+      '--body',
+      `Unblocked: #${completed.number} is done. Remaining blockers: none — ready for agent.`,
+    ]);
+    console.log(
+      `  [#${completed.number}] removed status:blocked from #${dependentNumber}`,
+    );
+  }
+}
+
 const prd = ghJson<Pick<Issue, 'title' | 'body'>>([
   'issue',
   'view',
@@ -713,7 +827,49 @@ function integrateSlice(issue: Issue, sliceBranch: string): boolean {
   return true;
 }
 
+function resolveGate(issue: Issue): 'mechanical' | 'standard' | 'full' {
+  const labels = issue.labels.map((l) => l.name);
+  if (labels.includes('gate:mechanical')) return 'mechanical';
+  if (labels.includes('gate:full')) return 'full';
+  return 'standard';
+}
+
+function buildGateInstructions(
+  gate: 'mechanical' | 'standard' | 'full',
+): string[] {
+  const common = [
+    `- Quality gate for this slice: \`gate:${gate}\` (ADR 0012 / \`.claude/checklist.md\`).`,
+    `- Prefer short specialist reports (\`PASS|FAIL|ESCALATE\` + ≤5 bullets).`,
+    `- ComponentReviewer FAIL loops: max 3, then escalate with a diagnosis.`,
+  ];
+
+  if (gate === 'mechanical') {
+    return [
+      ...common,
+      `- Mechanical path: main agent may edit directly (fixture/type retarget, rename, dead delete, selector-only E2E, verify-already-done).`,
+      `- Do NOT run TestScaffold → TestReviewer → TestRunner or ComponentBuilder → ComponentReviewer for mechanical work.`,
+      `- Still run focused deterministic checks (jest/tsc/eslint on touched files).`,
+    ];
+  }
+
+  if (gate === 'full') {
+    return [
+      ...common,
+      `- Full path: follow mandatory specialist pipelines in CLAUDE.md for behavioral tests, stories, and components.`,
+      `- E2E: E2EPlanner → TestScaffold → TestReviewer (structural only); never execute Playwright in this sandbox.`,
+    ];
+  }
+
+  return [
+    ...common,
+    `- Standard path: one specialist hop for the changed artifact type (not every pipeline by default).`,
+    `- Follow CLAUDE.md / \`.claude/checklist.md\` for which agent chain applies.`,
+    `- Skip E2EPlanner only for selector-only E2E edits when the flow matrix is unchanged.`,
+  ];
+}
+
 function buildPrompt(issue: Issue, sliceBranch: string): string {
+  const gate = resolveGate(issue);
   return [
     `You are implementing GitHub Issue #${issue.number}: ${issue.title}`,
     ``,
@@ -727,7 +883,7 @@ function buildPrompt(issue: Issue, sliceBranch: string): string {
     `- Read CLAUDE.md, CONTEXT.md, and TECH_STACK.md before making any changes.`,
     `- Implement this vertical slice end-to-end (schema → API → UI → tests where applicable).`,
     `- Your working branch is \`${sliceBranch}\` (based on \`${featureBranch}\`). Do not switch branches.`,
-    `- Follow all mandatory delegation rules in CLAUDE.md (tests → TestScaffold, components → ComponentBuilder, etc.).`,
+    ...buildGateInstructions(gate),
     `- Commit your changes using Conventional Commit messages (\`corepack yarn ai:commit\`).`,
     `- Do NOT push and do NOT open a PR — this sandbox has no credentials. Just commit locally on your branch; leave nothing uncommitted. The orchestrator integrates your branch into the feature branch on the host.`,
     `- When implementation is complete, output <promise>COMPLETE</promise>.`,
@@ -984,6 +1140,7 @@ while (pendingSlices.length > 0) {
           `Integrated into the local \`${featureBranch}\` (fast-forward, not pushed) and closed as completed. ` +
           `It will reach \`main\` via the manual PRD PR.`,
       ]);
+      unblockDependents(issue);
     } else {
       ghSilent([
         'issue',

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -13,7 +13,7 @@ You are implementing a vertical slice for MyOrganizer.
 
 - Dependencies are **already installed** in this sandbox before you start (a setup hook runs `corepack yarn install --immutable`). Do NOT run `yarn install` yourself.
 - Read `CLAUDE.md`, `CONTEXT.md`, and `TECH_STACK.md` before making any changes.
-- Follow all mandatory delegation rules in `CLAUDE.md` (tests → TestScaffold, components → ComponentBuilder, etc.).
+- Follow the slice `gate:*` tier from ADR 0012 / `.claude/checklist.md` (Sandcastle injects gate instructions; default `gate:standard`).
 - Work only on the branch you were given. Do not switch branches.
 - Commit with Conventional Commit messages (`corepack yarn ai:commit`).
 - Do NOT push and do NOT open a PR — the sandbox has no credentials. Just commit locally; the orchestrator integrates your branch into the feature branch on the host.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - For issue creation requests, follow `.github/skills/github-issue-creation-workflow/SKILL.md` and delegate to `IssueCreator` so duplicate checks, required details, and label validation are handled consistently.
 - For issue/PR triage requests, follow `.github/skills/triage/SKILL.md`. Use `.github/skills/triage/AGENT-BRIEF.md` when moving to `ready-for-agent`, and `.github/skills/triage/OUT-OF-SCOPE.md` when rejecting enhancements as `wontfix`.
 - For Jest unit or integration test creation/update requests, follow `.github/skills/unit-test-delegation-workflow/SKILL.md` and delegate implementation to `TestScaffold` first. The brief must include a behavior matrix from the actual implementation plus explicit in-scope and out-of-scope scenarios. Main agent must review behavior correctness, side effects, failures, boundaries, security-sensitive paths, mock hygiene, duplicate output, and validation before finalizing. Use `docs/testing/README.md` as the project-aware tooling reference.
-- For implementing agreed work from a spec, PRD, or tickets in the current session, use `.github/skills/implement/SKILL.md`. Use TDD at pre-agreed seams, respect mandatory delegation rules, and commit or open PRs only when the user explicitly asks.
+- For implementing agreed work from a spec, PRD, or tickets in the current session, use `.github/skills/implement/SKILL.md`. Classify `gate:*` first (ADR 0012); ad-hoc work needs no ticket. Use TDD at pre-agreed seams, respect tiered delegation rules, and commit or open PRs only when the user explicitly asks.
 - For reviewing branch or WIP changes against repo standards and the originating spec, use `.github/skills/code-review/SKILL.md`.
 - For building features or fixing bugs test-first (red-green-refactor), use `.github/skills/tdd/SKILL.md`. Plan the behavior list with the user before writing any code, work in vertical tracer-bullet slices (one test → one implementation → repeat), and consult `.github/skills/codebase-design/SKILL.md` for deep-module vocabulary during the refactor step.
 - For Playwright E2E creation/update requests, follow `.github/skills/playwright-e2e-workflow/SKILL.md`; use `E2EPlanner` for broad flows and delegate implementation to `TestScaffold` only with a precise flow matrix.
@@ -73,39 +73,31 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - To break a PRD Issue into Slice Issues, use `.github/skills/to-issues/SKILL.md`. The user must supply the PRD Issue number. Every slice body must start with `PRD: #<N>`. Flag `type:hitl` slices prominently — `dispatch-agents` skips them. After publishing, remind the user to run `yarn dispatch-agents --prd <N>`.
 - Before issuing 3 or more consecutive read/search operations to locate something in the codebase, stop and delegate to `CodeExplorer` (`.github/agents/explore.agent.md`) instead. Provide an Explore Request with a `Goal` sentence; optionally include `Known Locations`, `Search Hints`, `Out of Scope`, and `Expected Output`. CodeExplorer returns a structured Explore Summary with `[found]`/`[inferred]` tagged findings and ranked file paths.
 
-## ⚠️ Mandatory Delegation Rules (NO EXCEPTIONS)
+## ⚠️ Tiered Quality Gates (ADR 0012)
 
-**ALWAYS delegate tasks for these file types.** Do NOT skip delegation even if the change seems small or obvious.
+Do not treat every test/component touch as a full multi-agent pipeline. Classify a **gate tier** first (checklist Step 0 or slice `gate:*` label). When unsure → promote. Applies to interactive and AFK sessions.
 
-| File Pattern                    | Skill                                                   | Agent Flow                           | Rule                   |
-| ------------------------------- | ------------------------------------------------------- | ------------------------------------ | ---------------------- |
-| `*.spec.ts` (Playwright E2E)    | `.github/skills/playwright-e2e-workflow/SKILL.md`       | E2EPlanner → TestScaffold            | ✅ **Always delegate** |
-| `*.test.ts` (Jest tests)        | `.github/skills/unit-test-delegation-workflow/SKILL.md` | TestScaffold                         | ✅ **Always delegate** |
-| `*.stories.tsx` (Storybook)     | `.github/skills/storybook-delegation-workflow/SKILL.md` | StorybookCurator                     | ✅ **Always delegate** |
-| Components in `libs/web-ui/`    | Component workflow                                      | ComponentBuilder → ComponentReviewer | ✅ **Always delegate** |
-| Components in `libs/web/pages/` | Component workflow                                      | ComponentBuilder → ComponentReviewer | ✅ **Always delegate** |
+| Tier              | Execution                                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `gate:mechanical` | Main agent may edit (fixture/type retarget, rename, dead delete, selector-only E2E) + focused checks |
+| `gate:standard`   | Matching specialist hop for the artifact                                                             |
+| `gate:full`       | Full mandatory pipelines                                                                             |
 
-### Key Anti-Pattern to Avoid
+| File Pattern                                     | Skill                                                   | `standard` / `full` flow                                                                                      |
+| ------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `*.spec.ts` (Playwright E2E)                     | `.github/skills/playwright-e2e-workflow/SKILL.md`       | E2EPlanner → TestScaffold → TestReviewer (structural). Skip planner only for selector-only + unchanged matrix |
+| `*.test.ts` (Jest)                               | `.github/skills/unit-test-delegation-workflow/SKILL.md` | TestScaffold → TestReviewer → TestRunner                                                                      |
+| `*.stories.tsx`                                  | `.github/skills/storybook-delegation-workflow/SKILL.md` | StorybookCurator                                                                                              |
+| Components in `libs/web-ui/` / `libs/web/pages/` | Component workflow                                      | ComponentBuilder → ComponentReviewer (max 3 FAIL loops)                                                       |
 
-❌ **DO NOT do this:**
+### Key Anti-Patterns
 
-```
-"I see a bug in an E2E test. Let me read the similar test, find the pattern, and fix it directly."
-```
-
-✅ **DO THIS INSTEAD:**
-
-```
-"I see a bug in an E2E test. This is an E2E test UPDATE.
-1. Read .github/skills/playwright-e2e-workflow/SKILL.md
-2. Use E2EPlanner to outline the fix
-3. Delegate to TestScaffold with a precise brief
-4. Apply changes from TestScaffold output"
-```
+❌ Skip specialists on behavioral (`standard`/`full`) test or component work.  
+❌ Run the full test pipeline for a pure mechanical fixture retarget.
 
 ### Before You Edit Any File
 
-Use the decision tree in [`.claude/checklist.md`](.claude/checklist.md) to verify you're not skipping delegation.
+Use [`.claude/checklist.md`](.claude/checklist.md) Step 0 → file-type matrix.
 
 ## Do Not
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,46 +14,40 @@ Use the repo-local command files under `.claude/commands/` for commit, PR, test,
 - Commit-message drafting still belongs to the existing `Commit` sub-agent; commit execution belongs to the shared `ai:commit` runner.
 - Jest test implementation uses a three-stage pipeline: `TestScaffold` (writes tests) → `TestReviewer` (static gate: checklist, tsc, eslint) → `TestRunner` (execution with hang detection). Always provide a behavior matrix from the actual implementation, including unsupported scenarios to avoid. Consult `docs/testing/README.md` for per-project tooling, integration scope, mock patterns, and validation checks. Max 3 retries before escalating to the main agent.
 - Storybook implementation is delegated to the `StorybookCurator` sub-agent (`.claude/agents/storybook-curator.md`); require requirement-readiness analysis before edits and route clarification questions to the human-in-the-loop.
-- React component creation or editing (UI Primitives in `libs/web-ui/` or Feature Components in `libs/web/pages/<route>/`) must use the ComponentBuilder → ComponentReviewer workflow — see **UI Component Workflows** below.
+- React component creation or editing (UI Primitives in `libs/web-ui/` or Feature Components in `libs/web/pages/<route>/`) uses the ComponentBuilder → ComponentReviewer workflow on `gate:standard` / `gate:full` — see **UI Component Workflows** below and ADR 0012 for mechanical exceptions.
 - After any `yarn add`, `yarn remove`, or package upgrade, run `/dep-sync` to keep `TECH_STACK.md` current — see **Dependency Sync** below.
 - After any sub-agent change in any harness (`.github`, `.claude`, `.cursor`, `.gemini`), run `yarn agents:sync` and then `yarn agents:sync:check`.
 - Use `.github/skills/sub-agent-sync-workflow/SKILL.md` as the required workflow for sub-agent synchronization.
 
-## ⚠️ Mandatory Delegation Rules (NO EXCEPTIONS)
+## ⚠️ Tiered Quality Gates (ADR 0012)
 
-**ALWAYS delegate tasks for these file types.** Do NOT skip delegation even if the change seems small or obvious.
+Pipeline depth is chosen by **gate tier**, not file extension alone. Classify via **`.claude/checklist.md` Step 0** (or the slice `gate:*` label). When unsure → promote. Same policy for interactive and AFK.
 
-| File Pattern                    | Skill                                                   | Agent Flow                                                                             | Rule                                     |
-| ------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `*.spec.ts` (Playwright E2E)    | `.github/skills/playwright-e2e-workflow/SKILL.md`       | E2EPlanner → TestScaffold → TestReviewer (structural only; never execute autonomously) | ✅ **Always delegate**                   |
-| `*.test.ts` (Jest tests)        | `.github/skills/unit-test-delegation-workflow/SKILL.md` | TestScaffold → TestReviewer → TestRunner                                               | ✅ **Always delegate**                   |
-| `*.stories.tsx` (Storybook)     | `.github/skills/storybook-delegation-workflow/SKILL.md` | StorybookCurator                                                                       | ✅ **Always delegate**                   |
-| Components in `libs/web-ui/`    | Component workflow (below)                              | ComponentBuilder → ComponentReviewer                                                   | ✅ **Always delegate**                   |
-| Components in `libs/web/pages/` | Component workflow (below)                              | ComponentBuilder → ComponentReviewer                                                   | ✅ **Always delegate**                   |
-| New planned feature (PRD)       | `.github/skills/to-prd/SKILL.md`                        | to-prd                                                                                 | ✅ **Always use for planned features**   |
-| Slice breakdown from PRD        | `.github/skills/to-issues/SKILL.md`                     | to-issues                                                                              | ✅ **Always use after PRD is published** |
+| Tier              | When                                                                                             | Execution                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `gate:mechanical` | Fixture/type retarget, rename, dead delete, selector-only E2E string, already-satisfied AC check | Main agent may edit + focused lint/tests                      |
+| `gate:standard`   | Single-surface behavior change                                                                   | Matching specialist hop (+ reviewer/runner as skill requires) |
+| `gate:full`       | New UI module, vault/crypto, API contract, multi-file product behavior                           | Full mandatory pipelines                                      |
 
-### Key Anti-Pattern to Avoid
+| File Pattern                                     | Skill                                                   | `standard` / `full` agent flow                                                                                                              |
+| ------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `*.spec.ts` (Playwright E2E)                     | `.github/skills/playwright-e2e-workflow/SKILL.md`       | E2EPlanner → TestScaffold → TestReviewer (structural; never execute in AFK). Skip E2EPlanner only for selector-only + unchanged flow matrix |
+| `*.test.ts` (Jest)                               | `.github/skills/unit-test-delegation-workflow/SKILL.md` | TestScaffold → TestReviewer → TestRunner (max 3 retries)                                                                                    |
+| `*.stories.tsx`                                  | `.github/skills/storybook-delegation-workflow/SKILL.md` | StorybookCurator                                                                                                                            |
+| Components in `libs/web-ui/` / `libs/web/pages/` | Component workflow (below)                              | ComponentBuilder → ComponentReviewer (max 3 FAIL loops)                                                                                     |
+| New planned feature (PRD)                        | `.github/skills/to-prd/SKILL.md`                        | Always for planned features                                                                                                                 |
+| Slice breakdown from PRD                         | `.github/skills/to-issues/SKILL.md`                     | Always after PRD; assign `gate:*` + `complexity:*`                                                                                          |
 
-❌ **DO NOT do this:**
+### Key Anti-Patterns
 
-```
-"I see a bug in an E2E test. Let me read the similar test, find the pattern, and fix it directly."
-```
+❌ Behavioral E2E/Jest/component edits done directly to skip specialists on `standard`/`full`.  
+❌ Full TestScaffold → Reviewer → Runner for a pure fixture retarget (`gate:mechanical`).
 
-✅ **DO THIS INSTEAD:**
-
-```
-"I see a bug in an E2E test. This is an E2E test UPDATE.
-1. Read .github/skills/playwright-e2e-workflow/SKILL.md
-2. Use E2EPlanner to outline the fix
-3. Delegate to TestScaffold with a precise brief
-4. Apply changes from TestScaffold output"
-```
+✅ State the gate, follow `.claude/checklist.md`, run focused deterministic checks.
 
 ### Before You Edit Any File
 
-Use the decision tree in **`.claude/checklist.md`** to verify you're not skipping delegation.
+Use **`.claude/checklist.md`** (Step 0 gate → file-type matrix).
 
 ## UI Component Workflows
 
@@ -102,27 +96,28 @@ all
 
 Pass the Structured Spec to the `ComponentBuilder` sub-agent (`.claude/agents/component-builder.md`). Wait for the **ComponentBuilder Report** before proceeding.
 
-### Step 3 — Delegate to ComponentReviewer (always — no exceptions)
+### Step 3 — Delegate to ComponentReviewer
 
-Pass the ComponentBuilder Report to the `ComponentReviewer` sub-agent (`.claude/agents/component-reviewer.md`). Do NOT skip this step, even for small edits.
+Required on `gate:standard` and `gate:full` after ComponentBuilder. Pass the ComponentBuilder Report to `ComponentReviewer` (`.claude/agents/component-reviewer.md`). Skip Builder/Reviewer only for `gate:mechanical` rename/import/dead-delete.
 
 ### Step 4 — Handle the Verdict
 
 - **`PASS`** — accept the component; note any warnings to the user.
 - **`PASS_WITH_WARNINGS`** — accept the component; surface the warnings to the user for awareness.
-- **`FAIL`** — relay the `Required Revisions` section back to ComponentBuilder and repeat from Step 2 until the verdict is `PASS` or `PASS_WITH_WARNINGS`.
+- **`FAIL`** — relay `Required Revisions` to ComponentBuilder and repeat from Step 2. **Max 3 FAIL cycles**, then escalate to the main agent/human with a diagnosis. Prefer short reviewer reports (`PASS|FAIL` + ≤5 bullets) unless detail is needed after a rejection.
 
 ### Step 5 — Storybook and Tests (after review passes)
 
 - New UI Primitives always need a Storybook story → use `.claude/commands/storybook.md`.
 - Any component with testable behaviour → use `.claude/commands/unit-test.md`.
+- On `gate:standard`, add stories/tests only when behavior warrants them.
 
 ### Key Rules
 
-- Do NOT write component code directly in the main agent context. Always delegate to ComponentBuilder.
+- On `gate:standard` / `gate:full`, do NOT write component code in the main agent — delegate to ComponentBuilder.
 - ComponentBuilder does not write stories or tests — those go to StorybookCurator and TestScaffold after the review passes.
-- Do NOT invent component conventions. ComponentBuilder and ComponentReviewer enforce `docs/ui/GUIDELINES.md` — read it if you need to understand the rules.
-- If the Structured Spec is incomplete (missing `Target Path` or `Props Interface`), gather the missing information from the user before delegating.
+- Do NOT invent component conventions. ComponentBuilder and ComponentReviewer enforce `docs/ui/GUIDELINES.md`.
+- If the Structured Spec is incomplete (missing `Target Path` or `Props Interface`), gather the missing information before delegating.
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -106,7 +106,7 @@ When agreed work from a spec, PRD, or tickets should be built in the current ses
 - **Command**: `.gemini/commands/implement.md`
 - **Skill location**: `.github/skills/implement/SKILL.md`
 - **When to use**: The user has a scoped spec or ticket set and wants implementation now (ad-hoc or single-session delivery).
-- **What it does**: Implements against the spec using TDD at pre-agreed seams, routes file types through mandatory delegation, validates with Nx lint/test targets, reviews with `/code-review`, and commits or opens PRs only when the user explicitly asks.
+- **What it does**: Implements against the spec using TDD at pre-agreed seams, classifies `gate:*` (ADR 0012), routes by gate + file type, validates with Nx lint/test targets, reviews with `/code-review` when appropriate, and commits or opens PRs only when the user explicitly asks.
 
 ## Code Review — Two-axis diff review
 

--- a/docs/adr/0002-agent-orchestration-label-vocabulary.md
+++ b/docs/adr/0002-agent-orchestration-label-vocabulary.md
@@ -10,12 +10,16 @@ The full label vocabulary:
 | `complexity:low`     | Route to Haiku                                                        |
 | `complexity:medium`  | Route to Sonnet                                                       |
 | `complexity:high`    | Route to Opus                                                         |
+| `gate:mechanical`    | Mechanical path — no specialist chains (ADR 0012)                     |
+| `gate:standard`      | Single-hop specialist path (ADR 0012)                                 |
+| `gate:full`          | Full mandatory pipelines (ADR 0012)                                   |
 | `type:afk`           | Agent can implement and merge without human interaction               |
 | `type:hitl`          | Human decision required before agent can proceed — orchestrator skips |
 | `status:in-progress` | Agent has picked up the issue                                         |
+| `status:blocked`     | Waiting on `## Blocked by` deps — orchestrator skips until unblocked  |
 | `status:done`        | Agent finished; slice integrated into the local feature branch        |
 
-`to-issues` applies `ready-for-agent` + `type:*` + `complexity:*` at creation time. The orchestrator filters on `ready-for-agent` + `type:afk` and reads `complexity:*` to select the model.
+`to-issues` applies `ready-for-agent` + `type:*` + `complexity:*` + one `gate:*` at creation time, plus `status:blocked` when `## Blocked by` is non-empty. The orchestrator filters on `ready-for-agent` + `type:afk` (and excludes `status:blocked`), reads `complexity:*` for model size, and reads `gate:*` for pipeline depth (default `gate:standard` when missing). On successful completion, Sandcastle and `/implement` remove `status:blocked` from dependents whose blockers are all done. See `docs/adr/0012-tiered-quality-gates.md`.
 
 ## Considered Options
 

--- a/docs/adr/0012-tiered-quality-gates.md
+++ b/docs/adr/0012-tiered-quality-gates.md
@@ -1,0 +1,86 @@
+# Tiered quality gates for AFK and interactive agent work
+
+Mandatory multi-agent chains (TestScaffold → TestReviewer → TestRunner, ComponentBuilder → ComponentReviewer, etc.) preserve quality on structural work but over-tax mechanical and exploratory slices — including local/interactive sessions with no ticket. We adopt **tiered quality gates** so the same policy applies to Sandcastle AFK and Cursor/Claude interactive work: depth scales with risk, not with file extension alone.
+
+## Status
+
+accepted
+
+## Decision
+
+Quality depth is selected by a **gate tier**, not by “always full pipeline.” Deterministic checks (`tsc`, `eslint`, focused jest) stay mandatory at every tier. Multi-agent specialist chains are reserved for behavioral and structural risk.
+
+### Gate tiers
+
+| Tier              | When                                                                                                                                                      | Allowed execution                                                                                                   | Required gates                                                                                         |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `gate:mechanical` | Fixture/type retarget, rename, delete dead code, selector-only E2E string fix, already-satisfied AC verification, import/path fix with no behavior change | Main agent may edit directly (interactive or AFK)                                                                   | Focused lint + focused tests (or `tsc` for type-only). No specialist chain. Short report (≤5 bullets). |
+| `gate:standard`   | Single-surface behavior change: one component props/state fix, one schema field, one assertion suite update                                               | One specialist hop when that artifact type changes (e.g. TestScaffold **or** ComponentBuilder), not both by default | Specialist + matching Reviewer **or** Runner once. Collapse redundant re-runs. Cap retries at 3.       |
+| `gate:full`       | New UI primitive/feature module, vault/crypto, API contract, multi-file product behavior, ambiguous UX                                                    | Current mandatory chains                                                                                            | Full documented pipelines. ComponentReviewer retry cap = 3 (mirror test pipeline).                     |
+
+### Session modes (same tiers, different entry)
+
+| Mode                       | Entry                                        | How the tier is chosen                                                                                                                                             |
+| -------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **AFK / Sandcastle**       | Slice issue with labels                      | `to-issues` applies `gate:*` (+ existing `complexity:*`). Orchestrator injects the matching prompt rules.                                                          |
+| **Interactive + ticket**   | User points at an issue / PRD slice          | Main agent reads labels (or infers from issue body) and follows the same tier.                                                                                     |
+| **Interactive, no ticket** | Ad-hoc (“fix this”, “retarget this fixture”) | Main agent classifies via `.claude/checklist.md` Step 0 (risk questions) → picks a tier → states the tier in the first reply. User can override (“use full gate”). |
+
+Ad-hoc work does **not** require IssueCreator or a GitHub ticket. Tickets remain the path for planned features, triage, and AFK dispatch.
+
+### Mechanical classification (escape hatch)
+
+A change is `gate:mechanical` only if **all** are true:
+
+1. No new product behavior or public API contract.
+2. Diff is localized (prefer ≤2 files; larger only if pure rename/delete).
+3. Assertions/stories either unchanged or only retarget fixtures/types to match an already-landed domain model.
+4. Success is decidable by deterministic checks alone.
+
+If any check fails → promote to `gate:standard` or `gate:full`. When unsure → promote (never demote).
+
+### Label vocabulary extension (AFK contract)
+
+Extends ADR 0002:
+
+| Label             | Meaning                                                  |
+| ----------------- | -------------------------------------------------------- |
+| `gate:mechanical` | AFK agent must use mechanical path; no specialist chains |
+| `gate:standard`   | Single-hop specialist path                               |
+| `gate:full`       | Full mandatory pipelines                                 |
+
+`complexity:*` continues to select **model size**. `gate:*` selects **pipeline depth**. They are independent (e.g. `complexity:low` + `gate:mechanical`, or `complexity:high` + `gate:full`).
+
+Default when missing: `gate:standard` for AFK (safer than mechanical); interactive no-ticket defaults to classification at session start.
+
+### Report and handoff discipline (all modes)
+
+Specialist agents return **machine-short** verdicts:
+
+- `PASS | FAIL | ESCALATE`
+- ≤5 bullets of rationale
+- Exact command(s) already run
+
+No novel-length checklist dumps unless `gate:full` and the reviewer rejected once.
+
+### Explicit non-goals
+
+- This does **not** remove GUIDELINES, behavior matrices, or vault safety rules for structural work.
+- This does **not** authorize plaintext vault APIs or skipping OpenAPI sync after contract changes.
+- This does **not** make E2E autonomous in Sandcastle (still structural-only per ADR 0004).
+
+## Considered Options
+
+- **Keep NO EXCEPTIONS forever** — Rejected: proven cost-compounding on mechanical slices (e.g. fixture retarget paying full TestScaffold → Reviewer → Runner).
+- **Separate interactive vs AFK policies** — Rejected: doubles maintenance and invites checklist drift; one tier vocabulary with two entry modes is enough.
+- **Model downgrade only (always full chains on Haiku)** — Rejected: call count and handoff duplication dominate cost more than model tier alone.
+- **Ticket-required for all agent work** — Rejected: interactive friction without quality gain for mechanical ad-hoc edits.
+
+## Consequences
+
+- Update `.claude/checklist.md`, `CLAUDE.md`, `AGENTS.md` to replace absolute “NO EXCEPTIONS” with tiered rules + mechanical criteria.
+- Extend `to-issues` / `create-labels` with `gate:*`; teach Sandcastle prompt builder to inject tier rules.
+- Add ComponentReviewer max-retry = 3 (parity with unit-test pipeline).
+- Extend `/implement` and `/ask-matt` with an **ad-hoc, no-ticket** playbook that classifies gate tier first.
+- Align Cursor premium models on static gates (TestReviewer) with cost policy unless benchmarks justify otherwise.
+- Fix stale checklist pointer to missing `.claude/commands/component-builder.md`.

--- a/tools/scripts/ai/create-labels.mjs
+++ b/tools/scripts/ai/create-labels.mjs
@@ -27,6 +27,22 @@ const LABELS = [
     description: 'Route to Opus — complex task requiring deep reasoning',
   },
   {
+    name: 'gate:mechanical',
+    color: 'd4c5f9',
+    description:
+      'Mechanical path — main agent edits; no specialist chains (ADR 0012)',
+  },
+  {
+    name: 'gate:standard',
+    color: 'b392f0',
+    description: 'Single-hop specialist path (ADR 0012)',
+  },
+  {
+    name: 'gate:full',
+    color: '6f42c1',
+    description: 'Full mandatory multi-agent pipelines (ADR 0012)',
+  },
+  {
     name: 'type:afk',
     color: 'e4e669',
     description: 'Agent can implement and merge without human interaction',
@@ -41,6 +57,12 @@ const LABELS = [
     name: 'status:in-progress',
     color: 'fef2c0',
     description: 'Agent has picked up the issue and is working on it',
+  },
+  {
+    name: 'status:blocked',
+    color: 'd93f0b',
+    description:
+      'Waiting on blocker issue(s) in ## Blocked by — skipped by dispatch-agents until unblocked',
   },
   {
     name: 'status:done',


### PR DESCRIPTION
## Why
Adopt tiered quality gates and issue unblock.

## Changes
- Add ADR 0012 (mechanical/standard/full) and extend ADR 0002 with gate:* and status:blocked
- Replace mandatory-delegation checklist with Step 0 gate tier classification
- Update AGENTS/CLAUDE/GEMINI, implement/ask-matt/to-issues skills, and workflow skills
- Sandcastle injects gate instructions; unblocks dependents after slice completion
- ComponentReviewer short reports with max 3 FAIL retries
- create-labels adds gate:* and status:blocked; bidirectional Blocked by/Blocks in to-issues

## Validation
- Generated from 1 commit(s) on `docs/tiered-quality-gates-and-issue-unblock`.
- Compared against base branch `main`.
