### PR TITLE
fix(graphify): repair the MCP server setup and auto-refresh the graph on commit

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,89 @@
+# Refresh the Graphify knowledge graph after commits that touch code.
+# Background, AST-only, no network egress. See docs/graphify.md.
+#
+# This hook is a deliberate no-op for anyone who has not installed graphify,
+# so it is safe to ship to every contributor. Opt out at any time with
+# GRAPHIFY_SKIP_HOOK=1.
+
+if [ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ]; then
+  exit 0
+fi
+
+# Locate graphify. `uv tool install` drops it in ~/.local/bin, which is not
+# always on PATH for hooks launched from a GUI client, so check there too.
+GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+if [ -z "$GRAPHIFY_BIN" ] && [ -x "$HOME/.local/bin/graphify" ]; then
+  GRAPHIFY_BIN="$HOME/.local/bin/graphify"
+fi
+if [ -z "$GRAPHIFY_BIN" ]; then
+  exit 0
+fi
+
+# Only the primary checkout owns graphify-out/. Linked worktrees under
+# .claude/worktrees/ share core.hooksPath, so without this guard a commit in
+# any worktree writes a rogue delta-only graph and races the primary checkout.
+# A linked worktree has git-dir != git-common-dir; both are resolved to
+# absolute first, because git can hand back an absolute GIT_DIR alongside a
+# relative ".git" common dir and a raw compare would skip the primary too.
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+  exit 0
+fi
+
+# Never rebuild mid-rebase/merge/cherry-pick: the rebuild would leave unstaged
+# output and block `--continue`.
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+for _state in "$GIT_DIR/rebase-merge" "$GIT_DIR/rebase-apply"; do
+  if [ -d "$_state" ]; then
+    exit 0
+  fi
+done
+for _state in "$GIT_DIR/MERGE_HEAD" "$GIT_DIR/CHERRY_PICK_HEAD"; do
+  if [ -f "$_state" ]; then
+    exit 0
+  fi
+done
+
+# Refresh an existing graph only. The first build needs an LLM pass for docs and
+# images, so it stays manual — see the Build / refresh section of docs/graphify.md.
+if [ ! -d graphify-out ]; then
+  exit 0
+fi
+
+# Only when committed source under apps/ or libs/ changed. Doc and image changes
+# are intentionally ignored here so a commit never triggers an LLM call; refresh
+# those by hand.
+CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null)
+if ! printf '%s\n' "$CHANGED" | grep -qE '^(apps|libs)/.*\.(ts|tsx|js|jsx|mjs|cjs)$'; then
+  exit 0
+fi
+
+# networkx louvain iterates string-keyed sets whose order is randomised per
+# process, so community ids churn between runs. Pinning this keeps the graph
+# reproducible instead of drifting a few nodes on every rebuild.
+export PYTHONHASHSEED=0
+export GRAPHIFY_OUT=graphify-out
+
+# Git for Windows hooks can inherit fragile pipe handles from GUI clients and
+# agent shells; keep the rebuild sequential there unless told otherwise.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+  export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$GRAPHIFY_LOG")"
+
+# Detached, with stdin and both streams off the hook's pipes, so `git commit`
+# returns immediately instead of waiting on a ~40s rebuild.
+echo "[graphify] code changed - refreshing graph in background (log: $GRAPHIFY_LOG)"
+# --backend claude-cli is pinned deliberately. Without it graphify picks
+# "whichever API key is set", which with ANTHROPIC_BASE_URL exported would send
+# source through an external endpoint. claude-cli keeps the rebuild local.
+nohup sh -c "
+  '$GRAPHIFY_BIN' extract apps --backend claude-cli &&
+  '$GRAPHIFY_BIN' extract libs --backend claude-cli &&
+  '$GRAPHIFY_BIN' merge-graphs apps/graphify-out/graph.json libs/graphify-out/graph.json --out graphify-out/graph.json
+" >"$GRAPHIFY_LOG" 2>&1 </dev/null &
+
+exit 0

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -70,6 +70,8 @@ This is a per-developer machine setup step, not a repo change — nothing here i
 Verify the whole chain with `graphify --version` (should match the warning-free CLI output)
 and `claude mcp list` (should report `graphify: … ✔ Connected`).
 
+### Build the graph
+
 ```pwsh
 # Full rebuild (per-package extract + merge + cluster + label), zero external egress.
 # Uses --backend claude-cli, which routes doc/image semantic extraction through the local

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -90,5 +90,34 @@ graphify extract libs --backend claude-cli
 graphify merge-graphs apps/graphify-out/graph.json libs/graphify-out/graph.json --out graphify-out/graph.json
 ```
 
