### PR TITLE
fix(graphify): graduate from probation and make the agent wiring survive sync

### DIFF
--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -42,8 +42,43 @@ Which sections of the Explore Summary matter most for this request.
 
 1. Read `DEVELOPMENT.md` first to understand the monorepo structure.
 2. Start with Known Locations if provided — do not start from scratch when hints exist.
-3. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
-4. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+3. If the Goal is a relationship question ("what calls / imports / consumes X?"), query the Graphify index before grepping — see below.
+4. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
+5. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+
+## Graphify structural index (MCP)
+
+A pre-built AST knowledge graph of `apps/` and `libs/` is served over MCP from
+`graphify-out/graph.json`, refreshed automatically on commit. It came off probation on 2026-08-12 as
+a **permanent tool for two question shapes only**. Full rationale and evidence: `docs/graphify.md`.
+
+**Use it before grep, for exactly these two:**
+
+- _"What calls / imports / consumes symbol X?"_ → `get_neighbors`. Returns callers, importers and
+  callees with `file:line`, in about a second, at zero token cost.
+- _"What are the core abstractions here?"_ → `god_nodes`. A hub map for orienting in unfamiliar code.
+
+`query_graph` is a fallback for a broad "what relates to X" sweep when you have no exact symbol.
+
+**Never use it for these. It answers wrongly or emptily, and it does so silently:**
+
+| Question shape                                                                           | What actually happens                                                                                                           | Use instead                                           |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Cross-package or cross-HTTP-boundary impact ("what breaks if `VaultController` changes") | No edge spans the OpenAPI/codegen seam, so you get an empty result that reads as "nothing is affected"                          | `nx affected --files=<path>`                          |
+| Blast radius of a TypeScript **type**                                                    | Type references are not edges; the node reports degree ≈ 1                                                                      | `Grep`                                                |
+| Any symbol whose name occurs in more than one file                                       | `get_node` returns one arbitrary match **without saying it substituted** — asking for `EncryptedBlob` returns `EncryptedBlobV1` | `query_graph`, then disambiguate by reading the files |
+| Which fields or members a type has                                                       | Members are not nodes                                                                                                           | `Read` the type definition                            |
+| Database or schema questions                                                             | `**/*.sql` is excluded by design                                                                                                | `apps/backend/src/prisma/schema.prisma`               |
+| Ranking PRs or slices by review risk                                                     | Blast radius counts the changed file's own community, not its dependents, so it inverts risk for hub and barrel files           | `nx affected`                                         |
+
+**Trust rule.** Tag every graph-derived fact `[inferred]` until you confirm the exact location with
+`Read`/`Grep`, then upgrade it to `[found]` with the `file:line` citation. If the graphify tools are
+unavailable, fall back to Glob/Grep silently — an unbuilt graph is the normal state for anyone who
+has not opted in, not an error worth reporting.
+
+**Claude Code —** the tools are `mcp__graphify__get_neighbors`, `mcp__graphify__god_nodes`,
+`mcp__graphify__query_graph`, `mcp__graphify__get_node` and `mcp__graphify__graph_stats`, granted in
+this agent's `tools:` and registered in `.mcp.json`.
 
 ## Evidence Tagging
 

--- a/.cursor/agents/explore.md
+++ b/.cursor/agents/explore.md
@@ -37,8 +37,43 @@ Which sections of the Explore Summary matter most for this request.
 
 1. Read `DEVELOPMENT.md` first to understand the monorepo structure.
 2. Start with Known Locations if provided — do not start from scratch when hints exist.
-3. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
-4. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+3. If the Goal is a relationship question ("what calls / imports / consumes X?"), query the Graphify index before grepping — see below.
+4. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
+5. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+
+## Graphify structural index (MCP)
+
+A pre-built AST knowledge graph of `apps/` and `libs/` is served over MCP from
+`graphify-out/graph.json`, refreshed automatically on commit. It came off probation on 2026-08-12 as
+a **permanent tool for two question shapes only**. Full rationale and evidence: `docs/graphify.md`.
+
+**Use it before grep, for exactly these two:**
+
+- _"What calls / imports / consumes symbol X?"_ → `get_neighbors`. Returns callers, importers and
+  callees with `file:line`, in about a second, at zero token cost.
+- _"What are the core abstractions here?"_ → `god_nodes`. A hub map for orienting in unfamiliar code.
+
+`query_graph` is a fallback for a broad "what relates to X" sweep when you have no exact symbol.
+
+**Never use it for these. It answers wrongly or emptily, and it does so silently:**
+
+| Question shape                                                                           | What actually happens                                                                                                           | Use instead                                           |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Cross-package or cross-HTTP-boundary impact ("what breaks if `VaultController` changes") | No edge spans the OpenAPI/codegen seam, so you get an empty result that reads as "nothing is affected"                          | `nx affected --files=<path>`                          |
+| Blast radius of a TypeScript **type**                                                    | Type references are not edges; the node reports degree ≈ 1                                                                      | `Grep`                                                |
+| Any symbol whose name occurs in more than one file                                       | `get_node` returns one arbitrary match **without saying it substituted** — asking for `EncryptedBlob` returns `EncryptedBlobV1` | `query_graph`, then disambiguate by reading the files |
+| Which fields or members a type has                                                       | Members are not nodes                                                                                                           | `Read` the type definition                            |
+| Database or schema questions                                                             | `**/*.sql` is excluded by design                                                                                                | `apps/backend/src/prisma/schema.prisma`               |
+| Ranking PRs or slices by review risk                                                     | Blast radius counts the changed file's own community, not its dependents, so it inverts risk for hub and barrel files           | `nx affected`                                         |
+
+**Trust rule.** Tag every graph-derived fact `[inferred]` until you confirm the exact location with
+`Read`/`Grep`, then upgrade it to `[found]` with the `file:line` citation. If the graphify tools are
+unavailable, fall back to Glob/Grep silently — an unbuilt graph is the normal state for anyone who
+has not opted in, not an error worth reporting.
+
+**Cursor —** the tools are the `graphify` MCP server's `get_neighbors`, `god_nodes`, `query_graph`,
+`get_node` and `graph_stats`, registered in `.cursor/mcp.json`. Cursor subagents inherit the parent
+agent's tools and have no per-agent `tools:` grant of their own.
 
 ## Evidence Tagging
 

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "graphify": {
+      "type": "stdio",
+      "command": "graphify-mcp",
+      "args": ["graphify-out/graph.json"],
+      "env": {}
+    }
+  }
+}

--- a/.cursor/rules/sub-agent-sync-workflow.mdc
+++ b/.cursor/rules/sub-agent-sync-workflow.mdc
@@ -37,6 +37,25 @@ Run the sync workflow after any of these:
 4. Prune extra harness files when canonical file no longer exists (default apply behavior).
 5. Model frontmatter must match `tools/config/agent-model-policy.json`.
 6. `CodeExplorer` in Cursor must stay `model: composer-2.5`.
+7. Never hand-edit an instruction into `.cursor/agents/**` — the next apply regenerates the body from
+   canonical and the edit is lost. Put it in canonical instead.
+
+## Harness-Specific Body Sections
+
+Canonical bodies may scope a section to particular harnesses:
+
+```markdown
+<!-- harness:cursor -->
+Rendered only into .cursor/agents/.
+<!-- /harness -->
+```
+
+- Valid names: `claude`, `copilot`, `cursor`, `gemini`. Unmarked content goes everywhere.
+- Markers sit alone on their own line and must not nest; violations are hard errors.
+- Use it for genuinely per-harness facts, mainly MCP tool names. Cursor subagents inherit the parent
+  agent's tools, so Cursor has no per-agent `tools:` grant to describe — only server names from
+  `.cursor/mcp.json`.
+- Implementation: `tools/scripts/lib/harness-sections.mjs`; tests via `yarn agents:sync:test`.
 
 ## Model Policy
 

