### PR TITLE
feat(sandcastle): add standalone dispatch and resolve Claude auth

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -17,10 +17,21 @@ SANDCASTLE_AGENT=claude
 SANDCASTLE_CURSOR_MODEL=composer-2.5
 SANDCASTLE_COPILOT_MODEL=claude-sonnet-5
 
-# Required for Claude Code agents.
-# Provide one of:
+# Required for Claude Code agents. Provide exactly ONE — the orchestrator forwards
+# the OAuth token when both are present and drops the API key entirely, so a stale
+# key can never silently take over billing.
+#
+#   CLAUDE_CODE_OAUTH_TOKEN — run `claude setup-token` on the HOST (needs a Pro/Max
+#     plan). Bills your subscription, which is the same quota as your interactive
+#     Claude Code sessions: long AFK batches can throttle you at the keyboard.
+#   ANTHROPIC_API_KEY — metered API billing, isolated from the plan quota.
+#
 # CLAUDE_CODE_OAUTH_TOKEN=your-token-here
 # ANTHROPIC_API_KEY=your-key-here
+
+# Optional: force one auth mode instead of letting the token win.
+# Fails fast if the matching credential is missing. subscription | api
+# SANDCASTLE_CLAUDE_AUTH=subscription
 
 # Required for Cursor agents.
 # CURSOR_API_KEY=your-cursor-api-key

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -33,8 +33,8 @@ const agentModelPolicy = JSON.parse(
 const sandcastleModels = agentModelPolicy.orchestrators.sandcastle;
 
 // ─── Integration model (local-only) ───────────────────────────────────────────
-// GitHub coupling is deliberately minimal: we READ the PRD + slice issues and
-// WRITE status labels + a completion comment back to each slice. That is all.
+// GitHub coupling is deliberately minimal: we READ the issue(s) and WRITE status
+// labels + a completion comment back. That is all.
 //
 // Everything else is LOCAL:
 //   • The feature branch `feat/<slug>` is created from origin/main and is NEVER
@@ -46,6 +46,13 @@ const sandcastleModels = agentModelPolicy.orchestrators.sandcastle;
 //
 // After the run you QA the local feature branch, then push it and open ONE PR to
 // `main` yourself — CI runs there. See docs/adr/0010 and docs/sandcastle/RUNBOOK.md.
+//
+// TWO MODES (see the run plan below):
+//   • prd   — the model above: `--prd <n>`, integrating into `feat/<slug>`.
+//   • issue — `--issue <n>` with NO `--prd`. One ad-hoc issue, cut from origin/main
+//     (or `--base`). There is no integration branch, so the work branch IS the
+//     deliverable: gate green ends the run, the issue is left OPEN, and nothing is
+//     fast-forwarded. Same sandbox, same in-container install, same gate.
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -98,8 +105,6 @@ function ensureSandboxImage(): void {
     );
   }
 }
