### PR TITLE
feat(ai-commit): add failure trailers and secret path guards

### DIFF
--- a/.claude/agents/commit.md
+++ b/.claude/agents/commit.md
@@ -1,29 +1,31 @@
 ---
 name: Commit
 description: >
-  Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged or unstaged changes. Read-only — produces the message text only and does not create the commit.
+  Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged changes. Read-only — produces the message text only and does not create the commit.
 tools: [Read, Glob, Grep, Edit, Write, Bash]
 model: haiku
 ---
 
-You are a Conventional Commits specialist for the MyOrganizer Nx monorepo. Your job is to inspect the current git changes and produce a clean, accurate commit message — nothing more.
+You are a Conventional Commits specialist for the MyOrganizer Nx monorepo. Your job is to inspect the **staged** git changes and produce a clean, accurate commit message — nothing more.
 
 ## Constraints
 
 - DO NOT run `git commit`, `git add`, `git push`, or any mutating git command.
 - DO NOT modify files.
-- DO NOT speculate about intent — describe only what the diff shows.
-- ONLY output the final commit message text in the requested format.
+- DO NOT speculate about intent — describe only what the staged diff shows.
+- DO NOT inspect or draft from the unstaged working tree.
+- ONLY output the final commit message text in the requested format, except for the empty-index case below.
 
 ## Approach
 
-1. Run `git status --short` and `git --no-pager diff --staged` (fall back to unstaged diff if nothing staged).
-2. Group changes by Nx project / library / domain (e.g. `backend`, `myorganizer`, `web-vault`, `app-api-client`).
-3. Pick the dominant Conventional Commit type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`.
-4. Choose a scope matching the primary affected project or library (kebab-case).
-5. Write a ≤72-char subject in imperative mood; add a body only if multiple notable changes exist.
-6. Note breaking changes with `!` and a `BREAKING CHANGE:` footer when applicable.
-7. If changes span unrelated areas, recommend splitting into multiple commits and propose each message.
+1. Run `git status --short` and `git --no-pager diff --staged`.
+2. If the index is empty, return exactly:
+
+```
+NO_STAGED_CHANGES: Stage the intended files before requesting a commit message.
+```
+
+Do not fall back to `git diff` (unstaged). 3. Group staged changes by Nx project / library / domain (e.g. `backend`, `myorganizer`, `web-vault`, `app-api-client`). 4. Pick the dominant Conventional Commit type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`. 5. Choose a scope matching the primary affected project or library (kebab-case). 6. Write a ≤72-char subject in imperative mood; add a body only if multiple notable changes exist. 7. Note breaking changes with `!` and a `BREAKING CHANGE:` footer when applicable. 8. If staged changes span unrelated areas, recommend splitting into multiple commits and propose each message. Do not invent a single catch-all subject that hides the split.
 
 ## Output Format
 

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -2,8 +2,11 @@
 
 Use this workflow when the user asks Claude Code to commit the current staged changes.
 
-1. Draft the Conventional Commit message with the existing `Commit` sub-agent.
-2. Execute the commit with `corepack yarn ai:commit`.
-3. Wait for `git commit` to finish. Do not cancel the command while Husky pre-commit checks are running.
-4. If Husky fails, fix the reported issue, rerun the narrow validation, and retry the commit.
-5. Keep the final response concise.
+1. Inspect `git status`. Never `git add .`. If nothing is staged, or the tree is mixed, list files and ask before staging. Do not stage secret-looking files.
+2. Draft the Conventional Commit message with the existing `Commit` sub-agent (staged diff only). If it recommends splitting commits, ask which group to commit first.
+3. Write the message to a temp file and execute `corepack yarn ai:commit --message-file <path>`. Do not run `git commit` directly.
+4. Wait for the command to finish. Do not cancel it while Husky pre-commit checks are running.
+5. If it fails, read the `ai:commit: failed` trailer, fix the reported slice, rerun the hinted check, and retry.
+6. Keep the final response concise.
+
+Canonical skill: `.github/skills/commit-change-workflow/SKILL.md`

--- a/.cursor/agents/commit.md
+++ b/.cursor/agents/commit.md
@@ -1,27 +1,29 @@
 ---
 name: Commit
-description: Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged or unstaged changes. Read-only — produces the message text only and does not create the commit.
+description: Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged changes. Read-only — produces the message text only and does not create the commit.
 model: composer-2.5
 ---
 
-You are a Conventional Commits specialist for the MyOrganizer Nx monorepo. Your job is to inspect the current git changes and produce a clean, accurate commit message — nothing more.
+You are a Conventional Commits specialist for the MyOrganizer Nx monorepo. Your job is to inspect the **staged** git changes and produce a clean, accurate commit message — nothing more.
 
 ## Constraints
 
 - DO NOT run `git commit`, `git add`, `git push`, or any mutating git command.
 - DO NOT modify files.
-- DO NOT speculate about intent — describe only what the diff shows.
-- ONLY output the final commit message text in the requested format.
+- DO NOT speculate about intent — describe only what the staged diff shows.
+- DO NOT inspect or draft from the unstaged working tree.
+- ONLY output the final commit message text in the requested format, except for the empty-index case below.
 
 ## Approach
 