-> **Maintenance reality:** there is no commit hook wiring this up. The graph reflects the
-> last manual build. Rebuild before relying on it for a fresh area of the code.
+## Automatic refresh on commit
+
+`.husky/post-commit` runs the incremental refresh above in the background after any commit that
+touches `.ts/.tsx/.js/.jsx/.mjs/.cjs` under `apps/` or `libs/`. `git commit` returns immediately;
+progress goes to `~/.cache/graphify-rebuild.log`.
+
+It is a **no-op unless you have opted in** by installing graphify and building the graph once by
+hand, so it costs nothing for contributors who do not use it. Specifically, it exits early when:
+
+| Condition                                        | Why                                                                                                                               |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `graphify` is not on `PATH` or in `~/.local/bin` | Most contributors never install it                                                                                                |
+| `graphify-out/` does not exist                   | The first build needs an LLM pass — keep it manual                                                                                |
+| The commit touched no `apps/`/`libs/` source     | Doc and image changes must never trigger an LLM call from a hook                                                                  |
+| You are in a linked worktree                     | `graphify-out/` belongs to the primary checkout; rebuilding from a worktree writes a rogue delta-only graph and races the primary |
+| A rebase, merge, or cherry-pick is in progress   | A rebuild mid-sequence leaves unstaged output and blocks `--continue`                                                             |
+| `GRAPHIFY_SKIP_HOOK=1` is set                    | Explicit opt-out                                                                                                                  |
+
+Two environment settings in the hook are load-bearing, so do not drop them when editing it:
+
+- `PYTHONHASHSEED=0` — networkx's louvain clustering iterates string-keyed sets whose order is
+  randomised per process. Unpinned, repeated no-op refreshes were observed drifting
+  (2,965 → 2,967 → 2,968 nodes); pinned, consecutive no-op refreshes hold steady at the same node
+  and edge count. Without it you cannot tell a real change from clustering noise.
+- `--backend claude-cli` — pinned on purpose. Without it graphify selects "whichever API key is
+  set", and with `ANTHROPIC_BASE_URL` exported that would send source to an external endpoint.
+  `claude-cli` keeps the rebuild local.
+
+> **Maintenance reality:** the hook only covers **code**. Docs, images, community clustering, and
+> the domain names in `GRAPH_REPORT.md` still need the manual `cluster-only` + `label` pass above.
+> Rebuild by hand before relying on the report for a fresh area of the code.

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -42,9 +42,33 @@ rebuild + staleness cost. Keep it only if it earns a clear `helped` track record
 The graph is **not committed** (it's generated and goes stale). Build it once locally; the
 `graphify` MCP server in `.mcp.json` then serves `graphify-out/graph.json`.
 
-Prerequisite: `uv tool install graphifyy --with mcp` (provides `graphify` + `graphify-mcp`).
-The `--with mcp` extra is **required** — without it `graphify-mcp` crashes with
+Prerequisite: `uv tool install "graphifyy[mcp]"` (provides `graphify` + `graphify-mcp`).
+The `mcp` extra is **required** — without it `graphify-mcp` crashes with
 `ModuleNotFoundError: No module named 'mcp'` and the MCP server in `.mcp.json` won't start.
+Installing it via the `[mcp]` extra records `extras = ["mcp"]` in the uv receipt, so a later
+`uv tool upgrade graphifyy` keeps it. Installing plain `graphifyy` drops the extra and silently
+re-breaks the MCP server — the symptom in Claude Code is
+`graphify: … ✘ Failed to connect — MCP error -32000: Connection closed`.
+
+### Resync the skill after any version change
+
+The `/graphify` skill under `~/.claude/skills/graphify/` is written by the CLI and is
+**pinned to the version that wrote it**. Upgrading the package does not update it, so the two
+drift apart and the CLI starts every command with:
+
+```
+warning: skill is from graphify 0.9.16, package is 0.9.37. Run 'graphify install' to update.
+```
+
+After **any** install, upgrade, or reinstall of `graphifyy`, resync it:
+
+```pwsh
+graphify install --platform claude   # rewrites ~/.claude/skills/graphify/{SKILL.md,references/}
+```
+
+This is a per-developer machine setup step, not a repo change — nothing here is committed.
+Verify the whole chain with `graphify --version` (should match the warning-free CLI output)
+and `claude mcp list` (should report `graphify: … ✔ Connected`).
 
 ```pwsh
 # Full rebuild (per-package extract + merge + cluster + label), zero external egress.


### PR DESCRIPTION
## Why

The `graphify` MCP server had stopped connecting entirely — Claude Code reported
`✘ Failed to connect — MCP error -32000: Connection closed`. Diagnosing it turned up three
separate problems, all setup drift rather than code defects:

1. `graphifyy` had been installed **without the `mcp` extra**, so `graphify-mcp` died on startup
   with `ModuleNotFoundError: No module named 'mcp'`. `docs/graphify.md` warned about this but
   recommended `--with mcp`, which is easy to lose on a reinstall.
2. Repairing that bumped the package `0.9.16 → 0.9.37`, leaving the `/graphify` skill pinned to the
   old version. The CLI warns on every command, but nothing documented the fix.
3. The graph was **71 commits stale** and only ever refreshed by hand, so it rotted silently
   between manual rebuilds.

Fixes 1 and 2 were machine-level and are already applied; this PR documents them so the next
person can self-serve. Fix 3 is the hook.

## What changed

**`docs/graphify.md`**

- Prerequisite is now `uv tool install "graphifyy[mcp]"`. The extra is recorded in the uv receipt
  as `extras = ["mcp"]`, so `uv tool upgrade graphifyy` preserves it; plain `graphifyy` silently
  drops it and re-breaks the server. The Claude Code symptom is spelled out so the error text is
  greppable.
- New **"Resync the skill after any version change"** section covering
  `graphify install --platform claude`, plus the two commands that verify the chain end to end.
- New **"Automatic refresh on commit"** section documenting the hook, its six early-exit
  conditions, and why two of its settings are load-bearing.

**`.husky/post-commit`** (new)

Runs the already-documented incremental flow — `extract apps`, `extract libs`, `merge-graphs` —
detached, so `git commit` returns immediately while the ~40s rebuild finishes in the background.
Progress goes to `~/.cache/graphify-rebuild.log`.

## Why not graphify's own hook installer

Graphify ships `graphify hook install`, and it is well built — it is Husky-9 aware, guards against
linked worktrees, and detaches properly. But it rebuilds at the **repo root**, whereas this repo
extracts `apps` and `libs` separately and merges them, tagging every node with its package
(`libs: 2178, apps: 789`, ids like `apps::config_http`). Adopting it would have silently replaced
the graph with a differently shaped one. The hook here runs our three documented commands and
borrows only the upstream hardening.

GitHub Actions was considered and rejected: the consumer is a **local** MCP server reading a local,
gitignored `graphify-out/graph.json`, so a CI-built graph is an artifact nothing consumes. Making
it useful would mean either committing the graph (which this doc explicitly rejects) or adding a
manual download step — more friction than the local rebuild it replaces.

## Safety — the hook is inert unless you opt in

It exits early when graphify is not installed, when `graphify-out/` was never built, when the
commit touched no `apps/`/`libs/` source, inside a linked worktree, during a
rebase/merge/cherry-pick, or under `GRAPHIFY_SKIP_HOOK=1`. Contributors who do not use graphify
pay nothing. Doc and image changes are deliberately excluded so a commit can never trigger an LLM
call.

Two pinned settings are load-bearing:

- **`PYTHONHASHSEED=0`** — unpinned, repeated no-op refreshes drifted (2,965 → 2,967 → 2,968 nodes)
  because louvain clustering is hash-order dependent. Pinned, consecutive no-op refreshes hold
  steady at 2,968 / 5,626.
- **`--backend claude-cli`** — unset, graphify picks "whichever API key is set", and
  `ANTHROPIC_BASE_URL` is exported on at least one dev machine, which would have sent source to an
  external endpoint. This keeps the rebuild local.

## Verification

- `claude mcp list` → `graphify: … ✔ Connected` from both the primary checkout and a linked worktree.
- Incremental refresh: **2,072 → 2,965 nodes, 4,083 → 5,603 edges** (now 2,968 / 5,626).
- `get_neighbors YouTubeSyncService` returned `decryptAccessToken` at L676 and `decryptRefreshToken`
  at L691 — both line numbers match `apps/backend/src/services/YouTubeSyncService.ts` exactly.
- Hook: `sh -n` clean; worktree guard verified to skip in a worktree and proceed in the primary
  checkout; the change filter verified to skip the docs-only commits on this branch and fire on
  four real code commits; the detached launch verified to return in 0s and complete the full
  extract → extract → merge chain in the background.

`graphify-out/` is gitignored, so no graph artifacts are in this PR.

## Follow-up

#292 — SQL files and 7 parse-error files are silently missing from the graph. Pre-existing,
unrelated to this fix, and needs a judgement call on whether migrations are worth graphing.

## Known limit left as-is

In a linked worktree the MCP server connects but every call returns `graph.json not found`;
`.mcp.json` uses a relative path and the graph is per-checkout. Run graphify queries from the
primary checkout. The hook skips worktrees for the same reason.
