### PR TITLE
ci(security): trigger the npm audit on dependency content, not file paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,16 +169,25 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
-          changed_files="$(git diff --name-only --diff-filter=ACDMRT "$BASE_SHA" "$HEAD_SHA")"
-
-          if printf '%s\n' "$changed_files" | grep -Eq '^(package\.json|yarn\.lock|\.yarnrc\.yml)$'; then
+          # Content-aware, not path-aware: editing a `scripts` entry is not a
+          # dependency change. yarn.lock and .yarnrc.yml still always trigger,
+          # and every workspace manifest is inspected (the previous check only
+          # looked at the root package.json).
+          #
+          # If the detector itself fails, audit anyway — never skip on error.
+          if ! result="$(node tools/scripts/ci/dependency-manifest-changed.mjs "$BASE_SHA" "$HEAD_SHA")"; then
+            echo '::warning title=Dependency detection failed::Falling back to running the audit.'
             echo 'run_audit=true' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo 'run_audit=false' >> "$GITHUB_OUTPUT"
+          if [ "$result" = 'true' ]; then
+            echo 'run_audit=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run_audit=false' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run Yarn npm audit
         if: github.event_name != 'pull_request' || steps.dependency-files.outputs.run_audit == 'true'
@@ -188,7 +197,7 @@ jobs:
         if: github.event_name == 'pull_request' && steps.dependency-files.outputs.run_audit != 'true'
         shell: bash
         run: |
-          echo 'Skipped npm audit because no dependency manifests changed in this pull request.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'Skipped npm audit because this pull request changes no dependencies: yarn.lock and .yarnrc.yml are untouched, and any package.json edits were confined to non-dependency fields such as `scripts`.' >> "$GITHUB_STEP_SUMMARY"
 
   prepare-dependencies:
     name: Prepare Dependency Cache