-1. Run `git status --short` and `git --no-pager diff --staged` (fall back to unstaged diff if nothing staged).
-2. Group changes by Nx project / library / domain (e.g. `backend`, `myorganizer`, `web-vault`, `app-api-client`).
-3. Pick the dominant Conventional Commit type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`.
-4. Choose a scope matching the primary affected project or library (kebab-case).
-5. Write a ≤72-char subject in imperative mood; add a body only if multiple notable changes exist.
-6. Note breaking changes with `!` and a `BREAKING CHANGE:` footer when applicable.
-7. If changes span unrelated areas, recommend splitting into multiple commits and propose each message.
+1. Run `git status --short` and `git --no-pager diff --staged`.
+2. If the index is empty, return exactly:
+
+```
+NO_STAGED_CHANGES: Stage the intended files before requesting a commit message.
+```
+
+Do not fall back to `git diff` (unstaged). 3. Group staged changes by Nx project / library / domain (e.g. `backend`, `myorganizer`, `web-vault`, `app-api-client`). 4. Pick the dominant Conventional Commit type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`. 5. Choose a scope matching the primary affected project or library (kebab-case). 6. Write a ≤72-char subject in imperative mood; add a body only if multiple notable changes exist. 7. Note breaking changes with `!` and a `BREAKING CHANGE:` footer when applicable. 8. If staged changes span unrelated areas, recommend splitting into multiple commits and propose each message. Do not invent a single catch-all subject that hides the split.
 
 ## Output Format
 

--- a/.cursor/rules/commit-change-workflow.mdc
+++ b/.cursor/rules/commit-change-workflow.mdc
@@ -5,8 +5,10 @@ alwaysApply: false
 
 # Commit Change Workflow
 
-- Use the existing `Commit` sub-agent to draft the Conventional Commit message from the staged diff.
-- Run the actual commit with `corepack yarn ai:commit`.
-- Wait for `git commit` to finish. Do not cancel or background the process while Husky is running.
-- If Husky fails, fix the reported formatting, lint, typecheck, or test issue, rerun the narrow validation, and then retry the commit.
-- Do not auto-stage unrelated files.
+- Inspect git status first. Never `git add .`. If nothing is staged, or staged and unstaged files are mixed, list the files and ask before staging.
+- Do not stage secret-looking files (`.env`, `credentials.json`, `*.pem`, private keys).
+- Use the existing `Commit` sub-agent to draft the Conventional Commit message from the **staged** diff only.
+- If `Commit` recommends multiple commits, ask which group to commit first.
+- Run the actual commit with `corepack yarn ai:commit --message-file <path>`. Do not run `git commit` directly. Do not pipe the message on stdin.
+- Wait for `yarn ai:commit` to finish. Do not cancel or background the process while Husky is running.
+- If it fails, read the `ai:commit: failed` trailer (`reason`, `hint`, optional `projects` / `paths`), fix that slice, rerun the hinted check, then retry.

--- a/.gemini/agents/commit.md
+++ b/.gemini/agents/commit.md
@@ -1,7 +1,7 @@
 ---
 name: commit
 description: >
-  Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged or unstaged changes. Read-only — produces the message text only and does not create the commit.
+  Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged changes. Read-only — produces the message text only and does not create the commit.
 model: gemini-3.5-flash-lite
 tools:
   - read_file
@@ -12,24 +12,26 @@ tools:
   - run_shell_command
 ---
 
-You are a Conventional Commits specialist for the MyOrganizer Nx monorepo. Your job is to inspect the current git changes and produce a clean, accurate commit message — nothing more.
+You are a Conventional Commits specialist for the MyOrganizer Nx monorepo. Your job is to inspect the **staged** git changes and produce a clean, accurate commit message — nothing more.
 
 ## Constraints
 
 - DO NOT run `git commit`, `git add`, `git push`, or any mutating git command.
 - DO NOT modify files.
-- DO NOT speculate about intent — describe only what the diff shows.
-- ONLY output the final commit message text in the requested format.
+- DO NOT speculate about intent — describe only what the staged diff shows.
+- DO NOT inspect or draft from the unstaged working tree.
+- ONLY output the final commit message text in the requested format, except for the empty-index case below.
 
 ## Approach
 
-1. Run `git status --short` and `git --no-pager diff --staged` (fall back to unstaged diff if nothing staged).
-2. Group changes by Nx project / library / domain (e.g. `backend`, `myorganizer`, `web-vault`, `app-api-client`).
-3. Pick the dominant Conventional Commit type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`.
-4. Choose a scope matching the primary affected project or library (kebab-case).
-5. Write a ≤72-char subject in imperative mood; add a body only if multiple notable changes exist.
-6. Note breaking changes with `!` and a `BREAKING CHANGE:` footer when applicable.
-7. If changes span unrelated areas, recommend splitting into multiple commits and propose each message.
+1. Run `git status --short` and `git --no-pager diff --staged`.
+2. If the index is empty, return exactly:
+
+```
+NO_STAGED_CHANGES: Stage the intended files before requesting a commit message.
+```
+
+Do not fall back to `git diff` (unstaged). 3. Group staged changes by Nx project / library / domain (e.g. `backend`, `myorganizer`, `web-vault`, `app-api-client`). 4. Pick the dominant Conventional Commit type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`. 5. Choose a scope matching the primary affected project or library (kebab-case). 6. Write a ≤72-char subject in imperative mood; add a body only if multiple notable changes exist. 7. Note breaking changes with `!` and a `BREAKING CHANGE:` footer when applicable. 8. If staged changes span unrelated areas, recommend splitting into multiple commits and propose each message. Do not invent a single catch-all subject that hides the split.
 
 ## Output Format
 

--- a/.github/agents/commit.agent.md
+++ b/.github/agents/commit.agent.md
@@ -1,5 +1,5 @@
 ---
-description: 'Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged or unstaged changes. Read-only — produces the message text only and does not create the commit.'
+description: 'Use when the user asks to write, draft, generate, or suggest a Conventional Commit message based on staged changes. Read-only — produces the message text only and does not create the commit.'
 name: 'Commit'
 tools: [read, search, execute]
 model: ['GPT-5.6 Luna (copilot)', 'MAI-Code-1-Flash (copilot)']
@@ -7,24 +7,26 @@ user-invocable: true
 argument-hint: 'Optional: scope hint or area of change'
 ---
 
