### PR TITLE
fix(deps): resolve nanoid DoS advisories and document image-size exception

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -84,10 +84,24 @@ npmPreapprovedPackages:
   - '@nx/workspace@22.7.7'
   - 'brace-expansion@5.0.9'
   - 'undici@7.29.0'
+  - 'nanoid@3.3.17'
 
 # 1124334 – previous brace-expansion advisory (ReDoS variant) — kept for history
+#
+# 1138808 / 1138809 – image-size DoS via malformed ICNS / JXL / HEIF headers.
+# Patched in image-size 2.0.3, but no dependent can take it:
+#   * metro@0.82.5 requires image-size@^1.0.2 and calls it as a default export
+#     (node_modules/metro/src/Assets.js: `const getImageSize = require('image-size')`).
+#     v2 dropped the default export in favour of a named `imageSize`, so forcing 2.x
+#     breaks the React Native asset pipeline with "getImageSize is not a function".
+#   * less@4.5.1 requires image-size@~0.5.0 and declares it optional.
+# Both are build-time-only tools operating on first-party assets, so a parser DoS is
+# not reachable from untrusted input at runtime. Revisit when metro ships image-size v2
+# support — tracked in the issue linked from this commit.
 npmAuditIgnoreAdvisories:
   - '1124334'
+  - '1138808'
+  - '1138809'
 
 # @nx/express still declares express ^4; backend intentionally runs Express 5.
 # Yarn cannot override existing peer ranges via packageExtensions — discard the noise.

--- a/TECH_STACK.md
+++ b/TECH_STACK.md
@@ -307,10 +307,22 @@
 
 These transitive dependencies are explicitly resolved to patched versions via Yarn resolutions, npm overrides, and pnpm overrides.
 
-| Package                     | Resolved Version | Reason                                                                            | Vulnerability ID |
-| --------------------------- | ---------------- | --------------------------------------------------------------------------------- | ---------------- |
-| `shell-quote`               | 1.8.4            | Patches critical shell injection vulnerability (GHSA-w7jw-789q-3m8p)              | CVE-2024-XXXXX   |
-| `fast-xml-parser`           | 5.7.3            | Patches XMLBuilder comment/CDATA injection (GHSA-gh4j-gqv2-49f6)                  | CVE-2026-41650   |
-| `react-native-quick-base64` | 3.0.0            | Resolution keeps transitive copies aligned with direct dep (peer of quick-crypto) | —                |
+| Package                     | Resolved Version | Reason                                                                                        | Vulnerability ID |
+| --------------------------- | ---------------- | --------------------------------------------------------------------------------------------- | ---------------- |
+| `shell-quote`               | 1.8.4            | Patches critical shell injection vulnerability (GHSA-w7jw-789q-3m8p)                          | CVE-2024-XXXXX   |
+| `fast-xml-parser`           | 5.7.3            | Patches XMLBuilder comment/CDATA injection (GHSA-gh4j-gqv2-49f6)                              | CVE-2026-41650   |
+| `react-native-quick-base64` | 3.0.0            | Resolution keeps transitive copies aligned with direct dep (peer of quick-crypto)             | —                |
+| `nanoid`                    | 3.3.17           | Patches infinite loops on negative and zero `size` (GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8) | 1138811, 1138813 |
 
 > **Note**: `shell-quote` is a transitive dependency of `concurrently@9.2.1` (pulled in by `@openapitools/openapi-generator-cli@2.27.0`) and `launch-editor@2.9.1` (pulled in by `webpack-dev-server@5.2.3`). Upstream packages are pinned to versions that contain vulnerable `shell-quote`, so we use resolutions to force the patched version globally.
+
+> **Note**: `nanoid` reaches the tree through `postcss@8.5.18` (`^3.3.11`) and `@react-navigation/native@7.2.5` (`^3.3.12`). Both are resolved to `3.3.17`, the first release patching both advisories. It is also listed in `npmPreapprovedPackages` because it was published inside the 7-day `npmMinimalAgeGate` window.
+
+### Accepted audit exceptions
+
+Advisories deliberately ignored via `npmAuditIgnoreAdvisories` in `.yarnrc.yml`. Each needs a reachability argument and a revisit condition.
+
+| Advisory IDs     | Package           | Why it is not fixable now                                                                                                                                                                                                                                                                                                          | Revisit when                          |
+| ---------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| 1138808, 1138809 | `image-size`      | Patched in 2.0.3, but `metro@0.82.5` needs `^1.0.2` and calls it as a default export, which v2 removed; forcing 2.x breaks the React Native asset pipeline. `less@4.5.1` needs `~0.5.0` and marks it optional. Both are build-time tools over first-party assets, so the parser DoS is not reachable from untrusted runtime input. | `metro` ships `image-size` v2 support |
+| 1124334          | `brace-expansion` | Superseded ReDoS variant; kept for history.                                                                                                                                                                                                                                                                                        | —                                     |