-
-ensureSandboxImage();
 
 /**
  * Maps the files a slice changed (between base and head) to the Nx projects that
@@ -174,7 +179,7 @@ function gitRefExists(ref: string): boolean {
   );
 }
 
-// ─── Parse --prd <N> ─────────────────────────────────────────────────────────
+// ─── Parse arguments ─────────────────────────────────────────────────────────
 
 function getArgValue(name: string): string | undefined {
   const prefix = `--${name}=`;
@@ -191,11 +196,19 @@ function getArgValue(name: string): string | undefined {
 function printHelp(): void {
   console.log(`
 Usage:
-  yarn dispatch-agents --prd <issue-number> [--issue <slice-number>] [--agent claude|cursor|copilot] [--model <model>]
+  PRD mode        yarn dispatch-agents --prd <issue-number> [--issue <slice-number>]
+  Standalone mode yarn dispatch-agents --issue <issue-number> [--base <ref>]
+
+  Both accept [--agent claude|cursor|copilot] [--model <model>]
 
 Flags:
-  --prd <issue-number>   PRD issue number to dispatch
-  --issue <slice-number> Dispatch only this slice issue
+  --prd <issue-number>   PRD issue number to dispatch. Slices integrate into the
+                         local feat/<slug> branch, one by one.
+  --issue <number>       With --prd: dispatch only this slice of that PRD.
+                         Without --prd: standalone mode — dispatch this one issue
+                         off --base, leave the result on its own local branch.
+  --base <ref>           Standalone mode only: base ref for the work branch
+                         (default: origin/main).
   --agent <name>         Agent provider to use (default: SANDCASTLE_AGENT or claude)
   --model <model>        Override the model for this run (default: env/provider routing)
   --help                 Show this help text
@@ -207,6 +220,13 @@ Environment:
   SANDCASTLE_CLAUDE_MODEL
   SANDCASTLE_CURSOR_MODEL
   SANDCASTLE_COPILOT_MODEL
+
+Claude auth (see docs/sandcastle/RUNBOOK.md):
+  CLAUDE_CODE_OAUTH_TOKEN  Pro/Max subscription token from \`claude setup-token\`.
+                           Takes precedence; ANTHROPIC_API_KEY is then NOT forwarded.
+  ANTHROPIC_API_KEY        Metered API billing. Used only when no OAuth token is set.
+  SANDCASTLE_CLAUDE_AUTH   Force one mode: \`subscription\` or \`api\`. Fails if the
+                           matching credential is missing.
 `);
 }
 
@@ -215,24 +235,101 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   process.exit(0);
 }
 
+const USAGE =
+  'Usage: yarn dispatch-agents --prd <issue-number> [--issue <slice-number>]\n' +
+  '   or: yarn dispatch-agents --issue <issue-number> [--base <ref>]   (standalone, no PRD)';
+
 const prdValue = getArgValue('prd');
-if (!prdValue) {
-  fail(
-    'Usage: yarn dispatch-agents --prd <issue-number> [--issue <slice-number>] [--agent claude|cursor|copilot] [--model <model>]',
-  );
-}
-
-const prdNumber = parseInt(prdValue, 10);
-if (isNaN(prdNumber)) fail('--prd must be a number.');
-
 const issueValue = getArgValue('issue');
+
+if (!prdValue && !issueValue) fail(USAGE);
+
+const prdNumber = prdValue ? parseInt(prdValue, 10) : undefined;
+if (prdValue && isNaN(prdNumber as number)) fail('--prd must be a number.');
+
 const issueNumber = issueValue ? parseInt(issueValue, 10) : undefined;
 if (issueValue && isNaN(issueNumber as number)) {
   fail('--issue must be a number.');
 }
 
+// Standalone mode: one issue, no PRD, no integration branch. The work branch IS
+// the deliverable — nothing is fast-forwarded and nothing is closed, because the
+// work only reaches `main` once you push the branch and open a PR yourself.
+const mode: 'prd' | 'issue' = prdNumber === undefined ? 'issue' : 'prd';
+
+const baseFlag = getArgValue('base');
+if (baseFlag && mode === 'prd') {
+  fail(
+    '--base applies to standalone mode only. In PRD mode every slice is cut from the local feature branch.',
+  );
+}
+
 const agentFlag = getArgValue('agent');
 const modelFlag = getArgValue('model');
+
+// ─── Claude auth mode ─────────────────────────────────────────────────────────
+// Two ways to authenticate the Claude Code agent inside the sandbox:
+//
+//   • subscription — CLAUDE_CODE_OAUTH_TOKEN, produced by `claude setup-token` on
+//     the host (requires an active Pro/Max plan). Bills against that plan, which is
+//     the SAME quota as your interactive Claude Code sessions: a long AFK batch of
+//     complexity:high (opus) slices can throttle you at the keyboard.
+//   • api — ANTHROPIC_API_KEY. Metered per token, isolated from the plan quota.
+//
+// We forward exactly ONE of them into the container. Which credential Claude Code
+// prefers when both are present is version-dependent, so a stale ANTHROPIC_API_KEY
+// sitting next to a valid token can silently bill the API while you believe you are
+// on the plan. Resolve the mode up front, fail loudly if the credential is missing
+// (before we build worktrees and containers), and print the mode in the run header.
+
+type ClaudeAuthMode = 'subscription' | 'api';
+
+function resolveClaudeAuth(kind: AgentKind): ClaudeAuthMode | null {
+  if (kind !== 'claude') return null;
+
+  const hasToken = Boolean(process.env.CLAUDE_CODE_OAUTH_TOKEN);
+  const hasApiKey = Boolean(process.env.ANTHROPIC_API_KEY);
+  const forced = (process.env.SANDCASTLE_CLAUDE_AUTH ?? '')
+    .trim()
+    .toLowerCase();
+
+  if (forced && forced !== 'subscription' && forced !== 'api') {
+    fail(
+      `SANDCASTLE_CLAUDE_AUTH must be "subscription" or "api" (got "${forced}").`,
+    );
+  }
+
+  if (forced === 'subscription' && !hasToken) {
+    fail(
+      'SANDCASTLE_CLAUDE_AUTH=subscription but CLAUDE_CODE_OAUTH_TOKEN is not set.\n' +
+        'Run `claude setup-token` on the host and store the result in your 1Password Environment.',
+    );
+  }
+  if (forced === 'api' && !hasApiKey) {
+    fail('SANDCASTLE_CLAUDE_AUTH=api but ANTHROPIC_API_KEY is not set.');
+  }
+
+  if (forced === 'subscription' || forced === 'api') return forced;
+
+  // Unforced: the subscription token wins when both are available.
+  if (hasToken) return 'subscription';
+  if (hasApiKey) return 'api';
+
+  fail(
+    'No Claude credential found. Set one of:\n' +
+      '  CLAUDE_CODE_OAUTH_TOKEN  — `claude setup-token` on the host (Pro/Max plan)\n' +
+      '  ANTHROPIC_API_KEY        — metered API billing\n' +
+      'See docs/sandcastle/RUNBOOK.md. Both are normally injected via 1Password.',
+  );
+}
+
+const agentKind = resolveAgentKind();
+const claudeAuth = resolveClaudeAuth(agentKind);
+
+// Only now — after --help, argument validation, and the credential preflight have
+// all had their say. Building this image can take minutes; there is no reason to
+// pay for it before we know the run can actually authenticate.
+ensureSandboxImage();
 
 // ─── Fetch PRD issue ──────────────────────────────────────────────────────────
 
@@ -374,72 +471,168 @@ function unblockDependents(completed: Issue): void {
   }
 }
 
-const prd = ghJson<Pick<Issue, 'title' | 'body'>>([
-  'issue',
-  'view',
-  String(prdNumber),
-  '--repo',
-  REPO,
-  '--json',
-  'title,body',
-]);
-
-const featureName = prd.title.replace(/^\[PRD\]\s*/i, '').trim();
-const featureSlug = featureName
-  .toLowerCase()
-  .replace(/[^a-z0-9]+/g, '-')
-  .replace(/^-|-$/g, '');
-const featureBranch = `feat/${featureSlug}`;
-
-console.log(`\nPRD #${prdNumber}: ${featureName}`);
-console.log(`Feature branch:  ${featureBranch} (local only — never pushed)\n`);
-
-// ─── Ensure the feature branch exists LOCALLY (never pushed) ───────────────────
-// The PRD branch is created once, locally, from the freshest main. It is the
-// integration target for every slice in this PRD. We do NOT create it on origin
-// and we do NOT push it — you push it by hand after QA to open the PRD PR.
+// ─── Build the run plan ───────────────────────────────────────────────────────
+// The two modes differ in exactly three things — where work branches are cut from,
+// whether finished work is fast-forwarded anywhere, and how the issue set is chosen.
+// Everything downstream (sandbox, in-container install, gate, prompt, usage log)
+// is shared and reads from this plan.
+//
+//   prd   — integrationBranch = local `feat/<slug>`, also the base each slice is cut
+//           from, so slice N sees slices 1..N-1. Issues are the PRD's ready AFK
+//           slices, ordered by `## Blocked by`.
+//   issue — integrationBranch = null. One explicitly named issue, cut from
+//           origin/main (or --base). Its branch IS the deliverable: nothing is
+//           fast-forwarded, nothing is closed. You QA it, push it, open the PR.
 
 gitCmd(['fetch', 'origin', 'main']);
 