-You are a Conventional Commits specialist for the MyOrganizer Nx monorepo. Your job is to inspect the current git changes and produce a clean, accurate commit message — nothing more.
+You are a Conventional Commits specialist for the MyOrganizer Nx monorepo. Your job is to inspect the **staged** git changes and produce a clean, accurate commit message — nothing more.
 
 ## Constraints
 
 - DO NOT run `git commit`, `git add`, `git push`, or any mutating git command.
 - DO NOT modify files.
-- DO NOT speculate about intent — describe only what the diff shows.
-- ONLY output the final commit message text in the requested format.
+- DO NOT speculate about intent — describe only what the staged diff shows.
+- DO NOT inspect or draft from the unstaged working tree.
+- ONLY output the final commit message text in the requested format, except for the empty-index case below.
 
 ## Approach
 
-1. Run `git status --short` and `git --no-pager diff --staged` (fall back to unstaged diff if nothing staged).
-2. Group changes by Nx project / library / domain (e.g. `backend`, `myorganizer`, `web-vault`, `app-api-client`).
-3. Pick the dominant Conventional Commit type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`.
-4. Choose a scope matching the primary affected project or library (kebab-case).
-5. Write a ≤72-char subject in imperative mood; add a body only if multiple notable changes exist.
-6. Note breaking changes with `!` and a `BREAKING CHANGE:` footer when applicable.
-7. If changes span unrelated areas, recommend splitting into multiple commits and propose each message.
+1. Run `git status --short` and `git --no-pager diff --staged`.
+2. If the index is empty, return exactly:
+
+```
+NO_STAGED_CHANGES: Stage the intended files before requesting a commit message.
+```
+
+Do not fall back to `git diff` (unstaged). 3. Group staged changes by Nx project / library / domain (e.g. `backend`, `myorganizer`, `web-vault`, `app-api-client`). 4. Pick the dominant Conventional Commit type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`. 5. Choose a scope matching the primary affected project or library (kebab-case). 6. Write a ≤72-char subject in imperative mood; add a body only if multiple notable changes exist. 7. Note breaking changes with `!` and a `BREAKING CHANGE:` footer when applicable. 8. If staged changes span unrelated areas, recommend splitting into multiple commits and propose each message. Do not invent a single catch-all subject that hides the split.
 
 ## Output Format
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -316,10 +316,11 @@ When you need to find **shallow modules**, **seam leaks**, or **testability gaps
 ### Commit And PR Workflows
 
 - When the user asks to commit changes, use the repo-local commit workflow skill and the existing `Commit` sub-agent together:
-  - The `Commit` sub-agent drafts the Conventional Commit message only.
-  - The actual commit must run through `corepack yarn ai:commit`.
-- The commit workflow must wait for `git commit` to finish. Do not cancel, background, or move on while Husky pre-commit checks are still running.
-- If Husky fails because of linting, tests, formatting, or another validation issue, fix the reported problem first, rerun the narrow validation for that slice, and only then retry the commit.
+  - Inspect git status first. Never `git add .`. Ask before staging when the tree is mixed.
+  - The `Commit` sub-agent drafts the Conventional Commit message from the staged diff only.
+  - The actual commit must run through `corepack yarn ai:commit --message-file <path>`. Do not run `git commit` directly.
+- The commit workflow must wait for `yarn ai:commit` to finish. Do not cancel, background, or move on while Husky pre-commit checks are still running.
+- If `ai:commit` fails, read the `ai:commit: failed` trailer (`reason`, `hint`, optional `projects` / `paths`), fix that slice, rerun the hinted check, and only then retry.
 - Commit-time Nx output should remain readable. The Husky hook uses static output for Nx task execution; preserve that behavior when editing the hook.
 - When the user asks to open or create a PR, use `corepack yarn ai:create-pr` unless an IDE-native integration can satisfy the exact same behavior.
 - PR creation should gather the commit history from the current branch, push upstream if needed, assign the authenticated GitHub user, keep reviewers empty unless the user explicitly names one, and return only success plus the PR link.

--- a/.github/skills/commit-change-workflow/SKILL.md
+++ b/.github/skills/commit-change-workflow/SKILL.md
@@ -11,51 +11,79 @@ description: 'Use when the user asks to commit changes, make a commit, git commi
 - The user asks for `git commit`, a Conventional Commit, or to save the staged changes.
 - The user wants the agent to finish the commit, not only to draft the message.
 
+## Ownership
+
+| Step                                              | Owner                                            |
+| ------------------------------------------------- | ------------------------------------------------ |
+| Inspect the working tree and decide what to stage | Main agent (ask the user when the tree is mixed) |
+| Draft the Conventional Commit message             | `Commit` sub-agent (read-only)                   |
+| Run `git commit`                                  | `corepack yarn ai:commit`                        |
+| Repair a Husky / lint / format failure            | Main agent, then retry `ai:commit`               |
+
+The `Commit` sub-agent must stay read-only. Do not ask it to stage, commit, or fix hook failures.
+
 ## Core Rules
 