--- a/.gemini/agents/explore.md
+++ b/.gemini/agents/explore.md
@@ -10,6 +10,7 @@ tools:
   - read_file
   - list_files
   - search_files
+  - mcp_graphify_*
 ---
 
 You are CodeExplorer, a read-only codebase exploration specialist for the MyOrganizer Nx monorepo. Your sole responsibility is to answer the main agent's question about the codebase and return a structured Explore Summary. You do NOT write or modify any files.
@@ -45,8 +46,45 @@ Which sections of the Explore Summary matter most for this request.
 
 1. Read `DEVELOPMENT.md` first to understand the monorepo structure.
 2. Start with Known Locations if provided — do not start from scratch when hints exist.
-3. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
-4. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+3. If the Goal is a relationship question ("what calls / imports / consumes X?"), query the Graphify index before grepping — see below.
+4. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
+5. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+
+## Graphify structural index (MCP)
+
+A pre-built AST knowledge graph of `apps/` and `libs/` is served over MCP from
+`graphify-out/graph.json`, refreshed automatically on commit. It came off probation on 2026-08-12 as
+a **permanent tool for two question shapes only**. Full rationale and evidence: `docs/graphify.md`.
+
+**Use it before grep, for exactly these two:**
+
+- _"What calls / imports / consumes symbol X?"_ → `get_neighbors`. Returns callers, importers and
+  callees with `file:line`, in about a second, at zero token cost.
+- _"What are the core abstractions here?"_ → `god_nodes`. A hub map for orienting in unfamiliar code.
+
+`query_graph` is a fallback for a broad "what relates to X" sweep when you have no exact symbol.
+
+**Never use it for these. It answers wrongly or emptily, and it does so silently:**
+
+| Question shape                                                                           | What actually happens                                                                                                           | Use instead                                           |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Cross-package or cross-HTTP-boundary impact ("what breaks if `VaultController` changes") | No edge spans the OpenAPI/codegen seam, so you get an empty result that reads as "nothing is affected"                          | `nx affected --files=<path>`                          |
+| Blast radius of a TypeScript **type**                                                    | Type references are not edges; the node reports degree ≈ 1                                                                      | `Grep`                                                |
+| Any symbol whose name occurs in more than one file                                       | `get_node` returns one arbitrary match **without saying it substituted** — asking for `EncryptedBlob` returns `EncryptedBlobV1` | `query_graph`, then disambiguate by reading the files |
+| Which fields or members a type has                                                       | Members are not nodes                                                                                                           | `Read` the type definition                            |
+| Database or schema questions                                                             | `**/*.sql` is excluded by design                                                                                                | `apps/backend/src/prisma/schema.prisma`               |
+| Ranking PRs or slices by review risk                                                     | Blast radius counts the changed file's own community, not its dependents, so it inverts risk for hub and barrel files           | `nx affected`                                         |
+
+**Trust rule.** Tag every graph-derived fact `[inferred]` until you confirm the exact location with
+`Read`/`Grep`, then upgrade it to `[found]` with the `file:line` citation. If the graphify tools are
+unavailable, fall back to Glob/Grep silently — an unbuilt graph is the normal state for anyone who
+has not opted in, not an error worth reporting.
+
+**Gemini CLI —** the tools are `mcp_graphify_get_neighbors`, `mcp_graphify_god_nodes`,
+`mcp_graphify_query_graph`, `mcp_graphify_get_node` and `mcp_graphify_graph_stats`, registered in
+`.gemini/settings.json`. Gemini CLI has an open bug where subagents do not always receive MCP tools
+(google-gemini/gemini-cli#17005, #19599); if they are missing, use Glob/Grep and do not report it as
+a failure.
 
 ## Evidence Tagging
 

--- a/.gemini/commands/sync-subagents.md
+++ b/.gemini/commands/sync-subagents.md
@@ -36,6 +36,26 @@ node tools/scripts/sync-subagents.mjs --apply --no-prune
 - Create missing files in `.claude/agents`, `.cursor/agents`, and `.gemini/agents`.
 - Remove target files with no canonical counterpart when pruning is enabled.
 - Ensure Cursor `CodeExplorer` remains `model: composer-2.5`.
+- Never hand-edit an instruction into `.gemini/agents/**`; the next apply regenerates the body from
+  canonical and the edit is lost. Put it in canonical instead.
+
+## Harness-specific body sections
+
+Canonical bodies may scope a section to particular harnesses:
+
+```markdown
+<!-- harness:gemini -->
+
+Rendered only into .gemini/agents/.
+
+<!-- /harness -->
+```
+
+- Valid names: `claude`, `copilot`, `cursor`, `gemini`. Unmarked content goes to every harness.
+- Markers sit alone on their own line and must not nest; violations are hard errors.
+- Main use is MCP tool naming. In Gemini CLI the fully qualified name is `mcp_<server>_<tool>`, and
+  `mcp_<server>_*` grants a whole server; servers are registered in `.gemini/settings.json`.
+- Implementation: `tools/scripts/lib/harness-sections.mjs`; test with `yarn agents:sync:test`.
 
 ## Model policy
 

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "graphify": {
+      "command": "graphify-mcp",
+      "args": ["graphify-out/graph.json"],
+      "includeTools": [
+        "query_graph",
+        "get_neighbors",
+        "get_node",
+        "god_nodes",
+        "graph_stats"
+      ]
+    }
+  }
+}

--- a/.github/agents/explore.agent.md
+++ b/.github/agents/explore.agent.md
@@ -1,7 +1,7 @@
 ---
 description: 'Read-only codebase exploration specialist for MyOrganizer. Delegate when the main agent would issue 3 or more consecutive file read/search operations to locate something in the codebase.'
 name: 'CodeExplorer'
-tools: [read, search]
+tools: [read, search, 'graphify/*']
 model: ['GPT-5.6 Luna (copilot)']
 user-invocable: false
 argument-hint: 'Explore Request with Goal (required) + optional Known Locations, Search Hints, Out of Scope, Expected Output'
@@ -40,8 +40,72 @@ Which sections of the Explore Summary matter most for this request.
 
 1. Read `DEVELOPMENT.md` first to understand the monorepo structure.
 2. Start with Known Locations if provided — do not start from scratch when hints exist.