--- a/package.json
+++ b/package.json
@@ -165,6 +165,8 @@
     "minimatch@^9.0.1": "9.0.9",
     "minimatch@^9.0.4": "9.0.9",
     "minimatch@^9.0.5": "9.0.9",
+    "nanoid@^3.3.11": "3.3.17",
+    "nanoid@^3.3.12": "3.3.17",
     "path-to-regexp@6.1.0": "6.3.0",
     "path-to-regexp@8.2.0": "8.4.2",
     "path-to-regexp@8.3.0": "8.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22961,21 +22961,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:3.3.17":
+  version: 3.3.17
+  resolution: "nanoid@npm:3.3.17"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
+  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Four high-severity advisories were published on 2026-08-07/08 and broke `yarn npm audit --all --recursive --severity high`. **No code change caused this** — the same lockfile passed on main yesterday.

`Secure Install Review` runs the audit unconditionally on non-PR events, so **main fails on the next push regardless of any open PR**. This unblocks it.

Found while investigating the failure on #282, which is a docs/tooling refactor with no dependency changes — it only tripped the audit because the trigger is path-based on `package.json` and it added a `scripts` entry.

## nanoid — fixed

Advisories 1138811 / 1138813: infinite loops on negative and zero `size`.

Reaches the tree twice — `postcss@8.5.18` (`^3.3.11`) and `@react-navigation/native@7.2.5` (`^3.3.12`). Both resolved to **3.3.17**, the first release patching both, using the descriptor-specific `resolutions` style already used for `minimatch`/`js-yaml`.

3.3.17 is 5 days old, inside the 7-day `npmMinimalAgeGate`, so it is added to `npmPreapprovedPackages` — the same escape hatch already used for ~70 other pins. 3.3.18 exists but is under a day old; 3.3.17 is the older, more-vetted release that still clears both advisories.

## image-size — not fixable, exception documented

Advisories 1138808 / 1138809: parser DoS via malformed ICNS / JXL / HEIF headers. Patched in 2.0.3, but **no dependent can take it**:

- `metro@0.82.5` requires `^1.0.2` and calls it as a default export — `metro/src/Assets.js:6`, `const getImageSize = require('image-size')`. v2 removed the default export in favour of a named `imageSize`, so forcing 2.x breaks the React Native asset pipeline with `getImageSize is not a function`.
- `less@4.5.1` requires `~0.5.0` and marks it optional.

Both are build-time tools operating on first-party assets, so the parser DoS is not reachable from untrusted input at runtime. Added to `npmAuditIgnoreAdvisories` with that reasoning inline and a revisit condition (when metro ships v2 support).

## TECH_STACK.md

Adds the `nanoid` row and a new **Accepted audit exceptions** table, so an ignored advisory carries a reachability argument and a revisit condition rather than sitting as a bare ID in `.yarnrc.yml`. The pre-existing `1124334` entry is backfilled into it.

## Verification

- `yarn npm audit --all --recursive --severity high` → `No audit suggestions`, exit 0
- `yarn install --immutable --mode=skip-build` → exit 0; `git diff --exit-code -- yarn.lock` clean (frozen-lockfile check passes)
- postcss source-map generation exercised against 3.3.17 (that's what postcss uses nanoid for)
- `yarn nx test web-vault` → 169/169 passing
- Lockfile delta is exactly `nanoid 3.3.11 + 3.3.12 → 3.3.17`; nothing else moved

## Reviewer note

The judgement call here is the `image-size` exception. If you'd rather patch metro or pin it to a fork than accept the advisory, say so and I'll redo it that way — but forcing v2 through resolutions is confirmed to break the bundler, so it isn't an option as-is.