-- Use the existing `Commit` sub-agent to draft the Conventional Commit message. Do not invent a message without checking the actual diff.
-- Treat the `Commit` sub-agent as read-only. It drafts the message only.
-- Execute the actual commit through `corepack yarn ai:commit`.
-- Wait for the `git commit` process to return. Do not cancel it, detach it, move on, or start other work while Husky pre-commit checks are still running.
-- Do not auto-stage unrelated files. If nothing is staged, stop and ask the user whether the intended files should be staged first.
-- If Husky fails, fix the reported formatting, linting, typecheck, test, or other validation issue before retrying the commit.
-- After fixing a Husky failure, rerun the narrowest relevant validation for the touched slice before re-running `corepack yarn ai:commit`.
+- Do not run `git commit` directly. The only commit entry point is `corepack yarn ai:commit`.
+- Prefer `--message-file`. Do not pipe the message on stdin from an agent session (PowerShell and TTY handling make that unreliable).
+- Treat the `Commit` sub-agent as read-only. It drafts the message from the **staged** diff only.
+- Wait for `yarn ai:commit` to return. Do not cancel it, detach it, move on, or start other work while Husky pre-commit checks are still running.
+- Never `git add .` or `git add -A`. Stage specific paths the user intends to commit.
+- Do not stage secret-looking files: `.env`, `.env.*` except `.env.example` / `.env.sample` / `.env.template`, `credentials.json`, `*.pem`, `*.p12`, `*.pfx`, `*.keystore`, `id_rsa`, `id_ed25519`, `id_dsa`, `id_ecdsa`.
+- If `Commit` recommends splitting into multiple commits, stop and ask which group to commit first. Do not run `ai:commit` for every proposed message.
+
+## Staging
+
+1. Run `git status --short` and inspect staged, unstaged, and untracked paths.
+2. If nothing is staged, list the unstaged/untracked files and ask which to stage. Do **not** call `Commit` yet.
+3. If some files are staged and others are not, list both sets and ask before adding or committing.
+4. If a secret-looking path is already staged, unstage it (`git restore --staged <path>`) and tell the user.
+5. Only after the index matches the intended commit, call `Commit`.
 
 ## Workflow
 
-1. Inspect the current git state and confirm which files are staged.
+1. Inspect git state and finish staging as above.
 2. Call the `Commit` sub-agent to draft the Conventional Commit message from the staged diff.
-3. Write the drafted message to a temporary file or pipe it over stdin.
-4. Run one of these commands:
+3. Write the drafted message to a temporary file.
+4. Run:
 
 ```sh
 corepack yarn ai:commit --message-file <path-to-message-file>
 ```
 
-or
+5. Wait for completion. Do not background the command.
+6. On success, report the commit hash/subject concisely.
+7. On failure, read the `ai:commit: failed` trailer at the end of stderr (see below), fix that slice, rerun the hinted check, then retry the same `ai:commit --message-file` command.
 