-3. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
-4. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+3. If the Goal is a relationship question ("what calls / imports / consumes X?"), query the Graphify index before grepping — see below.
+4. Use your own judgment to look one level deeper into related files/folders when the direct search is insufficient to answer the Goal.
+5. Stop when you can answer the Goal confidently, or when you have clearly documented in Gaps why you cannot.
+
+## Graphify structural index (MCP)
+
+A pre-built AST knowledge graph of `apps/` and `libs/` is served over MCP from
+`graphify-out/graph.json`, refreshed automatically on commit. It came off probation on 2026-08-12 as
+a **permanent tool for two question shapes only**. Full rationale and evidence: `docs/graphify.md`.
+
+**Use it before grep, for exactly these two:**
+
+- _"What calls / imports / consumes symbol X?"_ → `get_neighbors`. Returns callers, importers and
+  callees with `file:line`, in about a second, at zero token cost.
+- _"What are the core abstractions here?"_ → `god_nodes`. A hub map for orienting in unfamiliar code.
+
+`query_graph` is a fallback for a broad "what relates to X" sweep when you have no exact symbol.
+
+**Never use it for these. It answers wrongly or emptily, and it does so silently:**
+
+| Question shape                                                                           | What actually happens                                                                                                           | Use instead                                           |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Cross-package or cross-HTTP-boundary impact ("what breaks if `VaultController` changes") | No edge spans the OpenAPI/codegen seam, so you get an empty result that reads as "nothing is affected"                          | `nx affected --files=<path>`                          |
+| Blast radius of a TypeScript **type**                                                    | Type references are not edges; the node reports degree ≈ 1                                                                      | `Grep`                                                |
+| Any symbol whose name occurs in more than one file                                       | `get_node` returns one arbitrary match **without saying it substituted** — asking for `EncryptedBlob` returns `EncryptedBlobV1` | `query_graph`, then disambiguate by reading the files |
+| Which fields or members a type has                                                       | Members are not nodes                                                                                                           | `Read` the type definition                            |
+| Database or schema questions                                                             | `**/*.sql` is excluded by design                                                                                                | `apps/backend/src/prisma/schema.prisma`               |
+| Ranking PRs or slices by review risk                                                     | Blast radius counts the changed file's own community, not its dependents, so it inverts risk for hub and barrel files           | `nx affected`                                         |
+
+**Trust rule.** Tag every graph-derived fact `[inferred]` until you confirm the exact location with
+`Read`/`Grep`, then upgrade it to `[found]` with the `file:line` citation. If the graphify tools are
+unavailable, fall back to Glob/Grep silently — an unbuilt graph is the normal state for anyone who
+has not opted in, not an error worth reporting.
+
+<!-- harness:claude -->
+
+**Claude Code —** the tools are `mcp__graphify__get_neighbors`, `mcp__graphify__god_nodes`,
+`mcp__graphify__query_graph`, `mcp__graphify__get_node` and `mcp__graphify__graph_stats`, granted in
+this agent's `tools:` and registered in `.mcp.json`.
+
+<!-- /harness -->
+
+<!-- harness:copilot -->
+
+**Copilot —** the tools are the `graphify` MCP server's, granted as `graphify/*` in this agent's
+`tools:` and registered in `.vscode/mcp.json`.
+
+<!-- /harness -->
+
+<!-- harness:cursor -->
+
+**Cursor —** the tools are the `graphify` MCP server's `get_neighbors`, `god_nodes`, `query_graph`,
+`get_node` and `graph_stats`, registered in `.cursor/mcp.json`. Cursor subagents inherit the parent
+agent's tools and have no per-agent `tools:` grant of their own.
+
+<!-- /harness -->
+
+<!-- harness:gemini -->
+
+**Gemini CLI —** the tools are `mcp_graphify_get_neighbors`, `mcp_graphify_god_nodes`,
+`mcp_graphify_query_graph`, `mcp_graphify_get_node` and `mcp_graphify_graph_stats`, registered in
+`.gemini/settings.json`. Gemini CLI has an open bug where subagents do not always receive MCP tools
+(google-gemini/gemini-cli#17005, #19599); if they are missing, use Glob/Grep and do not report it as
+a failure.
+
+<!-- /harness -->
 
 ## Evidence Tagging
 

--- a/.github/skills/sub-agent-sync-workflow/SKILL.md
+++ b/.github/skills/sub-agent-sync-workflow/SKILL.md
@@ -18,6 +18,43 @@ Synchronization means:
 3. Added or removed canonical agents are propagated to all target harnesses.
 4. Harness-specific frontmatter is preserved when file already exists.
 5. Missing files are created with harness defaults.
+6. Harness-specific **body** content lives in canonical, wrapped in `<!-- harness:... -->` markers.
+
+## Harness-Specific Body Sections
+
+The body is regenerated from canonical on every apply, so an instruction hand-written into a target
+file does not survive the next sync. This is not hypothetical: the Graphify probation instrumentation
+was added to `.claude/agents/explore.md` on 2026-06-19 and silently deleted on 2026-07-02 that way.
+
+When an instruction genuinely applies to only some harnesses — MCP tool names are the usual case,
+since the same server is `mcp__graphify__*` in Claude, `mcp_graphify_*` in Gemini, and `graphify/*`
+in Copilot — put it in **canonical**, wrapped in a marker:
+
+```markdown
+<!-- harness:claude -->
+
+Rendered only into .claude/agents/.
+
+<!-- /harness -->
+
+<!-- harness:claude,cursor -->
+
+Rendered into both.
+
+<!-- /harness -->
+```
+
+Rules:
+
+- Valid harness names: `claude`, `copilot`, `cursor`, `gemini`. `copilot` means `.github/agents`.
+- Unmarked content goes to every harness. Use markers sparingly — a shared body is the default.
+- Markers must sit alone on their own line and must not nest. Violations, unknown harness names, and
+  unbalanced markers are hard errors, not warnings: a marker that silently fails to apply
+  reintroduces the bug the mechanism exists to prevent.
+- `.github/agents` is canonical, not a render target, so Copilot reads the file with the markers
+  still in it and sees every block. Keep block contents short and self-labeling
+  (`**Claude Code —** ...`) so that reads as a reference table, not as contradictory instructions.
+- Implementation and tests: `tools/scripts/lib/harness-sections.mjs`, run with `yarn agents:sync:test`.
 
 ## Commands
 
@@ -25,6 +62,8 @@ Synchronization means:
   - `yarn agents:sync:check`
 - Apply sync and prune extras:
   - `yarn agents:sync`
+- Test the harness-section renderer:
+  - `yarn agents:sync:test`
 - Keep extra non-canonical files (rare):
   - `node tools/scripts/sync-subagents.mjs --apply --no-prune`
 
@@ -67,6 +106,7 @@ Run this workflow after any of the following:
 Before closing the task:
 
 - `yarn agents:sync:check` returns exit code 0.
+- `yarn agents:sync:test` passes if you touched the harness-section renderer or its markers.
 - `CodeExplorer` in Cursor remains `model: composer-2.5`.
 - Every harness model matches `tools/config/agent-model-policy.json`.
 - No canonical agent exists only in `.github/agents`.

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/mcp.json
 
 # misc
 /.sass-cache

--- a/.husky/graphify-refresh.sh
+++ b/.husky/graphify-refresh.sh
@@ -1,0 +1,94 @@
+# Shared body for the Graphify refresh hooks (post-commit, post-merge).
+# Background, AST-only, no network egress. See docs/graphify.md.
+#
+# The only thing that differs between the two hooks is how they name the set of
+# files that just changed, so the caller defines graphify_changed_files() —
+# printing one repo-relative path per line — and then sources this file.
+#
+# Every guard below exits the CALLING hook with 0. That is deliberate: a skipped
+# refresh must never fail the git operation that triggered it. The whole thing is
+# a no-op for anyone who has not installed graphify, so it is safe to ship to
+# every contributor. Opt out at any time with GRAPHIFY_SKIP_HOOK=1.
+
+if [ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ]; then
+  exit 0
+fi
+
+# Locate graphify. `uv tool install` drops it in ~/.local/bin, which is not
+# always on PATH for hooks launched from a GUI client, so check there too.
+GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+if [ -z "$GRAPHIFY_BIN" ] && [ -x "$HOME/.local/bin/graphify" ]; then
+  GRAPHIFY_BIN="$HOME/.local/bin/graphify"
+fi
+if [ -z "$GRAPHIFY_BIN" ]; then
+  exit 0
+fi
+
+# Only the primary checkout owns graphify-out/. Linked worktrees under
+# .claude/worktrees/ share core.hooksPath, so without this guard a commit in
+# any worktree writes a rogue delta-only graph and races the primary checkout.
+# A linked worktree has git-dir != git-common-dir; both are resolved to
+# absolute first, because git can hand back an absolute GIT_DIR alongside a
+# relative ".git" common dir and a raw compare would skip the primary too.
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+  exit 0
+fi
+
+# Never rebuild mid-rebase/merge/cherry-pick: the rebuild would leave unstaged
+# output and block `--continue`.
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+for _state in "$GIT_DIR/rebase-merge" "$GIT_DIR/rebase-apply"; do
+  if [ -d "$_state" ]; then
+    exit 0
+  fi
+done
+for _state in "$GIT_DIR/MERGE_HEAD" "$GIT_DIR/CHERRY_PICK_HEAD"; do
+  if [ -f "$_state" ]; then
+    exit 0
+  fi
+done
+
+# Refresh an existing graph only. The first build needs an LLM pass for docs and
+# images, so it stays manual — see the Build / refresh section of docs/graphify.md.
+if [ ! -d graphify-out ]; then
+  exit 0
+fi
+
+# Only when source under apps/ or libs/ changed. Doc and image changes are
+# intentionally ignored here so a hook never triggers an LLM call; refresh those
+# by hand.
+CHANGED=$(graphify_changed_files 2>/dev/null)
+if ! printf '%s\n' "$CHANGED" | grep -qE '^(apps|libs)/.*\.(ts|tsx|js|jsx|mjs|cjs)$'; then
+  exit 0
+fi
+
+# networkx louvain iterates string-keyed sets whose order is randomised per
+# process, so community ids churn between runs. Pinning this keeps the graph
+# reproducible instead of drifting a few nodes on every rebuild.
+export PYTHONHASHSEED=0
+export GRAPHIFY_OUT=graphify-out
+
+# Git for Windows hooks can inherit fragile pipe handles from GUI clients and
+# agent shells; keep the rebuild sequential there unless told otherwise.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+  export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$GRAPHIFY_LOG")"
+
+# Detached, with stdin and both streams off the hook's pipes, so the triggering
+# git command returns immediately instead of waiting on a ~40s rebuild.
+echo "[graphify] ${GRAPHIFY_TRIGGER:-code changed} - refreshing graph in background (log: $GRAPHIFY_LOG)"
+# --backend claude-cli is pinned deliberately. Without it graphify picks
+# "whichever API key is set", which with ANTHROPIC_BASE_URL exported would send
+# source through an external endpoint. claude-cli keeps the rebuild local.
+nohup sh -c "
+  '$GRAPHIFY_BIN' extract apps --backend claude-cli &&
+  '$GRAPHIFY_BIN' extract libs --backend claude-cli &&
+  '$GRAPHIFY_BIN' merge-graphs apps/graphify-out/graph.json libs/graphify-out/graph.json --out graphify-out/graph.json
+" >"$GRAPHIFY_LOG" 2>&1 </dev/null &
+
+exit 0

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,89 +1,12 @@
 # Refresh the Graphify knowledge graph after commits that touch code.
-# Background, AST-only, no network egress. See docs/graphify.md.
-#
-# This hook is a deliberate no-op for anyone who has not installed graphify,
-# so it is safe to ship to every contributor. Opt out at any time with
-# GRAPHIFY_SKIP_HOOK=1.
+# All the guards and the rebuild itself live in the shared script; this hook
+# only says which files count as "just changed". See docs/graphify.md.
 
-if [ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ]; then
-  exit 0
-fi
+graphify_changed_files() {
+  git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null
+}
 
-# Locate graphify. `uv tool install` drops it in ~/.local/bin, which is not
-# always on PATH for hooks launched from a GUI client, so check there too.
-GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
-if [ -z "$GRAPHIFY_BIN" ] && [ -x "$HOME/.local/bin/graphify" ]; then
-  GRAPHIFY_BIN="$HOME/.local/bin/graphify"
-fi
-if [ -z "$GRAPHIFY_BIN" ]; then
-  exit 0
-fi
+GRAPHIFY_TRIGGER="code changed"
+export GRAPHIFY_TRIGGER
 
-# Only the primary checkout owns graphify-out/. Linked worktrees under
-# .claude/worktrees/ share core.hooksPath, so without this guard a commit in
-# any worktree writes a rogue delta-only graph and races the primary checkout.
-# A linked worktree has git-dir != git-common-dir; both are resolved to
-# absolute first, because git can hand back an absolute GIT_DIR alongside a
-# relative ".git" common dir and a raw compare would skip the primary too.
-_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
-_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
-if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
-  exit 0
-fi
-
-# Never rebuild mid-rebase/merge/cherry-pick: the rebuild would leave unstaged
-# output and block `--continue`.
-GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
-for _state in "$GIT_DIR/rebase-merge" "$GIT_DIR/rebase-apply"; do
-  if [ -d "$_state" ]; then
-    exit 0
-  fi
-done
-for _state in "$GIT_DIR/MERGE_HEAD" "$GIT_DIR/CHERRY_PICK_HEAD"; do
-  if [ -f "$_state" ]; then
-    exit 0
-  fi
-done
-
-# Refresh an existing graph only. The first build needs an LLM pass for docs and
-# images, so it stays manual — see the Build / refresh section of docs/graphify.md.
-if [ ! -d graphify-out ]; then
-  exit 0
-fi
-
-# Only when committed source under apps/ or libs/ changed. Doc and image changes
-# are intentionally ignored here so a commit never triggers an LLM call; refresh
-# those by hand.
-CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null)
-if ! printf '%s\n' "$CHANGED" | grep -qE '^(apps|libs)/.*\.(ts|tsx|js|jsx|mjs|cjs)$'; then
-  exit 0
-fi
-
-# networkx louvain iterates string-keyed sets whose order is randomised per
-# process, so community ids churn between runs. Pinning this keeps the graph
-# reproducible instead of drifting a few nodes on every rebuild.
-export PYTHONHASHSEED=0
-export GRAPHIFY_OUT=graphify-out
-
-# Git for Windows hooks can inherit fragile pipe handles from GUI clients and
-# agent shells; keep the rebuild sequential there unless told otherwise.
-if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
-  export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
-fi
-
-GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
-mkdir -p "$(dirname "$GRAPHIFY_LOG")"
-
-# Detached, with stdin and both streams off the hook's pipes, so `git commit`
-# returns immediately instead of waiting on a ~40s rebuild.
-echo "[graphify] code changed - refreshing graph in background (log: $GRAPHIFY_LOG)"
-# --backend claude-cli is pinned deliberately. Without it graphify picks
-# "whichever API key is set", which with ANTHROPIC_BASE_URL exported would send
-# source through an external endpoint. claude-cli keeps the rebuild local.
-nohup sh -c "
-  '$GRAPHIFY_BIN' extract apps --backend claude-cli &&
-  '$GRAPHIFY_BIN' extract libs --backend claude-cli &&
-  '$GRAPHIFY_BIN' merge-graphs apps/graphify-out/graph.json libs/graphify-out/graph.json --out graphify-out/graph.json
-" >"$GRAPHIFY_LOG" 2>&1 </dev/null &
-
-exit 0
+. .husky/graphify-refresh.sh

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,26 @@
+# Refresh the Graphify knowledge graph after a merge or pull brings in code.
+#
+# post-commit does not cover this. `git merge` — which is what `git pull` runs —
+# never fires post-commit, not for a fast-forward (no commit is created at all)
+# and not for a merge commit (git merge writes it directly). So before this hook
+# existed, pulling other people's merged work left the graph a step behind until
+# your own next local commit happened to touch apps/ or libs/.
+#
+# All the guards and the rebuild itself live in the shared script; this hook only
+# says which files count as "just changed". See docs/graphify.md.
+
+graphify_changed_files() {
+  # git merge and git pull both set ORIG_HEAD to the pre-merge tip, which covers
+  # the fast-forward and merge-commit cases alike. HEAD@{1} is the fallback for
+  # the rare path where the reflog has the entry but ORIG_HEAD is unset.
+  if git rev-parse --verify --quiet ORIG_HEAD >/dev/null 2>&1; then
+    git diff --name-only ORIG_HEAD HEAD 2>/dev/null
+  else
+    git diff --name-only 'HEAD@{1}' HEAD 2>/dev/null
+  fi
+}
+
+GRAPHIFY_TRIGGER="merge brought in code"
+export GRAPHIFY_TRIGGER
+
+. .husky/graphify-refresh.sh

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,10 @@
+{
+  "servers": {
+    "graphify": {
+      "type": "stdio",
+      "command": "graphify-mcp",
+      "args": ["graphify-out/graph.json"],
+      "env": {}
+    }
+  }
+}

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -78,14 +78,71 @@ Two caveats worth keeping:
   "partially extracted" — an unknown subset of that file's symbols goes missing while the file still
   _looks_ covered. Re-run the scan before trusting the graph in a newly-touched area.
 