--- a/tools/scripts/ci/dependency-manifest-changed.mjs
+++ b/tools/scripts/ci/dependency-manifest-changed.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+/**
+ * Decides whether a pull request actually changes dependencies.
+ *
+ * `Secure Install Review` used to gate `yarn npm audit` on the *path*
+ * `package.json` changing. That is a poor proxy: editing a `scripts` entry is
+ * not a dependency change, but it triggered a full audit — and because the
+ * audit queries the live advisory database, an unrelated PR could go red
+ * overnight through no fault of its own.
+ *
+ * This narrows the trigger to *content*. Coverage of real dependency changes is
+ * unchanged: `yarn.lock` and `.yarnrc.yml` still always trigger, and any
+ * dependency-bearing field in any workspace manifest still triggers. Note the
+ * old check only looked at the root `package.json`; this one looks at every
+ * manifest in the repo, so it is strictly broader on that axis.
+ *
+ * Prints `true` or `false` on stdout. Exits non-zero only on internal error —
+ * callers should treat a failure as "audit anyway" rather than "skip".
+ *
+ * Usage:
+ *   node tools/scripts/ci/dependency-manifest-changed.mjs <baseSha> <headSha>
+ */
+
+import { execFileSync } from 'node:child_process';
+import process from 'node:process';
+
+/** Manifest fields that can change what gets installed. */
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+  'peerDependenciesMeta',
+  'dependenciesMeta',
+  'resolutions',
+  'overrides',
+  'packageManager',
+  'workspaces',
+  'bundledDependencies',
+  'bundleDependencies',
+];
+
+/** Files whose change always warrants an audit, regardless of content. */
+const ALWAYS_AUDIT = new Set(['yarn.lock', '.yarnrc.yml']);
+
+const MANIFEST_RE = /(^|\/)package\.json$/;
+
+function git(args) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+/** Returns the parsed manifest at `ref:path`, or null when absent/unparseable. */
+function manifestAt(ref, path) {
+  let raw;
+  try {
+    raw = git(['show', `${ref}:${path}`]);
+  } catch {
+    return null; // added or deleted on one side
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // A manifest we cannot parse is not something to reason about — let the
+    // caller audit rather than silently skipping.
+    throw new Error(`Unparseable JSON at ${ref}:${path}`);
+  }
+}
+
+function dependencySlice(manifest) {
+  if (!manifest) return null;
+  const slice = {};
+  for (const field of DEPENDENCY_FIELDS) {
+    if (manifest[field] !== undefined) slice[field] = manifest[field];
+  }
+  return slice;
+}
+
+/** Stable stringify so key reordering alone is not treated as a change. */
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+function main() {
+  const [baseSha, headSha] = process.argv.slice(2);
+  if (!baseSha || !headSha) {
+    process.stderr.write(
+      'Usage: dependency-manifest-changed.mjs <baseSha> <headSha>\n',
+    );
+    process.exit(2);
+  }
+
+  const changed = git([
+    'diff',
+    '--name-only',
+    '--diff-filter=ACDMRT',
+    baseSha,
+    headSha,
+  ])
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const reasons = [];
+
+  for (const file of changed) {
+    if (ALWAYS_AUDIT.has(file)) reasons.push(`${file} changed`);
+  }
+
+  if (!reasons.length) {
+    for (const file of changed.filter((f) => MANIFEST_RE.test(f))) {
+      const before = canonical(dependencySlice(manifestAt(baseSha, file)));
+      const after = canonical(dependencySlice(manifestAt(headSha, file)));
+      if (before !== after) reasons.push(`${file} dependency fields changed`);
+    }
+  }
+
+  const shouldAudit = reasons.length > 0;
+  for (const reason of reasons)
+    process.stderr.write(`audit reason: ${reason}\n`);
+  if (!shouldAudit) {
+    process.stderr.write(
+      'no dependency-bearing changes detected (manifest edits, if any, were to non-dependency fields)\n',
+    );
+  }
+  process.stdout.write(shouldAudit ? 'true\n' : 'false\n');
+}
+
+try {
+  main();
+} catch (error) {
+  // Fail loud: the workflow treats a non-zero exit as "audit anyway".
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Why

`Secure Install Review` decided whether to run `yarn npm audit` by grepping the diff for the *path* `package.json`:

```bash
if printf '%s\n' "$changed_files" | grep -Eq '^(package\.json|yarn\.lock|\.yarnrc\.yml)$'; then
```

That is a poor proxy for "this PR changes dependencies". Adding a `scripts` entry triggers a full dependency audit. And because `yarn npm audit` queries the **live** advisory database, an unrelated PR can go red overnight through no fault of its own.

That is exactly what happened to #282 — a docs-and-tooling refactor whose only manifest change was one line in `scripts`. It tripped the audit and failed on four advisories published that morning, none of them related to the PR.

## What changed

The grep is replaced by `tools/scripts/ci/dependency-manifest-changed.mjs`, which compares the **dependency-bearing fields** of every changed manifest between base and head:

`dependencies` · `devDependencies` · `peerDependencies` · `optionalDependencies` · `peerDependenciesMeta` · `dependenciesMeta` · `resolutions` · `overrides` · `packageManager` · `workspaces` · `bundledDependencies`

Comparison is over a canonical stringify, so reordering keys is not treated as a change.

## This does not weaken the gate

- `yarn.lock` and `.yarnrc.yml` still **always** trigger, regardless of content.
- Every workspace manifest is now inspected. The old grep was anchored with `^…$` to the **root** `package.json`, so a dependency edit in `apps/mobile/package.json` matched only indirectly via `yarn.lock`. This is strictly **broader** on that axis.
- A detector failure falls back to **running** the audit, never to skipping it, and emits a `::warning`.
- Pushes to `main` are unaffected — that path already audits unconditionally (`github.event_name != 'pull_request'`).

In short: it can only skip when nothing that affects installed packages changed.

## Verification

Real branches:

| Diff | Result |
| --- | --- |
| `main` → #282 (scripts-only edit) | `false` — correctly skips |
| `main` → #283 (resolutions + lockfile) | `true` — correctly audits |

Synthetic commits:

| Case | Expected | Got |
| --- | --- | --- |
| `scripts` entry added | false | false |
| root `dependencies` entry added | true | true |
| workspace `dependencies` entry added (`apps/mobile`) | true | true |
| `dependencies` keys reordered, no value change | false | false |
| `yarn.lock` touched | true | true |

Workflow YAML re-parsed and the `Run Yarn npm audit` condition confirmed unchanged.

## Relationship to the other PRs

- #283 fixes the advisories themselves and should merge first — it unblocks `main`, which this PR does not (and should not) affect.
- #282 is the docs refactor that surfaced this. It will pass once #283 lands; this PR stops the same class of false failure recurring.