-```sh
-printf '%s\n' '<commit-message>' | corepack yarn ai:commit
+## Failure trailer
+
+`ai:commit` reprints the git/Husky output, then always ends a failure with:
+
+```
+---
+ai:commit: failed
+reason: lint
+projects: backend
+hint: yarn nx lint backend
+---
 ```
 
-5. Wait for completion.
-6. If the commit fails because Husky fails:
-   - read the actual error output
-   - fix the reported issue
-   - rerun the narrowest relevant validation
-   - rerun `corepack yarn ai:commit`
-7. Report the final commit result concisely.
+`reason` is one of: `lint`, `format`, `secret`, `empty-index`, `hook`, `unknown`.
 
-## Validation
+| reason             | What to do                                                                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `lint`             | Run the `hint` command (or `yarn nx lint <project>` from `projects:`), fix the reported issues, retry `ai:commit` |
+| `format`           | Run `corepack yarn format:write --uncommitted`, confirm the rewrite, retry `ai:commit`                            |
+| `secret`           | Unstage the `paths:` listed; do not retry until they are out of the index                                         |
+| `empty-index`      | Stage the intended files, then call `Commit` and `ai:commit`                                                      |
+| `hook` / `unknown` | Read the hook output above the trailer, fix that check, rerun the narrowest validation, retry `ai:commit`         |
 
-- Prefer the exact failing check reported by Husky.
-- If Husky reports lint issues, rerun the relevant lint target or affected lint command.
-- If Husky reports formatting issues, rerun the narrowest formatter or repo formatter that matches the touched files.
-- Only retry the commit after the focused validation passes.
+Do not retry `ai:commit` until the focused validation passes.
 
 ## References
 
 - `.github/agents/commit.agent.md` — message generation only
 - `tools/scripts/ai/commit-change.mjs` — shared commit runner
+- `tools/scripts/ai/classify-commit-failure.mjs` — trailer classification
 - `.husky/pre-commit` — commit-time formatting and lint checks
 - `AGENTS.md` — repo-wide workflow routing

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,7 @@
 . .husky/common.sh
 
+# Format uncommitted files once, restage so the commit includes the rewrite,
+# then lint with static Nx output so failures stay readable for AI tools.
 corepack yarn format:write --uncommitted
-corepack yarn affected:lint --uncommitted --outputStyle=static
-
-# .husky/pre-commit
-
-corepack yarn prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\ |g') --write --ignore-unknown
 git update-index --again
+corepack yarn affected:lint --uncommitted --outputStyle=static

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -15,7 +15,7 @@ You are implementing a vertical slice for MyOrganizer.
 - Read `CLAUDE.md`, `CONTEXT.md`, and `TECH_STACK.md` before making any changes.
 - Follow the slice `gate:*` tier from ADR 0012 / `.claude/checklist.md` (Sandcastle injects gate instructions; default `gate:standard`).
 - Work only on the branch you were given. Do not switch branches.
-- Commit with Conventional Commit messages (`corepack yarn ai:commit`).
+- Commit with Conventional Commit messages (`corepack yarn ai:commit --message-file <path>`). Do not run `git commit` directly.
 - Do NOT push and do NOT open a PR — the sandbox has no credentials. Just commit locally; the orchestrator integrates your branch into the feature branch on the host.
 
 # Task

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - E2E: `yarn nx e2e myorganizer-e2e`.
 - Lint: `yarn nx lint <project-name>` or `yarn lint`.
 - Format: `yarn format:write`.
-- AI commit workflow: `corepack yarn ai:commit --message-file <path>` (or pipe the message on stdin).
+- AI commit workflow: `corepack yarn ai:commit --message-file <path>`.
 - AI PR workflow: `corepack yarn ai:create-pr [--reviewer <login>]`.
 - API sync after backend contract changes: `yarn openapi:sync`; check drift with `yarn openapi:check`.
 - Release (cut branch): `yarn release:cut --version vX.Y.Z --push --notes-file RELEASE_NOTES.md`.
@@ -54,8 +54,8 @@ This is an Nx monorepo for a full-stack organizer app: Next.js frontend, Express
 - Use the generated API client when it covers the endpoint.
 - Add or update focused tests for changed behavior.
 - Keep docs concise and link to existing docs when possible.
-- Use the `Commit` sub-agent only to draft Conventional Commit messages; execute commits through the shared AI workflow so Husky is allowed to finish.
-- For commit requests, wait for `git commit` to return before continuing. If Husky fails, fix the reported issue and rerun the narrow validation before retrying the commit.
+- Use the `Commit` sub-agent only to draft Conventional Commit messages from the staged diff; execute commits with `corepack yarn ai:commit --message-file <path>` so Husky is allowed to finish. Never `git add .` or run `git commit` directly.
+- For commit requests, wait for `yarn ai:commit` to return before continuing. If it fails, read the `ai:commit: failed` trailer, fix the hinted slice, and retry.
 - For PR requests, gather commit history from the current branch, push upstream if needed, create or reuse the PR, assign the authenticated GitHub user, and leave reviewers empty unless the user explicitly names them.
 - For issue creation requests, follow `.github/skills/github-issue-creation-workflow/SKILL.md` and delegate to `IssueCreator` so duplicate checks, required details, and label validation are handled consistently.
 - For issue/PR triage requests, follow `.github/skills/triage/SKILL.md`. Use `.github/skills/triage/AGENT-BRIEF.md` when moving to `ready-for-agent`, and `.github/skills/triage/OUT-OF-SCOPE.md` when rejecting enhancements as `wontfix`.
@@ -108,6 +108,7 @@ Use [`.claude/checklist.md`](.claude/checklist.md) Step 0 → file-type matrix.
 - Do not store vault plaintext on the server or add plaintext todo APIs.
 - Do not hand-edit generated API client code.
 - Do not commit secrets or production credentials.
-- Do not cancel, background, or abandon a running `git commit` while Husky checks are still executing.
+- Do not run `git commit` directly or `git add .`; use `corepack yarn ai:commit --message-file <path>`.
+- Do not cancel, background, or abandon a running `yarn ai:commit` while Husky checks are still executing.
 - Do not open pull requests from `main` or another base branch directly.
 - Do not leave harness-only agent additions/removals unsynchronized. If one agent is added/removed in canonical, propagate to all harnesses via `yarn agents:sync`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Use the repo-local command files under `.claude/commands/` for commit, PR, test,
 - Storybook creation or updates should use `.claude/commands/storybook.md`.
 - Playwright E2E creation/updates should follow `.github/skills/playwright-e2e-workflow/SKILL.md`.
 - Issue/PR triage requests should use `.claude/commands/triage.md` (`.github/skills/triage/SKILL.md`).
-- Commit-message drafting still belongs to the existing `Commit` sub-agent; commit execution belongs to the shared `ai:commit` runner.
+- Commit-message drafting still belongs to the existing `Commit` sub-agent (staged diff only); commit execution belongs to `corepack yarn ai:commit --message-file <path>`.
 - Jest test implementation uses a three-stage pipeline: `TestScaffold` (writes tests) → `TestReviewer` (static gate: checklist, tsc, eslint) → `TestRunner` (execution with hang detection). Always provide a behavior matrix from the actual implementation, including unsupported scenarios to avoid. Consult `docs/testing/projects/<project>.md` for that project's tooling and mock patterns (`docs/testing/README.md` is the index plus cross-project rules). Max 3 retries before escalating to the main agent.
 - Storybook implementation is delegated to the `StorybookCurator` sub-agent (`.claude/agents/storybook-curator.md`); require requirement-readiness analysis before edits and route clarification questions to the human-in-the-loop.
 - React component creation or editing (UI Primitives in `libs/web-ui/` or Feature Components in `libs/web/pages/<route>/`) uses the ComponentBuilder → ComponentReviewer workflow on `gate:standard` / `gate:full` — see **UI Component Workflows** below and ADR 0012 for mechanical exceptions.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -470,9 +470,10 @@ Examples of existing page libraries:
 
 4. **Commit Your Changes**
 
+   Stage the specific files for this change (never `git add .`), then:
+
    ```bash
-   git add .
-   git commit -m "feat: add your feature description"
+   corepack yarn ai:commit --message "feat: add your feature description"
    ```
 
    Follow [Conventional Commits](https://www.conventionalcommits.org/) format:
@@ -728,14 +729,15 @@ Good issues help maintainers understand and address problems quickly. Here's how
 
 5. **Commit Your Changes**
 
+   Stage the specific files for this change (never `git add .`), then:
+
    ```bash
-   git add .
    corepack yarn ai:commit --message "feat: add user profile settings page"
    ```
 
    Use [Conventional Commits](https://www.conventionalcommits.org/) format.
    The shared commit workflow waits for Husky pre-commit checks to finish and uses static Nx output so lint failures stay readable in terminal-based AI tools.
-   If Husky fails, fix the reported formatting, linting, test, or typecheck issue before retrying the commit.
+   If the command fails, read the `ai:commit: failed` trailer, fix the hinted formatting or lint slice, and retry.
 
 6. **Keep Your Branch Up to Date**
 
@@ -790,7 +792,7 @@ Good issues help maintainers understand and address problems quickly. Here's how
 
    ```bash
    # Make requested changes
-   git add .
+   # Stage the specific files for this change (never git add .)
    corepack yarn ai:commit --message "fix: address review feedback"
    git push origin feature/your-feature-name
    ```
@@ -1133,8 +1135,8 @@ git merge upstream/main
 
 # Edit files to resolve conflicts
 # Then:
-git add .
-git commit -m "chore: resolve merge conflicts"
+git add <resolved-files>
+git commit
 ```
 
 ### Common Errors

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,10 +4,11 @@ Use these repo-local workflows for commit, pull request, test, and Storybook-sui
 
 ## Commit Changes
 