-## On probation — usage is measured
+## Graduated from probation — 2026-08-12
 
-This integration is **on probation**: a real-workflow spike showed an agent never invoked it
-directly and its contribution (buried inside CodeExplorer) was unmeasurable. So CodeExplorer now
-**queries Graphify first** for relationship questions and **logs the outcome** (`helped` /
-`redundant` / `wrong/missed`) in a `Graphify Usage` block on every run. If those logs show it is
-consistently `redundant` or `wrong/missed`, drop the integration — it is not worth the manual
-rebuild + staleness cost. Keep it only if it earns a clear `helped` track record.
+Probation is over. Graphify is a **permanent tool with a hard, narrow scope**: `get_neighbors` for
+"who calls / imports / consumes X", and `god_nodes` for orientation. Everything under "What it must
+NOT be used for" above is a standing ban, not a caution.
+
+Two things settled it.
+
+**The cost side collapsed.** The kill argument in `graphify-eval-notes.md` rested as much on
+maintenance — manual rebuilds, staleness — as on capability. #293 made the graph refresh on commit
+and #292 confirmed extraction is complete for authored `.ts`/`.tsx`. What is left costs close to
+nothing.
+
+**The capability side is unchanged, and was re-measured rather than assumed.** The original bar
+questions were re-run against the live graph on 2026-08-12 (2,853 nodes / 5,350 edges, 99%
+EXTRACTED):
+
+| Bar question                               | 2026-06-19         | 2026-08-12                                                    |
+| ------------------------------------------ | ------------------ | ------------------------------------------------------------- |
+| R3 — `get_neighbors saveEncryptedData`     | 🟢 degree 20       | 🟢 17 edges with `file:line`, ~1s, $0                         |
+| `god_nodes` hub map                        | 🟢                 | 🟢 `cn`, `Button`, `useToast`, `requireUserId`, `UserService` |
+| R1 — `get_node EncryptedBlob`              | 🔴 no unique match | 🔴 **silently returned `EncryptedBlobV1`**, degree 1          |
+| R5 — `VaultController` → `serverVaultSync` | 🔴 no path         | 🔴 "No directed path found"                                   |
+
+The shape of the tool is therefore settled and will not improve: the good half is reliable, and the
+bad half fails **silently**. R1 is the sharp case — asking for one symbol returns a _different_ one
+with no ambiguity warning. That is why the ban list is written into the agent as a table of question
+shapes rather than as general advice.
+
+**What this replaces.** The earlier probation required CodeExplorer to log a `helped` / `redundant` /
+`wrong-missed` verdict in a `Graphify Usage` block on every run. That instrumentation never actually
+ran: it was added 2026-06-19 and deleted 2026-07-02 by `yarn agents:sync`, because it lived only in
+`.claude/agents/explore.md` while the sync script regenerates every target body from canonical
+`.github/agents/`. It is **not** being restored — it charged a per-run token cost on a Haiku agent to
+keep re-deciding a question the table above answers.
+
+The scoping rules now live in canonical `.github/agents/explore.agent.md`, so they survive the sync.
+The harness-specific parts (tool names) use the `<!-- harness:... -->` mechanism documented in
+`.github/skills/sub-agent-sync-workflow/SKILL.md`.
+
+## Harness registration
+
+Registered in all four harnesses. The MCP server itself is harness-agnostic — plain stdio JSON-RPC —
+so only the registration differs, and the formats are **not** interchangeable. Each was checked
+against that harness's own docs rather than copied from `.mcp.json`.
+
+| Harness           | MCP config                              | Top-level key | Agent tool grant                                         |
+| ----------------- | --------------------------------------- | ------------- | -------------------------------------------------------- |
+| Claude Code       | `.mcp.json`                             | `mcpServers`  | `mcp__graphify__*` in `.claude/agents/explore.md`        |
+| Copilot / VS Code | `.vscode/mcp.json`                      | `servers`     | `graphify/*` in `.github/agents/explore.agent.md`        |
+| Cursor            | `.cursor/mcp.json`                      | `mcpServers`  | none — Cursor subagents inherit the parent agent's tools |
+| Gemini CLI        | `.gemini/settings.json` (project scope) | `mcpServers`  | `mcp_graphify_*` in `.gemini/agents/explore.md`          |
+
+Two caveats:
+
+- The Gemini entry uses `includeTools` to allowlist the same five read-only tools the other harnesses
+  grant, so `triage_prs` and `get_pr_impact` — which invert risk for hub and barrel files — are not
+  reachable there at all.
+- Gemini CLI has an open bug where subagents do not always receive MCP tools
+  (google-gemini/gemini-cli#17005, #19599). CodeExplorer is told to fall back to Glob/Grep silently,
+  so this degrades rather than breaks.
+
+All four share the same local prerequisite: `uv tool install "graphifyy[mcp]"` plus one manual graph
+build (below). Without it a harness simply has no graphify tools, which is the documented fallback
+path, not a failure.
 
 ## Build / refresh
 
@@ -142,11 +199,24 @@ graphify extract libs --backend claude-cli
 graphify merge-graphs apps/graphify-out/graph.json libs/graphify-out/graph.json --out graphify-out/graph.json
 ```
 
-## Automatic refresh on commit
+## Automatic refresh on commit and on merge
 
-`.husky/post-commit` runs the incremental refresh above in the background after any commit that
-touches `.ts/.tsx/.js/.jsx/.mjs/.cjs` under `apps/` or `libs/`. `git commit` returns immediately;
-progress goes to `~/.cache/graphify-rebuild.log`.
+Two hooks run the incremental refresh above in the background whenever
+`.ts/.tsx/.js/.jsx/.mjs/.cjs` under `apps/` or `libs/` changes. The triggering git command returns
+immediately; progress goes to `~/.cache/graphify-rebuild.log`.
+
+| Hook                 | Fires on                       | "Changed" means                                 |
+| -------------------- | ------------------------------ | ----------------------------------------------- |
+| `.husky/post-commit` | `git commit`                   | the files in `HEAD`                             |
+| `.husky/post-merge`  | `git merge`, and so `git pull` | `git diff ORIG_HEAD HEAD` (fallback `HEAD@{1}`) |
+
+`post-merge` exists because `post-commit` genuinely does not cover pulls: `git merge` never fires
+`post-commit` — not for a fast-forward, where no commit is created at all, and not for a merge
+commit, which `git merge` writes directly. Without it, pulling other people's merged work left the
+graph a step behind until your own next local commit happened to touch `apps/` or `libs/`.
+
+Everything except the definition of "changed" lives in `.husky/graphify-refresh.sh`, which both
+hooks source, so the guards below cannot drift apart between them.
 
 It is a **no-op unless you have opted in** by installing graphify and building the graph once by
 hand, so it costs nothing for contributors who do not use it. Specifically, it exits early when:
@@ -155,12 +225,12 @@ hand, so it costs nothing for contributors who do not use it. Specifically, it e
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | `graphify` is not on `PATH` or in `~/.local/bin` | Most contributors never install it                                                                                                |
 | `graphify-out/` does not exist                   | The first build needs an LLM pass — keep it manual                                                                                |
-| The commit touched no `apps/`/`libs/` source     | Doc and image changes must never trigger an LLM call from a hook                                                                  |
+| No `apps/`/`libs/` source changed                | Doc and image changes must never trigger an LLM call from a hook                                                                  |
 | You are in a linked worktree                     | `graphify-out/` belongs to the primary checkout; rebuilding from a worktree writes a rogue delta-only graph and races the primary |
 | A rebase, merge, or cherry-pick is in progress   | A rebuild mid-sequence leaves unstaged output and blocks `--continue`                                                             |
 | `GRAPHIFY_SKIP_HOOK=1` is set                    | Explicit opt-out                                                                                                                  |
 
-Two environment settings in the hook are load-bearing, so do not drop them when editing it:
+Two environment settings in the shared script are load-bearing, so do not drop them when editing it:
 
 - `PYTHONHASHSEED=0` — networkx's louvain clustering iterates string-keyed sets whose order is
   randomised per process. Unpinned, repeated no-op refreshes were observed drifting
@@ -170,6 +240,10 @@ Two environment settings in the hook are load-bearing, so do not drop them when 
   set", and with `ANTHROPIC_BASE_URL` exported that would send source to an external endpoint.
   `claude-cli` keeps the rebuild local.
 
-> **Maintenance reality:** the hook only covers **code**. Docs, images, community clustering, and
-> the domain names in `GRAPH_REPORT.md` still need the manual `cluster-only` + `label` pass above.
+> **Maintenance reality:** the hooks only cover **code**. Docs, images, community clustering, and the
+> domain names in `GRAPH_REPORT.md` still need the manual `cluster-only` + `label` pass above.
 > Rebuild by hand before relying on the report for a fresh area of the code.
+>
+> Branch switching is still uncovered: `git checkout` fires neither hook, so the graph reflects
+> whichever branch last triggered a rebuild. Confirm any graph result against the file, which the
+> agent rules already require.

--- a/graphify-eval-notes.md
+++ b/graphify-eval-notes.md
@@ -330,3 +330,43 @@ its AST-symbol model. Against this sits a real cost: manual rebuilds + staleness
 dependency, and an extra indirection in CodeExplorer. Per the documented kill criterion
 (consistent `redundant`/`wrong-missed` → drop it), the evidence now points to **KILL the
 adoption**. Tool verdict (no-go as primary exploration/impact engine) is unchanged and reinforced.
+
+## RESOLUTION (2026-08-12, issue #294) — GRADUATED, narrowly scoped
+
+The kill call above was never executed, and the probation it depended on never actually ran: the
+`Graphify Usage` instrumentation was deleted on 2026-07-02 by `yarn agents:sync` (it lived only in
+`.claude/agents/explore.md`; the sync script regenerates every target body from canonical
+`.github/agents/`). So the tally above — two spikes from a single day — remained the entire evidence
+base for six weeks.
+
+Two inputs changed the call:
+
+1. **The cost half of the kill argument is gone.** #293 refreshes the graph automatically on commit,
+   and #292 confirmed extraction is complete for authored `.ts`/`.tsx` (2 unparseable files, both
+   generated and gitignored, contributing 0 nodes). "Manual rebuilds + staleness" no longer weighs
+   much.
+2. **The capability half was re-measured, not assumed.** Bar questions re-run against the live graph
+   on 2026-08-12 (2,853 nodes / 5,350 edges, 99% EXTRACTED):
+
+| Q                                      | Result                                                                               |
+| -------------------------------------- | ------------------------------------------------------------------------------------ |
+| R3 `get_neighbors saveEncryptedData`   | 🟢 17 edges with `file:line` (callers, importers, callees), ~1s, $0                  |
+| `god_nodes`                            | 🟢 `cn` 40, `Button` 33, `useToast` 30, `requireUserId` 26, `UserService` 26         |
+| R1 `get_node EncryptedBlob`            | 🔴 returned **`EncryptedBlobV1`** — a different symbol — degree 1, no ambiguity flag |
+| R5 `VaultController → serverVaultSync` | 🔴 "No directed path found"                                                          |
+
+R1/R5 reproduce exactly, confirming they are AST-bounded and permanent. R1 is the worst shape: a
+silent substitution, not an error.
+
+**Decision:** graduate rather than kill, with the scope enforced instead of measured. The two green
+rows become the sanctioned uses; every red row becomes a written ban in the agent body, expressed as
+a table of question shapes with the tool to use instead. The per-run usage logging is dropped — it
+charged Haiku tokens on every exploration to keep re-litigating a settled question.
+
+Also decided: register the MCP in **all four** harnesses (Claude, Copilot/VS Code, Cursor, Gemini
+CLI) rather than Claude only, so the wiring is not Claude-specific evidence. Formats were verified
+per harness; they are not interchangeable. See `docs/graphify.md` § Harness registration.
+
+The restoration is durable this time because the rules live in canonical
+`.github/agents/explore.agent.md`, with harness-specific tool names carried by a new
+`<!-- harness:... -->` section mechanism in `tools/scripts/sync-subagents.mjs`.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ai:create-labels": "node tools/scripts/ai/create-labels.mjs",
     "agents:sync": "node tools/scripts/sync-subagents.mjs --apply && node tools/scripts/sync-agent-models.mjs --apply",
     "agents:sync:check": "node tools/scripts/sync-subagents.mjs --check && node tools/scripts/sync-agent-models.mjs --check",
+    "agents:sync:test": "node --test tools/scripts/lib/harness-sections.test.mjs",
     "agents:models:audit": "node tools/scripts/audit-agent-model-catalog.mjs",
     "agents:usage:report": "node tools/scripts/report-agent-usage.mjs",
     "dispatch-agents": "npx tsx .sandcastle/main.mts",

--- a/tools/scripts/lib/harness-sections.mjs
+++ b/tools/scripts/lib/harness-sections.mjs
@@ -1,0 +1,150 @@
+/**
+ * Per-harness body sections for canonical sub-agent files.
+ *
+ * `.github/agents/*.agent.md` is the canonical body for every harness, and the
+ * sync script overwrites each target's body from it wholesale. That is normally
+ * what we want — one body, four harnesses — but some instructions only make
+ * sense where a specific harness grants a specific tool. MCP tools are the
+ * motivating case: the same graphify server is called `mcp__graphify__*` in
+ * Claude Code, `mcp_graphify_*` in Gemini CLI, and `graphify/*` in Copilot.
+ *
+ * Writing those differences straight into a target file does not survive: the
+ * next `yarn agents:sync` regenerates the body from canonical and the edit is
+ * gone (this is exactly how the Graphify instrumentation was lost in 555fe1c).
+ * So canonical carries them, wrapped in markers, and each target renders only
+ * the blocks addressed to it:
+ *
+ *   <!-- harness:claude -->
+ *   Claude-only text.
+ *   <!-- /harness -->
+ *
+ *   <!-- harness:claude,cursor -->
+ *   Text for both.
+ *   <!-- /harness -->
+ *
+ * Unmarked content is universal. Markers must sit alone on their own line, and
+ * blocks must not nest — both are enforced with a hard error rather than a
+ * best-effort parse, because a marker that silently fails to apply reintroduces
+ * the bug this mechanism exists to prevent.
+ *
+ * Note `.github/agents` is canonical, not a render target: Copilot reads the
+ * file with the markers still in it and therefore sees every block. Keep block
+ * contents short and self-labeling ("**Claude Code:** ...") so that reads as a
+ * reference table rather than as contradictory instructions.
+ *
+ * Consumers: sync-subagents.mjs
+ */
+
+/** Harness names a marker may address. `copilot` is `.github/agents` itself. */
+export const KNOWN_HARNESSES = Object.freeze([
+  'claude',
+  'copilot',
+  'cursor',
+  'gemini',
+]);
+
+const OPEN_LINE = /^[ \t]*<!--\s*harness:([^>]*?)\s*-->[ \t]*$/;
+const CLOSE_LINE = /^[ \t]*<!--\s*\/harness\s*-->[ \t]*$/;
+const ANY_MARKER = /<!--\s*\/?\s*harness\b/;
+
+/**
+ * Renders a canonical body for one harness, keeping blocks addressed to it and
+ * dropping the rest. Bodies with no markers are returned unchanged apart from
+ * blank-run collapsing, so adding this mechanism cannot drift existing agents.
+ *
+ * @param {string} body Canonical body text.
+ * @param {string} harness One of KNOWN_HARNESSES.
+ * @param {{ source?: string }} [options] `source` labels errors, e.g. a path.
+ * @returns {string} The body as that harness should see it.
+ */
+export function renderHarnessSections(body, harness, options = {}) {
+  const source = options.source ?? 'canonical body';
+
+  if (!KNOWN_HARNESSES.includes(harness)) {
+    throw new Error(
+      `Unknown harness "${harness}". Known harnesses: ${KNOWN_HARNESSES.join(', ')}.`,
+    );
+  }
+
+  const lines = body.replace(/\r\n/g, '\n').split('\n');
+  const kept = [];
+  let open = null;
+
+  lines.forEach((line, index) => {
+    const lineNo = index + 1;
+
+    const openMatch = line.match(OPEN_LINE);
+    if (openMatch) {
+      if (open) {
+        throw new Error(
+          `${source}:${lineNo}: nested <!-- harness: --> block; the block opened at line ${open.line} is still unclosed.`,
+        );
+      }
+      open = {
+        targets: parseTargets(openMatch[1], source, lineNo),
+        line: lineNo,
+      };
+      return;
+    }
+
+    if (CLOSE_LINE.test(line)) {
+      if (!open) {
+        throw new Error(
+          `${source}:${lineNo}: <!-- /harness --> with no matching <!-- harness:... --> open marker.`,
+        );
+      }
+      open = null;
+      return;
+    }
+
+    if (!open || open.targets.includes(harness)) {
+      kept.push(line);
+    }
+  });
+
+  if (open) {
+    throw new Error(
+      `${source}: <!-- harness:${open.targets.join(',')} --> opened at line ${open.line} is never closed.`,
+    );
+  }
+
+  const rendered = collapseBlankRuns(kept.join('\n'));
+
+  // A marker written inline rather than on its own line never matched above and
+  // would leak into every harness. Refuse it instead of shipping it.
+  if (ANY_MARKER.test(rendered)) {
+    throw new Error(
+      `${source}: stray harness marker left after rendering. Markers must sit alone on their own line, e.g.\n` +
+        `  <!-- harness:claude -->\n  ...\n  <!-- /harness -->`,
+    );
+  }
+
+  return rendered;
+}
+
+function parseTargets(rawList, source, lineNo) {
+  const targets = rawList
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (!targets.length) {
+    throw new Error(
+      `${source}:${lineNo}: <!-- harness: --> names no harness. Expected one or more of ${KNOWN_HARNESSES.join(', ')}.`,
+    );
+  }
+
+  const unknown = targets.filter((target) => !KNOWN_HARNESSES.includes(target));
+  if (unknown.length) {
+    throw new Error(
+      `${source}:${lineNo}: unknown harness ${unknown.map((t) => `"${t}"`).join(', ')}. Known harnesses: ${KNOWN_HARNESSES.join(', ')}.`,
+    );
+  }
+
+  return targets;
+}
+
+/** Removing a block leaves the blank lines that surrounded it back to back. */
+function collapseBlankRuns(text) {
+  return text.replace(/\n{3,}/g, '\n\n');
+}

--- a/tools/scripts/lib/harness-sections.test.mjs
+++ b/tools/scripts/lib/harness-sections.test.mjs
@@ -1,0 +1,118 @@
+/**
+ * Run with: yarn agents:sync:test  (node --test, no jest project covers tools/)
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { KNOWN_HARNESSES, renderHarnessSections } from './harness-sections.mjs';
+
+test('a body with no markers is identical for every harness', () => {
+  const body = '# Agent\n\nDo the thing.\n\n## Rules\n\n- One\n- Two';
+  for (const harness of KNOWN_HARNESSES) {
+    assert.equal(renderHarnessSections(body, harness), body);
+  }
+});
+
+test('keeps a block only for the harness it names', () => {
+  const body = [
+    'Shared intro.',
+    '',
+    '<!-- harness:claude -->',
+    'Claude only.',
+    '<!-- /harness -->',
+    '',
+    'Shared outro.',
+  ].join('\n');
+
+  assert.equal(
+    renderHarnessSections(body, 'claude'),
+    'Shared intro.\n\nClaude only.\n\nShared outro.',
+  );
+  assert.equal(
+    renderHarnessSections(body, 'gemini'),
+    'Shared intro.\n\nShared outro.',
+  );
+});
+
+test('a block may name several harnesses', () => {
+  const body = [
+    '<!-- harness:claude, cursor -->',
+    'Both.',
+    '<!-- /harness -->',
+  ].join('\n');
+
+  assert.equal(renderHarnessSections(body, 'claude'), 'Both.');
+  assert.equal(renderHarnessSections(body, 'cursor'), 'Both.');
+  assert.equal(renderHarnessSections(body, 'copilot'), '');
+});
+
+test('dropping a block does not leave a widening blank gap', () => {
+  const body = [
+    'Before.',
+    '',
+    '<!-- harness:claude -->',
+    'Claude.',
+    '<!-- /harness -->',
+    '',
+    '<!-- harness:gemini -->',
+    'Gemini.',
+    '<!-- /harness -->',
+    '',
+    'After.',
+  ].join('\n');
+
+  assert.equal(renderHarnessSections(body, 'cursor'), 'Before.\n\nAfter.');
+});
+
+test('rejects an unknown harness inside a marker', () => {
+  const body = '<!-- harness:claude,windsurf -->\nx\n<!-- /harness -->';
+  assert.throws(
+    () => renderHarnessSections(body, 'claude'),
+    /unknown harness "windsurf"/,
+  );
+});
+
+test('rejects an empty harness list', () => {
+  const body = '<!-- harness: -->\nx\n<!-- /harness -->';
+  assert.throws(
+    () => renderHarnessSections(body, 'claude'),
+    /names no harness/,
+  );
+});
+
+test('rejects an unclosed block', () => {
+  const body = 'Intro.\n\n<!-- harness:claude -->\nDangling.';
+  assert.throws(() => renderHarnessSections(body, 'claude'), /is never closed/);
+});
+
+test('rejects a close marker with no open', () => {
+  const body = 'Intro.\n\n<!-- /harness -->';
+  assert.throws(() => renderHarnessSections(body, 'claude'), /no matching/);
+});
+
+test('rejects nested blocks', () => {
+  const body = [
+    '<!-- harness:claude -->',
+    '<!-- harness:cursor -->',
+    'x',
+    '<!-- /harness -->',
+    '<!-- /harness -->',
+  ].join('\n');
+  assert.throws(() => renderHarnessSections(body, 'claude'), /nested/);
+});
+
+test('rejects an inline marker that would otherwise leak to every harness', () => {
+  const body = 'Text <!-- harness:claude --> more text';
+  assert.throws(
+    () => renderHarnessSections(body, 'gemini'),
+    /stray harness marker/,
+  );
+});
+
+test('rejects an unknown target harness', () => {
+  assert.throws(
+    () => renderHarnessSections('x', 'windsurf'),
+    /Unknown harness "windsurf"/,
+  );
+});

--- a/tools/scripts/sync-subagents.mjs
+++ b/tools/scripts/sync-subagents.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 
+import { renderHarnessSections } from './lib/harness-sections.mjs';
+
 const repoRoot = process.cwd();
 
 const CANONICAL_DIR = path.join(repoRoot, '.github', 'agents');
@@ -45,7 +47,7 @@ const HARNESS_CONFIG = {
   },
 };
 
-const USAGE = `Usage:\n  node tools/scripts/sync-subagents.mjs --check\n  node tools/scripts/sync-subagents.mjs --apply [--no-prune]\n\nNotes:\n  - Canonical source is .github/agents/*.agent.md\n  - Existing target frontmatter is always preserved verbatim; only the body is synced.\n    Harness defaults (including tools:) apply ONLY when creating a new file.\n  - A target whose frontmatter cannot be parsed is reported as malformed and skipped,\n    never rewritten, so per-agent tools: grants cannot be silently widened.\n  - Missing target files are created with harness-specific defaults.\n  - --apply prunes extra files by default (disable with --no-prune).\n`;
+const USAGE = `Usage:\n  node tools/scripts/sync-subagents.mjs --check\n  node tools/scripts/sync-subagents.mjs --apply [--no-prune]\n\nNotes:\n  - Canonical source is .github/agents/*.agent.md\n  - Existing target frontmatter is always preserved verbatim; only the body is synced.\n    Harness defaults (including tools:) apply ONLY when creating a new file.\n  - A target whose frontmatter cannot be parsed is reported as malformed and skipped,\n    never rewritten, so per-agent tools: grants cannot be silently widened.\n  - Canonical bodies may scope a section to specific harnesses:\n      <!-- harness:claude,cursor -->  ...  <!-- /harness -->\n    Unmarked content goes to every harness. See tools/scripts/lib/harness-sections.mjs.\n  - Missing target files are created with harness-specific defaults.\n  - --apply prunes extra files by default (disable with --no-prune).\n`;
 
 function parseArgs(argv) {
   const args = new Set(argv.slice(2));
@@ -182,7 +184,12 @@ async function loadCanonicalAgents() {
       throw new Error(`Canonical agent missing frontmatter: ${fullPath}`);
     }
     const canonicalMeta = parseCanonicalMeta(frontmatter, slug);
-    agents.push({ slug, body: normalizeBody(body), canonicalMeta });
+    agents.push({
+      slug,
+      body: normalizeBody(body),
+      canonicalMeta,
+      sourcePath: path.relative(repoRoot, fullPath),
+    });
   }
   return agents;
 }
@@ -219,14 +226,20 @@ async function syncHarness(harness, canonicalAgents, mode, prune) {
       existingContent = null;
     }
 
-    const desiredBody = canonical.body;
+    const desiredBody = normalizeBody(
+      renderHarnessSections(canonical.body, harness, {
+        source: canonical.sourcePath,
+      }),
+    );
     if (!existingContent) {
       const frontmatter = buildFrontmatter(
         harness,
         canonical.slug,
         canonical.canonicalMeta,
       );
-      const nextContent = `${frontmatter}${desiredBody}\n`;
+      // The blank line after `---` is what prettier expects; without it every
+      // file this script rewrites fails `nx format:check`.
+      const nextContent = `${frontmatter}\n${desiredBody}\n`;
       if (mode === 'apply') {
         await fs.writeFile(targetPath, nextContent, 'utf8');
       }
@@ -252,7 +265,7 @@ async function syncHarness(harness, canonicalAgents, mode, prune) {
     if (bodyDiffers) {
       report.drifted.push(rel);
       if (mode === 'apply') {
-        const nextContent = `${frontmatter}${desiredBody}\n`;
+        const nextContent = `${frontmatter}\n${desiredBody}\n`;
         await fs.writeFile(targetPath, nextContent, 'utf8');
         report.updated.push(rel);
       }


### PR DESCRIPTION
Closes #294.

## The problem

`docs/graphify.md` claimed CodeExplorer queried Graphify first and logged a `helped` / `redundant` / `wrong-missed` verdict on every run. None of that had been true since **2026-07-02**, when `555fe1c` ran `yarn agents:sync` and deleted 48 lines from `.claude/agents/explore.md`.

It was not a hand edit. The sync script regenerates each target as `${frontmatter}${desiredBody}` — frontmatter preserved, body overwritten from canonical — and canonical `.github/agents/explore.agent.md` has never contained any Graphify content. `yarn agents:sync:check` reported `drifted: 0` because by its own rules nothing was wrong.

So the keep/drop decision was resting on two spikes from a single day, and any fix written back into `.claude/` would have been deleted again by the next sync.

## The decision: graduate, narrowly scoped

I re-ran the original evaluation bars against the live graph (2,853 nodes / 5,350 edges, 99% EXTRACTED) rather than re-deciding from the six-week-old notes:

| Bar question | 2026-06-19 | 2026-08-12 |
| --- | --- | --- |
| R3 — `get_neighbors saveEncryptedData` | 🟢 degree 20 | 🟢 17 edges with `file:line`, ~1s, $0 |
| `god_nodes` hub map | 🟢 | 🟢 `cn`, `Button`, `useToast`, `requireUserId`, `UserService` |
| R1 — `get_node EncryptedBlob` | 🔴 no unique match | 🔴 **silently returned `EncryptedBlobV1`**, degree 1 |
| R5 — `VaultController` → `serverVaultSync` | 🔴 no path | 🔴 "No directed path found" |

The cost half of the original kill argument is gone — #293 refreshes on commit, #292 closed the coverage gaps. The capability half is unchanged and AST-bounded, so it will not improve. R1 is the sharp case: asking for one symbol returns a *different* one with no ambiguity warning.

Hence graduation with the scope **enforced rather than measured**. The two green rows are the sanctioned uses; every red row is now a written ban in the agent body, expressed as a table of question shapes paired with the tool to use instead. The per-run usage logging is dropped — it charged Haiku tokens on every exploration to keep re-litigating a settled question.

## Changes

**Per-harness body sections** (`tools/scripts/lib/harness-sections.mjs`) — canonical can now carry a section that renders only for named harnesses:

```markdown
<!-- harness:claude,cursor -->
Only these two see this.
<!-- /harness -->
```

Unmarked content stays universal, so no existing agent drifts. Unknown harness names, nesting, unbalanced markers, and inline markers are hard errors, not warnings: a marker that silently fails to apply would recreate exactly the bug this exists to prevent. 11 tests via `yarn agents:sync:test`.

**All four harnesses registered.** Formats were checked against each vendor's own docs rather than copied from `.mcp.json` — they are genuinely not interchangeable:

| Harness | Config | Top-level key | Tool grant |
| --- | --- | --- | --- |
| Claude Code | `.mcp.json` | `mcpServers` | `mcp__graphify__*` |
| Copilot / VS Code | `.vscode/mcp.json` | **`servers`** | `graphify/*` |
| Cursor | `.cursor/mcp.json` | `mcpServers` | none — subagents inherit |
| Gemini CLI | `.gemini/settings.json` | `mcpServers` | `mcp_graphify_*` |

Gemini's entry uses `includeTools` to allowlist the same five read-only tools, so `triage_prs` — which inverts risk for barrel files — is not reachable there at all. Gemini CLI also has an open bug where subagents do not always receive MCP tools ([#17005](https://github.com/google-gemini/gemini-cli/issues/17005), [#19599](https://github.com/google-gemini/gemini-cli/issues/19599)); the agent is told to fall back silently, so it degrades rather than breaks.

**`.husky/post-merge`.** `git merge` fires neither post-commit path — a fast-forward creates no commit, and a merge commit is written by `git merge` directly — so *no* pull refreshed the graph, not just fast-forward ones. Both hooks now source `.husky/graphify-refresh.sh` so their guards cannot drift apart.

**A latent formatting bug.** The sync script omitted the blank line prettier requires after `---`, so any agent file it rewrote would fail `nx format:check`. Only `explore.md` had been rewritten since, which is why it had not surfaced.

## Verification

- `yarn agents:sync` then `yarn agents:sync:check` → exit 0, and idempotent on a second apply
- Each harness renders exactly its own block; no stray markers in any target
- Claude's `tools:` grant and Cursor's `model: composer-2.5` preserved
- `yarn agents:sync:test` → 11/11
- `post-merge` guard verified both ways: a code-bearing merge range triggers, a docs-only range does not
- prettier and eslint clean

## Not included

`git checkout` still fires neither hook, so switching branches leaves the graph reflecting whichever branch last triggered a rebuild. Documented in `docs/graphify.md` rather than fixed — the agent rules already require confirming any graph result against the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