-if (gitRefExists(featureBranch)) {
-  console.log(`Reusing existing local branch ${featureBranch}.`);
-} else {
-  const base = gitRefExists('origin/main') ? 'origin/main' : 'main';
-  gitCmd(['branch', featureBranch, base]);
-  console.log(
-    `Created local branch ${featureBranch} from ${base} (not pushed).`,
+type RunPlan = {
+  /** Ref every work branch is cut from, and the gate's diff base. */
+  baseRef: string;
+  /** Local branch finished work fast-forwards into; null in standalone mode. */
+  integrationBranch: string | null;
+  issues: Issue[];
+  /** Full repo issue list, for dependency unblocking. Empty in standalone mode. */
+  allIssues: Issue[];
+};
+
+function planPrdRun(prd: number): RunPlan {
+  const prdIssue = ghJson<Pick<Issue, 'title' | 'body'>>([
+    'issue',
+    'view',
+    String(prd),
+    '--repo',
+    REPO,
+    '--json',
+    'title,body',
+  ]);
+
+  const name = prdIssue.title.replace(/^\[PRD\]\s*/i, '').trim();
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  const branch = `feat/${slug}`;
+
+  console.log(`\nPRD #${prd}: ${name}`);
+  console.log(`Feature branch:  ${branch} (local only — never pushed)`);
+
+  // The PRD branch is created once, locally, from the freshest main. It is the
+  // integration target for every slice in this PRD. We do NOT create it on origin
+  // and we do NOT push it — you push it by hand after QA to open the PRD PR.
+  if (gitRefExists(branch)) {
+    console.log(`Reusing existing local branch ${branch}.`);
+  } else {
+    const base = gitRefExists('origin/main') ? 'origin/main' : 'main';
+    gitCmd(['branch', branch, base]);
+    console.log(`Created local branch ${branch} from ${base} (not pushed).`);
+  }
+
+  const everyIssue = ghJson<Issue[]>([
+    'issue',
+    'list',
+    '--repo',
+    REPO,
+    '--state',
+    'all',
+    '--json',
+    'number,title,state,labels,body',
+    '--limit',
+    '100',
+  ]);
+
+  const isAfkSlice = (issue: Issue): boolean =>
+    issue.labels.some((label) => label.name === 'ready-for-agent') &&
+    issue.labels.some((label) => label.name === 'type:afk');
+
+  const selected = everyIssue.filter(
+    (i) =>
+      i.body?.includes(`PRD: #${prd}`) &&
+      isAfkSlice(i) &&
+      (issueNumber === undefined || i.number === issueNumber) &&
+      !i.labels.some((label) => label.name === 'status:blocked') &&
+      i.state === 'OPEN' &&
+      // Skip slices already merged into the feature branch so re-runs are
+      // idempotent — only undone work in the wave is re-dispatched.
+      !isCompleted(i),
   );
+
+  if (selected.length === 0) {
+    fail(
+      issueNumber === undefined
+        ? `No open AFK slice issues found for PRD #${prd}.\n` +
+            `Run /to-issues ${prd} to create them first.`
+        : `Slice issue #${issueNumber} was not found as an open AFK slice for PRD #${prd}.\n` +
+            `Check its labels and PRD reference, or run it standalone:\n` +
+            `  yarn dispatch-agents --issue ${issueNumber}`,
+    );
+  }
+
+  return {
+    baseRef: branch,
+    integrationBranch: branch,
+    issues: selected,
+    allIssues: everyIssue,
+  };
 }
 
-// ─── Fetch AFK slice issues for this PRD ─────────────────────────────────────
+function planStandaloneRun(number: number): RunPlan {
+  const issue = ghJson<Issue>([
+    'issue',
+    'view',
+    String(number),
+    '--repo',
+    REPO,
+    '--json',
+    'number,title,state,labels,body',
+  ]);
 
-const allIssues = ghJson<Issue[]>([
-  'issue',
-  'list',
-  '--repo',
-  REPO,
-  '--state',
-  'all',
-  '--json',
-  'number,title,state,labels,body',
-  '--limit',
-  '100',
-]);
+  if (issue.state === 'CLOSED') {
+    fail(`Issue #${number} is closed. Reopen it before dispatching.`);
+  }
 
-const isAfkSlice = (issue: Issue): boolean =>
-  issue.labels.some((label) => label.name === 'ready-for-agent') &&
-  issue.labels.some((label) => label.name === 'type:afk');
+  const base =
+    baseFlag ?? (gitRefExists('origin/main') ? 'origin/main' : 'main');
+  if (!gitRefExists(base)) fail(`Base ref "${base}" does not resolve locally.`);
 
-const slices = allIssues.filter(
-  (i) =>
-    i.body?.includes(`PRD: #${prdNumber}`) &&
-    isAfkSlice(i) &&
-    (issueNumber === undefined || i.number === issueNumber) &&
-    !i.labels.some((label) => label.name === 'status:blocked') &&
-    i.state === 'OPEN' &&
-    // Skip slices already merged into the feature branch so re-runs are
-    // idempotent — only undone work in the wave is re-dispatched.
-    !isCompleted(i),
+  console.log(`\nIssue #${number}: ${issue.title}`);
+  console.log(`Base:            ${base}`);
+  console.log(`Standalone — no PRD, no integration branch. Nothing is pushed.`);
+
+  // Naming the issue explicitly IS the authorization: standalone runs do not
+  // require ready-for-agent / type:afk. Labels that normally mean "a human wanted
+  // this one" are surfaced as warnings so a mis-typed number is still visible.
+  const labels = issue.labels.map((label) => label.name);
+  for (const flagged of ['type:hitl', 'status:blocked', 'status:in-progress']) {
+    if (labels.includes(flagged)) {
+      console.warn(`  ⚠ #${number} carries "${flagged}" — dispatching anyway.`);
+    }
+  }
+
+  return {
+    baseRef: base,
+    integrationBranch: null,
+    issues: [issue],
+    allIssues: [],
+  };
+}
+
+const plan =
+  mode === 'prd'
+    ? planPrdRun(prdNumber as number)
+    : planStandaloneRun(issueNumber as number);
+
+const { baseRef, integrationBranch, allIssues } = plan;
+const slices = plan.issues;
+
+console.log(
+  `Agent:           ${agentKind}${
+    claudeAuth
+      ? claudeAuth === 'subscription'
+        ? ' (auth: subscription — shares your Pro/Max quota)'
+        : ' (auth: API key — metered)'
+      : ''
+  }\n`,
 );
 
 const completedIssueNumbers = new Set(
@@ -452,23 +645,19 @@ const completedIssueNumbers = new Set(
 );
 
 function nextReadySlice(pending: Issue[]): Issue | undefined {
-  return pending
-    .filter((issue) =>
-      blockedBy(issue).every((dependency) =>
-        completedIssueNumbers.has(dependency),
-      ),
-    )
-    .sort((left, right) => left.number - right.number)[0];
-}
+  // `## Blocked by` ordering is PRD vocabulary. Standalone runs a single issue the
+  // human named explicitly — honouring a stale blocker section there would silently
+  // refuse to run it, since completedIssueNumbers is empty by construction.
+  const ready =
+    mode === 'prd'
+      ? pending.filter((issue) =>
+          blockedBy(issue).every((dependency) =>
+            completedIssueNumbers.has(dependency),
+          ),
+        )
+      : pending;
 
-if (slices.length === 0) {
-  fail(
-    issueNumber === undefined
-      ? `No open AFK slice issues found for PRD #${prdNumber}.\n` +
-          `Run /to-issues ${prdNumber} to create them first.`
-      : `Slice issue #${issueNumber} was not found as an open AFK slice for PRD #${prdNumber}.\n` +
-          `Check its labels and PRD reference before retrying.`,
-  );
+  return ready.sort((left, right) => left.number - right.number)[0];
 }
 
 // ─── Dependency install model ─────────────────────────────────────────────────
@@ -566,9 +755,17 @@ function buildAgent(agentKind: AgentKind, model: string) {
 }
 
 function providerEnvironment(): Record<string, string> {
+  // Exactly one Claude credential reaches the container — see resolveClaudeAuth.
+  // On cursor/copilot runs claudeAuth is null and neither is forwarded.
+  const claudeVariables =
+    claudeAuth === 'subscription'
+      ? ['CLAUDE_CODE_OAUTH_TOKEN']
+      : claudeAuth === 'api'
+        ? ['ANTHROPIC_API_KEY']
+        : [];
+
   const variableNames = [
-    'CLAUDE_CODE_OAUTH_TOKEN',
-    'ANTHROPIC_API_KEY',
+    ...claudeVariables,
     'CURSOR_API_KEY',
     'COPILOT_GITHUB_TOKEN',
     'GH_TOKEN',
@@ -590,7 +787,11 @@ function sliceBranchFor(issue: Issue): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '')
     .slice(0, 40);
-  return `slice/${issue.number}-${slug}`;
+  // Separate namespaces so a standalone re-run of an issue that later becomes a PRD
+  // slice (or vice versa) can never collide on a branch, worktree, or gate path.
+  return mode === 'prd'
+    ? `slice/${issue.number}-${slug}`
+    : `issue/${issue.number}-${slug}`;
 }
 
 // ─── Finalize the agent's local commit ─────────────────────────────────────────
@@ -636,15 +837,15 @@ function finalizeSliceBranch(issue: Issue, sliceBranch: string): boolean {
     }
   }
 
-  // Nothing ahead of the feature branch means the agent produced no work.
+  // Nothing ahead of the base means the agent produced no work.
   const ahead = spawnSync(
     'git',
-    ['rev-list', '--count', `${featureBranch}..${sliceBranch}`],
+    ['rev-list', '--count', `${baseRef}..${sliceBranch}`],
     { encoding: 'utf8', windowsHide: true },
   );
   if ((ahead.stdout || '').trim() === '0') {
     console.error(
-      `  [#${issue.number}] ${sliceBranch} has no commits beyond ${featureBranch} — nothing to integrate.`,
+      `  [#${issue.number}] ${sliceBranch} has no commits beyond ${baseRef} — nothing to integrate.`,
     );
     return false;
   }
@@ -671,7 +872,7 @@ function runSliceGate(issue: Issue, sliceBranch: string): boolean {
   // Gate only the projects whose OWN files this slice changed — not their
   // transitive dependents. For a per-file lint gate, an upstream change cannot
   // introduce lint errors downstream.
-  const projects = changedProjects(featureBranch, sliceBranch);
+  const projects = changedProjects(baseRef, sliceBranch);
   if (projects.length === 0) {
     console.log(`  [#${issue.number}] gate: no project files changed — pass.`);
     return true;
@@ -769,7 +970,14 @@ function runSliceGate(issue: Issue, sliceBranch: string): boolean {
 // always a pure descendant of the feature branch — a fast-forward, no merge commit,
 // no conflicts. We advance the (un-checked-out) feature ref with `git branch -f`.
 // Nothing is pushed. Fails closed if the slice is somehow not a descendant.
-function integrateSlice(issue: Issue, sliceBranch: string): boolean {
+//
+// Standalone runs never reach this: with no PRD there is no integration target, so
+// the work branch is left exactly as the agent committed it.
+function integrateSlice(
+  issue: Issue,
+  sliceBranch: string,
+  featureBranch: string,
+): boolean {
   const isDescendant =
     spawnSync(
       'git',
@@ -910,7 +1118,7 @@ function buildPrompt(issue: Issue, sliceBranch: string): string {
     `- Dependencies are ALREADY installed in this sandbox before you start (a setup hook runs \`corepack yarn install --immutable\`). Do NOT run \`yarn install\` yourself.`,
     `- Read CLAUDE.md, CONTEXT.md, and TECH_STACK.md before making any changes.`,
     `- Implement this vertical slice end-to-end (schema → API → UI → tests where applicable).`,
-    `- Your working branch is \`${sliceBranch}\` (based on \`${featureBranch}\`). Do not switch branches.`,
+    `- Your working branch is \`${sliceBranch}\` (based on \`${baseRef}\`). Do not switch branches.`,
     ...buildGateInstructions(gate),
     `- Commit your changes using Conventional Commit messages (\`corepack yarn ai:commit\`).`,
     `- Do NOT push and do NOT open a PR — this sandbox has no credentials. Just commit locally on your branch; leave nothing uncommitted. The orchestrator integrates your branch into the feature branch on the host.`,
@@ -1034,7 +1242,6 @@ function logRunUsage(
 
 const results: SliceResult[] = [];
 const crashed: Array<{ issue: Issue; error: string }> = [];
-const agentKind = resolveAgentKind();
 const pendingSlices = [...slices];
 
 while (pendingSlices.length > 0) {
@@ -1098,7 +1305,7 @@ while (pendingSlices.length > 0) {
       encoding: 'utf8',
       windowsHide: true,
     });
-    gitCmd(['branch', sliceBranch, featureBranch]);
+    gitCmd(['branch', sliceBranch, baseRef]);
     const wt = spawnSync(
       'git',
       ['worktree', 'add', worktreePath, sliceBranch],
@@ -1134,7 +1341,7 @@ while (pendingSlices.length > 0) {
       branchStrategy: {
         type: 'branch',
         branch: sliceBranch,
-        baseBranch: featureBranch,
+        baseBranch: baseRef,
       },
       // Install this slice's deps INSIDE the container before the agent starts, so
       // native binaries match the container's platform (correct on WSL2, Linux, and
@@ -1160,11 +1367,17 @@ while (pendingSlices.length > 0) {
     logRunUsage(issue.number, agentKind, model, result);
 
     // Finalize → gate → integrate, all LOCAL. No push, no PR.
+    // Standalone runs stop after the gate: with no integration branch the work
+    // branch is already the deliverable, so "succeeded" means gate-passed.
     const hasWork = finalizeSliceBranch(issue, sliceBranch);
     const gatePassed = hasWork ? runSliceGate(issue, sliceBranch) : false;
-    const mergeOk = gatePassed ? integrateSlice(issue, sliceBranch) : false;
+    const mergeOk = !gatePassed
+      ? false
+      : integrationBranch === null
+        ? true
+        : integrateSlice(issue, sliceBranch, integrationBranch);
 
-    if (mergeOk) {
+    if (mergeOk && integrationBranch !== null) {
       ghSilent([
         'issue',
         'edit',
@@ -1190,10 +1403,33 @@ while (pendingSlices.length > 0) {
         'completed',
         '--comment',
         `Agent completed and the build gate passed. ${result.commits.length} commit(s) on \`${sliceBranch}\`.\n` +
-          `Integrated into the local \`${featureBranch}\` (fast-forward, not pushed) and closed as completed. ` +
+          `Integrated into the local \`${integrationBranch}\` (fast-forward, not pushed) and closed as completed. ` +
           `It will reach \`main\` via the manual PRD PR.`,
       ]);
       unblockDependents(issue);
+    } else if (mergeOk) {
+      // Standalone success. The issue stays OPEN and is NOT marked status:done —
+      // nothing has reached `main` yet, and marking it done here would lie about
+      // work that only exists on an unpushed local branch.
+      ghSilent([
+        'issue',
+        'edit',
+        String(issue.number),
+        '--repo',
+        REPO,
+        '--remove-label',
+        'status:in-progress',
+      ]);
+      ghSilent([
+        'issue',
+        'comment',
+        String(issue.number),
+        '--repo',
+        REPO,
+        '--body',
+        `Agent completed and the build gate passed. ${result.commits.length} commit(s) on the local branch \`${sliceBranch}\` (based on \`${baseRef}\`).\n` +
+          `Nothing was pushed. Left open until the branch is reviewed, pushed, and merged via a PR.`,
+      ]);
     } else {
       ghSilent([
         'issue',
@@ -1216,9 +1452,11 @@ while (pendingSlices.length > 0) {
         '--repo',
         REPO,
         '--body',
-        `Agent finished but ${reason} — slice was NOT integrated into \`${featureBranch}\`. ` +
-          `The local branch \`${sliceBranch}\` is left in place for inspection. ` +
-          `Later slices in this PRD will NOT include this one until it is fixed and re-run.`,
+        integrationBranch === null
+          ? `Agent finished but ${reason}. The local branch \`${sliceBranch}\` is left in place for inspection.`
+          : `Agent finished but ${reason} — slice was NOT integrated into \`${integrationBranch}\`. ` +
+            `The local branch \`${sliceBranch}\` is left in place for inspection. ` +
+            `Later slices in this PRD will NOT include this one until it is fixed and re-run.`,
       ]);
       results.push({
         issue,
@@ -1235,7 +1473,7 @@ while (pendingSlices.length > 0) {
       sliceBranch,
       commits: result.commits.length,
       merged: true,
-      reason: 'integrated',
+      reason: integrationBranch === null ? 'gate passed' : 'integrated',
     });
     completedIssueNumbers.add(issue.number);
   } catch (e) {
@@ -1257,19 +1495,22 @@ while (pendingSlices.length > 0) {
 
 const merged = results.filter((r) => r.merged);
 const blocked = results.filter((r) => !r.merged);
+const succeededVerb = integrationBranch === null ? 'ready' : 'integrated';
 
 console.log(`\n${'─'.repeat(55)}`);
 console.log(
-  `Batch done: ${merged.length} integrated, ${blocked.length} blocked (gate/no-work), ${crashed.length} crashed.\n`,
+  `Batch done: ${merged.length} ${succeededVerb}, ${blocked.length} blocked (gate/no-work), ${crashed.length} crashed.\n`,
 );
 
 for (const r of merged) {
   console.log(
-    `  ✓ #${r.issue.number} integrated — ${r.commits} commit(s) on ${featureBranch}`,
+    integrationBranch === null
+      ? `  ✓ #${r.issue.number} ready — ${r.commits} commit(s) on ${r.sliceBranch}`
+      : `  ✓ #${r.issue.number} integrated — ${r.commits} commit(s) on ${integrationBranch}`,
   );
 }
 for (const r of blocked) {
-  console.error(`  ⚠ #${r.issue.number} NOT integrated — ${r.reason}`);
+  console.error(`  ⚠ #${r.issue.number} NOT ${succeededVerb} — ${r.reason}`);
 }
 for (const r of crashed) {
   console.error(`  ✗ #${r.issue.number} crashed — ${r.error}`);
@@ -1277,23 +1518,30 @@ for (const r of crashed) {
 
 if (blocked.length > 0 || crashed.length > 0) {
   console.log(
-    `\nOne or more slices did not integrate. Fix them and re-run — done slices are skipped.`,
+    integrationBranch === null
+      ? `\nThe run did not finish cleanly. Inspect the branch above, then fix and re-run.`
+      : `\nOne or more slices did not integrate. Fix them and re-run — done slices are skipped.`,
   );
 }
 if (merged.length > 0) {
-  console.log(`\nNext step: QA the local \`${featureBranch}\` branch`);
+  const deliverable = integrationBranch ?? merged[0].sliceBranch;
+  console.log(`\nNext step: QA the local \`${deliverable}\` branch`);
   console.log(
-    `  git switch ${featureBranch}   # it now contains the merged slices`,
+    integrationBranch === null
+      ? `  git switch ${deliverable}   # the agent's work for this issue`
+      : `  git switch ${deliverable}   # it now contains the merged slices`,
   );
   console.log(`Then push it and open ONE PR to \`main\` manually so CI runs:`);
   console.log(
-    `  git push -u origin ${featureBranch} && gh pr create --base main`,
+    `  git push -u origin ${deliverable} && gh pr create --base main`,
   );
 }
 
 // ─── Desktop notification (best-effort; Windows / WSL2 only) ───────────────────
 
-const safeTitle = featureName.replace(/'/g, "''");
+const runLabel = (
+  mode === 'prd' ? `PRD #${prdNumber}` : `Issue #${issueNumber}`
+).replace(/'/g, "''");
 spawnSync(
   'powershell.exe',
   [
@@ -1301,8 +1549,8 @@ spawnSync(
     [
       'Add-Type -AssemblyName System.Windows.Forms;',
       `[System.Windows.Forms.MessageBox]::Show(`,
-      `  '${merged.length} integrated, ${blocked.length} blocked, ${crashed.length} crashed.` +
-        `\\nPRD #${prdNumber}: ${safeTitle}',`,
+      `  '${merged.length} ${succeededVerb}, ${blocked.length} blocked, ${crashed.length} crashed.` +
+        `\\n${runLabel}',`,
       `  'dispatch-agents complete', 'OK', 'Information'`,
       `)`,
     ].join(' '),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,18 @@ QA the local `feat/<slug>` branch — it now contains every integrated slice. Wh
 - **Planned feature** → always start with `/to-prd` + `/to-issues`
 - **Ad-hoc bug or one-off task** → use the `github-issue-creation-workflow` skill directly (no PRD needed)
 
+### Dispatching a single issue
+
+```bash
+yarn dispatch-agents --prd <prd-number> --issue <slice-number>   # one slice of a PRD
+yarn dispatch-agents --issue <issue-number>                      # standalone, no PRD
+```
+
+Standalone mode gives an ad-hoc issue the same sandbox, in-container install, and lint gate as a
+PRD slice, but has no integration branch: the work is left on `issue/<n>-<slug>`, nothing is
+pushed, and the issue stays open until you push the branch and merge a PR. See
+`docs/sandcastle/RUNBOOK.md` and `docs/adr/0010`.
+
 ---
 
 ## Design & Planning Workflows

--- a/docs/adr/0010-sandcastle-local-only-integration.md
+++ b/docs/adr/0010-sandcastle-local-only-integration.md
@@ -30,6 +30,21 @@ integrates). Integration becomes entirely local.
 - After the run, the human QAs the local feature branch, then pushes it once and opens **one** PR
   to `main` so CI runs there and the PRD lands as a single review unit.
 
+### Amendment: standalone (no-PRD) dispatch
+
+`dispatch-agents --issue <n>` with no `--prd` runs a single issue that belongs to no PRD. It keeps
+every property above and simply has **no integration step**:
+
+- The work branch `issue/<n>-<slug>` is cut from `origin/main` (or `--base <ref>`) and **is** the
+  deliverable. There is no `feat/<slug>`, so there is nothing to fast-forward into.
+- Naming the issue explicitly is the authorization: no `ready-for-agent` / `type:afk` requirement,
+  no `## Blocked by` ordering, no dependent unblocking. Human-oriented labels (`type:hitl`,
+  `status:blocked`) warn but do not stop the run.
+- The issue is **not** closed and **not** labelled `status:done` — only `status:in-progress` is
+  removed, plus a comment naming the branch and gate verdict. Closing would assert completion of
+  work that exists only on an unpushed local branch; the PR merge is what completes it.
+- Nothing is pushed, so the "safer by default" property below is unchanged.
+
 ## Status
 
 accepted.
@@ -67,8 +82,9 @@ un-checked-out feature ref is enough.
 
 - **The feature branch is local and unpushed.** Deleting it loses the integrated work — push
   before deleting. Documented in `docs/sandcastle/RUNBOOK.md`.
-- **The gate operates on local refs** (`featureBranch`, `sliceBranch`) — no `git fetch origin
+- **The gate operates on local refs** (`baseRef`, `sliceBranch`) — no `git fetch origin
 <slice>` before gating. Still fail-closed: no integration without a green gate (or `SLICE_GATE=off`).
+  `baseRef` is the feature branch in PRD mode and `origin/main` (or `--base`) standalone.
 - **`dispatch-waves` still works** unchanged in behavior — it gates the `ready-for-agent` label
   per wave and calls `main.mts`; each wave's integrated output (local feature branch) is the next
   wave's base. Its role narrows to _ordering_ by `## Blocked by`.

--- a/docs/sandcastle/RUNBOOK.md
+++ b/docs/sandcastle/RUNBOOK.md
@@ -236,3 +236,8 @@ Slices run **serially** (one by one), so there is no concurrency knob — each s
   longer used (the seed step and lockfile-hash invalidation were removed).
 - **Never put the repo on `/mnt/d`** (or any drvfs/9P mount) for dispatch — that's the ~29 min
   trap.
+- **`Could not fetch from origin (reusing worktree at … as-is, …)` is expected — ignore it.** It
+  comes from `@ai-hero/sandcastle`'s `fastForwardFromOrigin`, which tries `git fetch origin <branch>`
+  on the work branch. Sandcastle work branches are local-only by design (`docs/adr/0010`), so that
+  fetch can never succeed; the library logs this and correctly reuses the worktree as-is. It fires
+  on every run in both modes and does not indicate a failed dispatch.

--- a/docs/sandcastle/RUNBOOK.md
+++ b/docs/sandcastle/RUNBOOK.md
@@ -91,6 +91,43 @@ corepack yarn dispatch-agents --prd <issue-number> --agent cursor
 corepack yarn dispatch-agents --prd <issue-number> --agent copilot --model claude-sonnet-5
 ```
 
+### Two dispatch modes
+
+| Mode           | Invocation                                 | Base for the work branch         | Where finished work lands                   |
+| -------------- | ------------------------------------------ | -------------------------------- | ------------------------------------------- |
+| **PRD**        | `--prd <n>` (optionally `--issue <slice>`) | the local `feat/<slug>` head     | fast-forwarded into `feat/<slug>`           |
+| **Standalone** | `--issue <n>` with **no** `--prd`          | `origin/main`, or `--base <ref>` | stays on `issue/<n>-<slug>` — nothing moves |
+
+**One slice of a PRD:** add `--issue` to a PRD run. It still creates/reuses `feat/<slug>`,
+gates, and fast-forwards — just for that one slice.
+
+```bash
+corepack yarn dispatch-agents --prd 42 --issue 45
+```
+
+**A one-off issue with no PRD** — a bug fix, a chore, anything created straight from the
+`github-issue-creation-workflow` skill. Same Docker isolation, same in-container install, same
+gate; only the integration step differs:
+
+```bash
+corepack yarn dispatch-agents --issue 57              # off origin/main
+corepack yarn dispatch-agents --issue 57 --base feat/some-branch
+```
+
+Standalone specifics:
+
+- **No label gate.** Naming `--issue` explicitly _is_ the authorization — `ready-for-agent` and
+  `type:afk` are not required. `type:hitl`, `status:blocked`, and `status:in-progress` print a
+  warning and the run proceeds, so a mistyped issue number is still visible.
+- **No `## Blocked by` ordering** and no dependent unblocking — that vocabulary belongs to a PRD.
+- **The branch is the deliverable.** `issue/<n>-<slug>` is left exactly as the agent committed it.
+  Nothing is fast-forwarded anywhere and nothing is pushed, per `docs/adr/0010`.
+- **The issue stays open** and is **not** labelled `status:done`. The orchestrator only removes
+  `status:in-progress` and comments with the branch name and gate verdict — marking it done would
+  claim work that exists solely on an unpushed local branch. Close it when the PR merges.
+- Branch namespaces are separate (`issue/` vs `slice/`), so a standalone run and a later PRD run of
+  the same issue can never collide on a branch, worktree, or gate path.
+
 Provider switching is optional: the default agent can live in `.sandcastle/.env` as
 `SANDCASTLE_AGENT=claude|cursor|copilot`. Per-provider model defaults can also live there
 (`SANDCASTLE_CLAUDE_MODEL`, `SANDCASTLE_CURSOR_MODEL`, `SANDCASTLE_COPILOT_MODEL`), and
@@ -109,9 +146,46 @@ catalogs with `corepack yarn agents:models:audit`.
 
 With 1Password Environments, put the same variable names in the Environment instead. For
 example, use `SANDCASTLE_AGENT`, `SANDCASTLE_CLAUDE_MODEL`, and the provider credential
-(`ANTHROPIC_API_KEY`, `CURSOR_API_KEY`, or `COPILOT_GITHUB_TOKEN`) as Environment variables.
-1Password Environments are currently beta functionality, and 1Password notes that
-`op run --environment` may take longer to start on Apple silicon Macs.
+(`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`, `CURSOR_API_KEY`, or `COPILOT_GITHUB_TOKEN`) as
+Environment variables. 1Password Environments are currently beta functionality, and 1Password
+notes that `op run --environment` may take longer to start on Apple silicon Macs.
+
+## Claude auth: subscription vs API key
+
+The Claude Code agent in the sandbox authenticates one of two ways. The orchestrator forwards
+**exactly one** credential into the container and prints which in the run header.
+
+| Mode           | Variable                  | Billing                                                     |
+| -------------- | ------------------------- | ----------------------------------------------------------- |
+| `subscription` | `CLAUDE_CODE_OAUTH_TOKEN` | Your Pro/Max plan — **the same quota as your own sessions** |
+| `api`          | `ANTHROPIC_API_KEY`       | Metered per token, isolated from the plan quota             |
+
+To use your plan instead of the API, mint a long-lived token on the **host** (not in the
+container) and store it in your 1Password Environment as `CLAUDE_CODE_OAUTH_TOKEN`:
+
+```bash
+claude setup-token
+```
+
+Resolution rules:
+
+- The OAuth token wins when both are present, and `ANTHROPIC_API_KEY` is then **not forwarded at
+  all**. Which credential Claude Code prefers when it sees both is version-dependent, so leaving a
+  stale API key alongside a valid token could otherwise bill the API while you believe you are on
+  the plan.
+- `SANDCASTLE_CLAUDE_AUTH=subscription|api` forces one mode and fails immediately if the matching
+  credential is missing.
+- With `--agent claude` and neither variable set, dispatch fails **before** building the sandbox
+  image or any worktrees.
+
+**Quota warning.** Subscription auth shares the 5-hour window with your interactive Claude Code
+sessions, and `complexity:high` slices route to `claude-opus-5`
+(`tools/config/agent-model-policy.json`). A long AFK batch can throttle you at the keyboard — send
+big batches to `SANDCASTLE_CLAUDE_AUTH=api` and keep the plan for short runs.
+
+Host credential files (`~/.claude/.credentials.json`) are deliberately **not** bind-mounted: the
+container would write token refreshes back into your host credential store, and the file does not
+exist at all on macOS (Keychain). `claude setup-token` is the supported headless path.
 
 **Integration is local-only** (see `docs/adr/0010`). The feature branch `feat/<slug>` is created
 from `origin/main` **locally and is never pushed**. Slices run **one by one**: each branches off
@@ -125,6 +199,10 @@ GitHub is touched only to **read** the PRD/slice issues and **write** status lab
 comment back to each slice, then **close** each slice that integrates successfully (reason:
 completed). The PRD issue stays open until you merge the manual PRD PR.
 
+Standalone runs follow the same rule with the last step removed: agent → commit → gate → **stop**.
+There is no integration branch to fast-forward into, so the work branch is the deliverable and the
+issue is left open.
+
 When the run finishes, **you** finish the loop by hand:
 
 ```bash
@@ -132,6 +210,8 @@ git switch feat/<slug>                 # QA the integrated branch locally
 git push -u origin feat/<slug>         # publish it when you're satisfied
 gh pr create --base main               # open ONE PR; CI runs here; merge it on GitHub
 ```
+
+For a standalone run, substitute the `issue/<n>-<slug>` branch the summary printed.
 
 ### Tunables
 


### PR DESCRIPTION
Two additions to the sandcastle orchestrator: dispatching a single issue that belongs to no PRD, and authenticating the sandbox agent with a Claude Pro/Max subscription instead of an API key.

**Exercised end-to-end against Docker and live issues.** Both modes were dispatched for real against throwaway fixtures (#301 standalone; #302/#303 PRD), authenticated by subscription token. Both completed, passed the gate, and produced exactly the expected branch, commit, and GitHub state. See the test plan at the bottom.

## Standalone (no-PRD) dispatch

`--prd` is no longer required. `--issue <n>` on its own runs one ad-hoc issue — a bug fix or chore created straight from the `github-issue-creation-workflow` skill — with the same Docker isolation, in-container install, and lint gate a PRD slice gets.

```bash
yarn dispatch-agents --prd 42 --issue 45   # one slice of a PRD (already worked before this PR)
yarn dispatch-agents --issue 57            # standalone, no PRD
yarn dispatch-agents --issue 57 --base feat/some-branch
```

| Mode | Base for the work branch | Where finished work lands |
| --- | --- | --- |
| PRD | the local `feat/<slug>` head | fast-forwarded into `feat/<slug>` |
| Standalone | `origin/main`, or `--base <ref>` | stays on `issue/<n>-<slug>` — nothing moves |

The two modes now differ in exactly three things — where work branches are cut from, whether finished work is fast-forwarded anywhere, and how the issue set is chosen. Those are captured in a `RunPlan` computed once (`baseRef` / `integrationBranch` / `issues`), so the dispatch loop reads from the plan instead of closing over `featureBranch` and `prdNumber` globals. Everything downstream — sandbox, install hook, gate, prompt builder, usage logging — is shared and unchanged.

Standalone semantics:

- **No label gate.** Naming `--issue` explicitly *is* the authorization; `ready-for-agent` / `type:afk` are not required. `type:hitl`, `status:blocked`, and `status:in-progress` warn and proceed, so a mistyped issue number is still visible.
- **The branch is the deliverable.** No integration branch exists, so nothing is fast-forwarded and nothing is pushed — `docs/adr/0010`'s local-only property is preserved.
- **The issue stays open** and is not labelled `status:done`. Only `status:in-progress` is removed, plus a comment naming the branch and gate verdict. Closing would assert completion of work that exists solely on an unpushed local branch.
- Separate branch namespaces (`issue/` vs `slice/`) so a standalone run and a later PRD run of the same issue cannot collide on a branch, worktree, or gate path.

### Bug fixed along the way

`nextReadySlice` filtered every issue through its `## Blocked by` section, and `completedIssueNumbers` is empty by construction in standalone mode. Any ad-hoc issue whose body happened to carry that section would have been reported "blocked by unfinished slice(s)" and silently never run. That filter is now PRD-only.

## Claude subscription auth

The plumbing largely existed — `providerEnvironment()` already forwarded `CLAUDE_CODE_OAUTH_TOKEN` and the container already ships Claude Code. What was missing was making it unambiguous.

```bash
claude setup-token   # on the host; requires an active Pro/Max plan
```

Store the result as `CLAUDE_CODE_OAUTH_TOKEN` in the 1Password Environment and drop `ANTHROPIC_API_KEY`.

- **Exactly one credential reaches the container.** The OAuth token wins and the API key is not forwarded at all. Previously both were passed, and which one Claude Code prefers is version-dependent — a stale key could quietly bill the API while you believed you were on the plan.
- **`SANDCASTLE_CLAUDE_AUTH=subscription|api`** forces a mode and fails immediately if the matching credential is missing.
- **Fail-fast preflight.** With `--agent claude` and neither variable set, dispatch fails before any worktree or image build. `ensureSandboxImage()` also moved below argument parsing — `--help` used to trigger a Docker image build.
- The run header prints which mode is active.

Two caveats documented in the RUNBOOK: subscription auth draws on the **same 5-hour window as interactive sessions**, and `complexity:high` routes to `claude-opus-5`, so a long AFK batch can throttle you at the keyboard — that is what the `api` override is for. Host credential files (`~/.claude/.credentials.json`) are deliberately **not** bind-mounted: the container would write token refreshes back into the host credential store, and the file does not exist at all on macOS.

## Docs

- `docs/sandcastle/RUNBOOK.md` — two-mode table, standalone semantics, new Claude auth section
- `docs/adr/0010` — standalone amendment (it preserves the local-only decision rather than revising it)
- `.sandcastle/.env.example`, `CLAUDE.md` — auth guidance and a dispatch pointer

## Test plan

- [x] `tsc --noEmit --strict` on `.sandcastle/main.mts`
- [x] `prettier --check`
- [x] Argument validation: no args, `--base` rejected in PRD mode
- [x] Auth validation: invalid `SANDCASTLE_CLAUDE_AUTH`, forced `api` with no key — all fail before Docker
- [x] `--help` renders both modes and no longer builds the sandbox image
- [x] Real standalone dispatch against a throwaway issue (#301)
- [x] Real PRD dispatch, to confirm no regression in the existing path (#302 → slice #303)
- [x] A run authenticated by subscription token, confirming the header reports `subscription`

### Live run results

Both runs used `complexity:low` fixtures, so both routed to `claude-haiku-4-5`.

| Assertion | Standalone (#301) | PRD (#303) |
| --- | --- | --- |
| Header reports `subscription` | ✅ | ✅ |
| Branch namespace | `issue/301-…` | `slice/303-…` |
| Gate | pass | pass |
| Fast-forwarded into `feat/<slug>` | n/a — no integration branch | ✅ identical SHAs |
| Issue state after | **OPEN**, no `status:done` | **CLOSED/COMPLETED**, `status:done` |
| Comment posted | branch + "Nothing was pushed" | branch + "Integrated… not pushed" |
| Pushed to origin | nothing (`git ls-remote` empty) | nothing |
| Scope | 1 file, 1 commit | 1 file, 1 commit |

The subscription token authenticated successfully inside the container — that was the only path with no prior coverage.

**Known benign warning.** Every run logs:

```
Could not fetch from origin (reusing worktree at … as-is, branch '…')
```

This originates in `@ai-hero/sandcastle`'s `fastForwardFromOrigin`, which runs `git fetch origin <branch>` against the work branch. Sandcastle branches are local-only by design (`docs/adr/0010`), so that fetch can never succeed; the library logs and correctly reuses the worktree as-is. Pre-existing, mode-independent, and not introduced by this PR.

**Coverage gap worth naming.** Both fixtures were docs-only, so the gate reported `no project files changed — pass` — it was invoked correctly but never actually ran lint. The gate is downstream of `RunPlan` and untouched by this diff, so this is judged acceptable rather than blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