-- Draft the Conventional Commit message with the existing `Commit` sub-agent or equivalent diff-based commit-message generator.
-- Execute the commit with `corepack yarn ai:commit`.
+- Inspect git status first. Never `git add .`. If nothing is staged, or staged and unstaged files are mixed, list the files and ask before staging.
+- Draft the Conventional Commit message with the existing `Commit` sub-agent from the staged diff only.
+- Execute the commit with `corepack yarn ai:commit --message-file <path>`. Do not run `git commit` directly.
 - Wait for the commit process to finish; do not cancel the command while Husky is running.
-- If Husky fails, fix the reported issue, rerun the narrow validation, and retry the commit.
+- If it fails, read the `ai:commit: failed` trailer, fix the hinted slice, rerun that check, and retry.
 
 ## Create Pull Request
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "format:write": "nx format:write",
     "format": "nx format",
     "ai:commit": "node tools/scripts/ai/commit-change.mjs",
+    "ai:commit:test": "node --test tools/scripts/ai/classify-commit-failure.test.mjs",
     "ai:create-pr": "node tools/scripts/ai/create-pr.mjs",
     "ai:create-labels": "node tools/scripts/ai/create-labels.mjs",
     "agents:sync": "node tools/scripts/sync-subagents.mjs --apply && node tools/scripts/sync-agent-models.mjs --apply",

--- a/tools/scripts/ai/classify-commit-failure.mjs
+++ b/tools/scripts/ai/classify-commit-failure.mjs
@@ -1,0 +1,154 @@
+/**
+ * Classify `git commit` / Husky output so the orchestrator can retry the
+ * narrowest check. Keep the trailer format stable — agents parse it.
+ */
+
+const NX_RUN_LINT = /> nx run ([a-zA-Z0-9._-]+):lint\b/g;
+const FAILED_LINT_TASK = /^- ([a-zA-Z0-9._-]+):lint\b/gm;
+
+const ALLOWED_ENV_SUFFIXES = new Set(['example', 'sample', 'template', 'dist']);
+
+export function normalizeRepoPath(filePath) {
+  return String(filePath).replaceAll('\\', '/');
+}
+
+export function isBlockedSecretPath(filePath) {
+  const normalized = normalizeRepoPath(filePath);
+  const base = normalized.split('/').pop() ?? normalized;
+
+  if (base === '.env') {
+    return true;
+  }
+
+  const envMatch = /^\.env\.(.+)$/i.exec(base);
+  if (envMatch && !ALLOWED_ENV_SUFFIXES.has(envMatch[1].toLowerCase())) {
+    return true;
+  }
+
+  if (base.toLowerCase() === 'credentials.json') {
+    return true;
+  }
+
+  if (/\.(pem|p12|pfx|keystore)$/i.test(base)) {
+    return true;
+  }
+
+  if (/^id_(rsa|dsa|ecdsa|ed25519)$/i.test(base)) {
+    return true;
+  }
+
+  return false;
+}
+
+export function findBlockedSecretPaths(filePaths) {
+  const blocked = [];
+  const seen = new Set();
+
+  for (const filePath of filePaths) {
+    if (!isBlockedSecretPath(filePath)) {
+      continue;
+    }
+
+    const normalized = normalizeRepoPath(filePath);
+    if (seen.has(normalized)) {
+      continue;
+    }
+
+    seen.add(normalized);
+    blocked.push(normalized);
+  }
+
+  return blocked;
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function collectMatches(pattern, text) {
+  pattern.lastIndex = 0;
+  const values = [];
+  let match = pattern.exec(text);
+  while (match) {
+    values.push(match[1]);
+    match = pattern.exec(text);
+  }
+  return values;
+}
+
+export function extractLintProjects(output) {
+  const text = output ?? '';
+  return uniqueSorted([
+    ...collectMatches(NX_RUN_LINT, text),
+    ...collectMatches(FAILED_LINT_TASK, text),
+  ]);
+}
+
+function hintForLint(projects) {
+  if (projects.length === 1) {
+    return `yarn nx lint ${projects[0]}`;
+  }
+
+  if (projects.length > 1) {
+    return projects.map((project) => `yarn nx lint ${project}`).join(' && ');
+  }
+
+  return 'corepack yarn affected:lint --uncommitted --outputStyle=static';
+}
+
+export function classifyCommitFailure(output) {
+  const text = output ?? '';
+  const projects = extractLintProjects(text);
+  const hasLint = projects.length > 0 || /eslint/i.test(text);
+  const hasFormat = /format:write|prettier/i.test(text);
+
+  if (hasLint) {
+    return {
+      reason: 'lint',
+      projects,
+      hint: hintForLint(projects),
+    };
+  }
+
+  if (hasFormat) {
+    return {
+      reason: 'format',
+      projects: [],
+      hint: 'corepack yarn format:write --uncommitted',
+    };
+  }
+
+  if (/husky|pre-commit/i.test(text)) {
+    return {
+      reason: 'hook',
+      projects: [],
+      hint: 'Read the hook output above, fix the reported check, then retry corepack yarn ai:commit --message-file <path>.',
+    };
+  }
+
+  return {
+    reason: 'unknown',
+    projects: [],
+    hint: 'Read the git/husky output above, fix the reported issue, then retry corepack yarn ai:commit --message-file <path>.',
+  };
+}
+
+export function formatCommitFailureTrailer({
+  reason,
+  hint,
+  projects = [],
+  paths = [],
+}) {
+  const lines = ['---', 'ai:commit: failed', `reason: ${reason}`];
+
+  if (projects.length > 0) {
+    lines.push(`projects: ${projects.join(', ')}`);
+  }
+
+  if (paths.length > 0) {
+    lines.push(`paths: ${paths.join(', ')}`);
+  }
+
+  lines.push(`hint: ${hint}`, '---', '');
+  return lines.join('\n');
+}

--- a/tools/scripts/ai/classify-commit-failure.test.mjs
+++ b/tools/scripts/ai/classify-commit-failure.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Run with: yarn ai:commit:test  (node --test, no jest project covers tools/)
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  classifyCommitFailure,
+  findBlockedSecretPaths,
+  formatCommitFailureTrailer,
+  isBlockedSecretPath,
+} from './classify-commit-failure.mjs';
+
+test('classifies Nx lint failures and names the project', () => {
+  const output = [
+    '> nx run backend:lint',
+    '',
+    'NX   Running 1 failed',
+    '',
+    'Failed tasks:',
+    '- backend:lint',
+  ].join('\n');
+
+  assert.deepEqual(classifyCommitFailure(output), {
+    reason: 'lint',
+    projects: ['backend'],
+    hint: 'yarn nx lint backend',
+  });
+});
+
+test('joins hints when several lint projects fail', () => {
+  const output = [
+    '> nx run backend:lint',
+    '> nx run web-ui:lint',
+    'Failed tasks:',
+    '- backend:lint',
+    '- web-ui:lint',
+  ].join('\n');
+
+  const result = classifyCommitFailure(output);
+  assert.equal(result.reason, 'lint');
+  assert.deepEqual(result.projects, ['backend', 'web-ui']);
+  assert.equal(result.hint, 'yarn nx lint backend && yarn nx lint web-ui');
+});
+
+test('prefers lint over format when both appear', () => {
+  const output = [
+    'corepack yarn format:write --uncommitted',
+    '> nx run backend:lint',
+    'eslint error',
+  ].join('\n');
+
+  assert.equal(classifyCommitFailure(output).reason, 'lint');
+});
+
+test('does not treat the husky lint command line as a lint failure', () => {
+  const output = [
+    'corepack yarn format:write --uncommitted',
+    'corepack yarn affected:lint --uncommitted --outputStyle=static',
+    'prettier check failed',
+  ].join('\n');
+
+  assert.equal(classifyCommitFailure(output).reason, 'format');
+});
+
+test('classifies prettier / format:write as format', () => {
+  const output =
+    'corepack yarn format:write --uncommitted\nprettier check failed';
+  assert.deepEqual(classifyCommitFailure(output), {
+    reason: 'format',
+    projects: [],
+    hint: 'corepack yarn format:write --uncommitted',
+  });
+});
+
+test('classifies a generic husky failure as hook', () => {
+  const result = classifyCommitFailure('husky - pre-commit script failed');
+  assert.equal(result.reason, 'hook');
+});
+
+test('falls back to unknown when the output has no hook signal', () => {
+  const result = classifyCommitFailure('fatal: cannot lock ref');
+  assert.equal(result.reason, 'unknown');
+});
+
+test('emits a stable trailer the orchestrator can parse', () => {
+  const trailer = formatCommitFailureTrailer({
+    reason: 'lint',
+    projects: ['backend'],
+    hint: 'yarn nx lint backend',
+  });
+
+  assert.equal(
+    trailer,
+    [
+      '---',
+      'ai:commit: failed',
+      'reason: lint',
+      'projects: backend',
+      'hint: yarn nx lint backend',
+      '---',
+      '',
+    ].join('\n'),
+  );
+});
+
+test('blocks env and credential filenames, not examples or source', () => {
+  assert.equal(isBlockedSecretPath('.env'), true);
+  assert.equal(isBlockedSecretPath('apps/backend/.env.local'), true);
+  assert.equal(isBlockedSecretPath('.env.example'), false);
+  assert.equal(isBlockedSecretPath('credentials.json'), true);
+  assert.equal(isBlockedSecretPath('certs/prod.pem'), true);
+  assert.equal(isBlockedSecretPath('id_rsa'), true);
+  assert.equal(isBlockedSecretPath('id_rsa.pub'), false);
+  assert.equal(isBlockedSecretPath('libs/web-ui/src/button.tsx'), false);
+  assert.equal(isBlockedSecretPath('next-env.d.ts'), false);
+
+  assert.deepEqual(
+    findBlockedSecretPaths(['src/app.ts', '.env', 'apps/.env', '.env']),
+    ['.env', 'apps/.env'],
+  );
+});

--- a/tools/scripts/ai/commit-change.mjs
+++ b/tools/scripts/ai/commit-change.mjs
@@ -5,19 +5,33 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import {
+  classifyCommitFailure,
+  findBlockedSecretPaths,
+  formatCommitFailureTrailer,
+} from './classify-commit-failure.mjs';
+
 const usage = `Usage:
-  corepack yarn ai:commit --message "type(scope): subject"
   corepack yarn ai:commit --message-file path/to/message.txt
-  cat message.txt | corepack yarn ai:commit
+  corepack yarn ai:commit --message "type(scope): subject"
+
+Agents should use --message-file. Stdin is accepted for non-interactive callers.
 
 Options:
+  --message-file <path>  Read the commit message from a file. Preferred.
   --message <text>       Commit message text to use.
-  --message-file <path>  Read the commit message from a file.
   --help                 Show this help text.
 `;
 
-function fail(message, exitCode = 1) {
+function writeTrailer(fields) {
+  process.stderr.write(formatCommitFailureTrailer(fields));
+}
+
+function fail(message, trailer, exitCode = 1) {
   process.stderr.write(`${message}\n`);
+  if (trailer) {
+    writeTrailer(trailer);
+  }
   process.exit(exitCode);
 }
 
@@ -48,13 +62,16 @@ function parseArgs(argv) {
       continue;
     }
 
-    fail(`Unknown argument: ${arg}`);
+    fail(`Unknown argument: ${arg}`, {
+      reason: 'unknown',
+      hint: 'Use --message-file <path> or --message <text>.',
+    });
   }
 
   return options;
 }
 
-function run(command, args, capture = false) {
+function run(command, args, { capture = false } = {}) {
   const result = spawnSync(command, args, {
     encoding: 'utf8',
     stdio: capture ? 'pipe' : 'inherit',
@@ -62,7 +79,10 @@ function run(command, args, capture = false) {
   });
 
   if (result.error) {
-    fail(`Failed to run ${command}: ${result.error.message}`);
+    fail(`Failed to run ${command}: ${result.error.message}`, {
+      reason: 'unknown',
+      hint: `Retry after fixing the ${command} launch error.`,
+    });
   }
 
   return result;
@@ -70,7 +90,10 @@ function run(command, args, capture = false) {
 
 function readCommitMessage(options) {
   if (options.message && options.messageFile) {
-    fail('Provide either --message or --message-file, not both.');
+    fail('Provide either --message or --message-file, not both.', {
+      reason: 'unknown',
+      hint: 'Prefer --message-file <path>.',
+    });
   }
 
   if (options.messageFile) {
@@ -86,24 +109,86 @@ function readCommitMessage(options) {
   }
 
   fail(
-    'A commit message is required. Use --message, --message-file, or stdin.',
+    'A commit message is required. Use --message-file (preferred) or --message.',
+    {
+      reason: 'unknown',
+      hint: 'corepack yarn ai:commit --message-file <path>',
+    },
   );
 }
 
-function ensureStagedChanges() {
-  const result = run('git', ['diff', '--cached', '--quiet', '--exit-code']);
+function listStagedPaths({ diffFilter } = {}) {
+  const args = ['diff', '--cached', '--name-only'];
+  if (diffFilter) {
+    args.push(`--diff-filter=${diffFilter}`);
+  }
 
-  if (result.status === 1) {
+  const result = run('git', args, {
+    capture: true,
+  });
+
+  if (result.status !== 0) {
+    fail('Unable to inspect staged changes before committing.', {
+      reason: 'unknown',
+      hint: 'Confirm git status, stage the intended files, then retry.',
+    });
+  }
+
+  return (result.stdout ?? '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function ensureStagedChanges(stagedPaths) {
+  if (stagedPaths.length > 0) {
     return;
   }
 
-  if (result.status === 0) {
-    fail(
-      'No staged changes found. Stage the intended files before running ai:commit.',
-    );
+  fail(
+    'No staged changes found. Stage the intended files before running ai:commit.',
+    {
+      reason: 'empty-index',
+      hint: 'Stage specific files (never git add .), then retry corepack yarn ai:commit --message-file <path>.',
+    },
+  );
+}
+
+function rejectStagedSecrets(stagedPaths) {
+  const blocked = findBlockedSecretPaths(stagedPaths);
+  if (blocked.length === 0) {
+    return;
   }
 
-  fail('Unable to inspect staged changes before committing.');
+  fail(`Refusing to commit secret-looking paths: ${blocked.join(', ')}`, {
+    reason: 'secret',
+    paths: blocked,
+    hint: 'Unstage those files (`git restore --staged <path>`) and keep secrets out of the commit.',
+  });
+}
+
+function runCommit(messagePath) {
+  const result = spawnSync('git', ['commit', '--file', messagePath], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    fail(`Failed to run git: ${result.error.message}`, {
+      reason: 'unknown',
+      hint: 'Retry after fixing the git launch error.',
+    });
+  }
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  return result;
 }
 
 const options = parseArgs(process.argv.slice(2));
@@ -116,22 +201,29 @@ if (options.help) {
 const commitMessage = readCommitMessage(options).trimEnd();
 
 if (!commitMessage.trim()) {
-  fail('Commit message cannot be empty.');
+  fail('Commit message cannot be empty.', {
+    reason: 'unknown',
+    hint: 'Write a Conventional Commit message, then pass it with --message-file.',
+  });
 }
 
-ensureStagedChanges();
+const stagedPaths = listStagedPaths();
+ensureStagedChanges(stagedPaths);
+rejectStagedSecrets(listStagedPaths({ diffFilter: 'ACMR' }));
 
 const tempDir = mkdtempSync(join(tmpdir(), 'myorganizer-ai-commit-'));
 const messagePath = join(tempDir, 'COMMIT_EDITMSG');
 
 writeFileSync(messagePath, `${commitMessage}\n`, 'utf8');
 
-const commitResult = run('git', ['commit', '--file', messagePath]);
+const commitResult = runCommit(messagePath);
 
 rmSync(tempDir, { force: true, recursive: true });
 
-if (typeof commitResult.status === 'number') {
-  process.exit(commitResult.status);
+if (commitResult.status === 0) {
+  process.exit(0);
 }
 
-process.exit(1);
+const output = `${commitResult.stdout ?? ''}\n${commitResult.stderr ?? ''}`;
+writeTrailer(classifyCommitFailure(output));
+process.exit(typeof commitResult.status === 'number' ? commitResult.status : 1);


### PR DESCRIPTION
## Summary
- Keep `Commit` as a read-only message specialist; the main agent stages specific files and `yarn ai:commit` is the only `git commit` entry point.
- `ai:commit` now rejects secret-looking staged paths and prints a parseable `ai:commit: failed` trailer (`reason`, `hint`, optional `projects` / `paths`) so Husky failures can be retried narrowly.
- Align the Commit agent, commit skill, Husky pre-commit hook, and agent docs so messages come from the staged diff only and agents never `git add .`.

## Test plan
- [ ] `yarn ai:commit:test` (classifier and secret-path cases)
- [ ] `yarn agents:sync:check`
- [ ] Stage a normal file and confirm `yarn ai:commit --message-file <path>` waits for Husky and succeeds
- [ ] Confirm an empty index or a staged `.env` fails with the matching trailer (`empty-index` / `secret`)
- [ ] Confirm a lint failure trailer includes `reason: lint` and a `yarn nx lint <project>` hint
